### PR TITLE
Update p256k1 version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsts"
-version = "1.0.1"
+version = "1.1.0"
 edition = "2021"
 authors = ["Joey Yandle <xoloki@gmail.com>"]
 license = "Apache-2.0"
@@ -20,7 +20,7 @@ num-traits = "0.2"
 polynomial = { version = "0.2.5", features = ["serde"] }
 primitive-types = "0.12"
 rand_core = "0.6"
-p256k1 = "5"
+p256k1 = "5.1"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"
 thiserror = "1.0"


### PR DESCRIPTION
Updates `p256k1` version. Depends on https://github.com/Trust-Machines/p256k1/pull/65