### PR TITLE
Speed up DKG using the `p256k1` `MultiMult` trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ num-traits = "0.2"
 polynomial = { version = "0.2.5", features = ["serde"] }
 primitive-types = "0.12"
 rand_core = "0.6"
-p256k1 = "5.2"
+p256k1 = "5.3"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"
 thiserror = "1.0"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -30,7 +30,7 @@ impl From<PointError> for DkgError {
 #[derive(Error, Debug, Clone)]
 /// Errors which can happen during signature aggregation
 pub enum AggregatorError {
-    #[error("bad poly commitment length (expected {0} got {1}")]
+    #[error("bad poly commitment length (expected {0} got {1})")]
     /// The polynomial commitment was the wrong size
     BadPolyCommitmentLen(usize, usize),
     #[error("bad poly commitments {0:?}")]

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -137,7 +137,6 @@ impl Party {
         if !bad_ids.is_empty() {
             return Err(DkgError::BadIds(bad_ids));
         }
-/*
         // let's optimize for the case where all shares are good, and test them as a batch
 
         // compute the powers of x (self.id())
@@ -152,8 +151,8 @@ impl Party {
         }
 
         // build a vector of scalars and points from public poly evaluations and expected values
-        let mut scalars = Vec::with_capacity(T*N + N);
-        let mut points = Vec::with_capacity(T*N + N);
+        let mut scalars = Vec::with_capacity(T * N + N);
+        let mut points = Vec::with_capacity(T * N + N);
         for (i, s) in shares.iter() {
             scalars.append(&mut powers.clone());
 
@@ -165,7 +164,7 @@ impl Party {
         }
 
         // if the batch verify fails then check them one by one and find the bad ones
-        if Point::multimult(scalars, points)? != Point::zero() {*/
+        if Point::multimult(scalars, points)? != Point::zero() {
             let mut bad_shares = Vec::new();
             for (i, s) in shares.iter() {
                 let Ai = &A[usize::try_from(*i).unwrap()];
@@ -173,8 +172,10 @@ impl Party {
                     bad_shares.push(*i);
                 }
             }
-        if !bad_shares.is_empty() { return Err(DkgError::BadShares(bad_shares)); }
-        //}
+            if !bad_shares.is_empty() {
+                return Err(DkgError::BadShares(bad_shares));
+            }
+        }
 
         for (i, s) in shares.iter() {
             let Ai = &A[usize::try_from(*i).unwrap()];

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -227,7 +227,7 @@ impl SignatureAggregator {
     pub fn new(N: u32, T: u32, A: Vec<PolyCommitment>) -> Result<Self, AggregatorError> {
         let len = N.try_into().unwrap();
         if A.len() != len {
-            return Err(AggregatorError::BadPolyCommitmentLen(A.len(), len));
+            return Err(AggregatorError::BadPolyCommitmentLen(len, A.len()));
         }
 
         let mut bad_poly_commitments = Vec::new();


### PR DESCRIPTION
As noted in #12 DKG takes an extremely long time with a large (>1000) number of keys and threshold.  Flamegraph analysis shows that basically all of the time is spent in `Party::compute_secret`, where we must verify every DKG private share by evaluating the sending party's polynomial (i.e. DKG public share) at our ID.  This comes down to a very large scalar/point multimult, and we not only have to do it for every DKG private share, we have to do it that for every `Party` in a `Signer`.  

So if we have `16` signers controlling a total of `N=1600` keys, with a `70%` threshold of `T=1120`, that means each `Signer` has to evaluate `1600` polynomials of degree `1120`, `100` times.  A naive implementation takes hours.

Previously we sped this up significantly by doing each polynomial evaluation as a single multimult.  But that still meant doing `1600*100` multimults for each `Signer`, at a prohibited cost in terms of execution time.  And this is still a fraction of the time for the real world use case in sBTC, which is `4000` keys with a threshold of `2800`.

My first attempt to speed this up involved doing a single large multimult of size `N*T` in `Party::compute_secret` by linearizing the polynomial evaluations into a single large `Scalar` and `Point` `Vec`.  This worked, but required an excessive amount of memory usage.  And it wasn't strictly speaking necessary, since internally `p256k1` copies each `Scalar` and `Point` into a scratch space while doing a multimult.  

So I added a `MultiMult` trait to `p256k1` which allows creating an object which, given some minimal set of data, possibly with lifetime references to avoid copying anything, knows how to return each `Scalar` and `Point` as a reference.  This minimizes memory usage and execution time, while allowing us to take advantage of the logarithmic speedup of Pippergers algorithm when used with a giant multimult.

This PR creates a `CheckPrivateShares` object which implements the `MultiMult` trait, and largely avoids copying data while allowing us to check all DKG private shares for a single party in one giant multimult.  This is basically the best we can do to optimize `Party::compute_secret`.  Now DKG takes only 17 minutes in the the `N=1600` `T=1120` case.  

The only further optimization possible is to do the same thing, but once for `Signer::compute_secrets` instead of separately for each `Party::compute_secret`.  That will be a much larger multimult, so we will have to balance memory usage more aggressively, and thus it will be left to a future PR.