### PR TITLE
Always use tweaked keys with taproot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ num-traits = "0.2"
 polynomial = { version = "0.2.5", features = ["serde"] }
 primitive-types = "0.12"
 rand_core = "0.6"
-p256k1 = "5"
+p256k1 = "5.4"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ num-traits = "0.2"
 polynomial = { version = "0.2.5", features = ["serde"] }
 primitive-types = "0.12"
 rand_core = "0.6"
-p256k1 = "5.3"
+p256k1 = "5"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"
 thiserror = "1.0"

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -141,17 +141,19 @@ pub fn tagged_hash(tag: &str) -> Sha256 {
 }
 
 /// Create a BIP341 compliant taproot tweak from a public key and merkle root
-pub fn tweak(public_key: &Point, merkle_root: &[u8]) -> Scalar {
+pub fn tweak(public_key: &Point, merkle_root: Option<[u8; 32]>) -> Scalar {
     let mut hasher = tagged_hash("TapTweak");
 
     hasher.update(public_key.x().to_bytes());
-    hasher.update(merkle_root);
+    if let Some(root) = merkle_root {
+        hasher.update(root);
+    }
 
     hash_to_scalar(&mut hasher)
 }
 
 /// Create a BIP341 compliant taproot tweak from a public key and merkle root
-pub fn tweaked_public_key(public_key: &Point, merkle_root: &[u8]) -> Point {
+pub fn tweaked_public_key(public_key: &Point, merkle_root: Option<[u8; 32]>) -> Point {
     public_key + tweak(public_key, merkle_root) * G
 }
 

--- a/src/taproot.rs
+++ b/src/taproot.rs
@@ -109,12 +109,8 @@ pub mod test_helpers {
         loop {
             let group_key = A.iter().fold(Point::new(), |s, a| s + a.A[0]);
             if group_key.has_even_y() {
-                if let Some(root) = merkle_root {
-                    let tweaked = compute::tweaked_public_key(&group_key, &root);
-                    if tweaked.has_even_y() {
-                        break;
-                    }
-                } else {
+                let tweaked = compute::tweaked_public_key(&group_key, merkle_root);
+                if tweaked.has_even_y() {
                     break;
                 }
             }
@@ -178,28 +174,12 @@ pub mod test_helpers {
         msg: &[u8],
         signers: &mut [Signer],
         rng: &mut RNG,
+        merkle_root: Option<[u8; 32]>,
     ) -> (Vec<PublicNonce>, Vec<SignatureShare>) {
         let (signer_ids, key_ids, nonces) = sign_params(msg, signers, rng);
         let shares = signers
             .iter()
-            .flat_map(|s| s.sign(msg, &signer_ids, &key_ids, &nonces))
-            .collect();
-
-        (nonces, shares)
-    }
-
-    /// Run a tweaked signing round for the passed `msg`
-    #[allow(non_snake_case)]
-    pub fn sign_tweaked<RNG: RngCore + CryptoRng, Signer: traits::Signer>(
-        msg: &[u8],
-        signers: &mut [Signer],
-        rng: &mut RNG,
-        tweaked_public_key: &Point,
-    ) -> (Vec<PublicNonce>, Vec<SignatureShare>) {
-        let (signer_ids, key_ids, nonces) = sign_params(msg, signers, rng);
-        let shares = signers
-            .iter()
-            .flat_map(|s| s.sign_tweaked(msg, &signer_ids, &key_ids, &nonces, tweaked_public_key))
+            .flat_map(|s| s.sign_taproot(msg, &signer_ids, &key_ids, &nonces, merkle_root))
             .collect();
 
         (nonces, shares)
@@ -212,112 +192,6 @@ mod test {
 
     use crate::{compute, traits::Signer, v1, v2};
     use rand_core::OsRng;
-
-    #[test]
-    #[allow(non_snake_case)]
-    fn test_schnorr_sign_verify_v1() {
-        let mut rng = OsRng::default();
-
-        // First create and verify a frost signature
-        let msg = "It was many and many a year ago".as_bytes();
-        let N: u32 = 10;
-        let T: u32 = 7;
-        let signer_ids: Vec<Vec<u32>> = [
-            [0, 1, 2].to_vec(),
-            [3, 4].to_vec(),
-            [5, 6, 7].to_vec(),
-            [8, 9].to_vec(),
-        ]
-        .to_vec();
-        let mut signers: Vec<v1::Signer> = signer_ids
-            .iter()
-            .enumerate()
-            .map(|(id, ids)| v1::Signer::new(id.try_into().unwrap(), ids, N, T, &mut rng))
-            .collect();
-
-        let A = match test_helpers::dkg(&mut signers, &mut rng, None) {
-            Ok(A) => A,
-            Err(secret_errors) => {
-                panic!("Got secret errors from DKG: {:?}", secret_errors);
-            }
-        };
-
-        let mut S = [signers[0].clone(), signers[1].clone(), signers[3].clone()].to_vec();
-        let mut sig_agg =
-            v1::SignatureAggregator::new(N, T, A.clone()).expect("aggregator ctor failed");
-
-        let (nonces, sig_shares) = test_helpers::sign(&msg, &mut S, &mut rng);
-        let sig = match sig_agg.sign(&msg, &nonces, &sig_shares) {
-            Err(e) => panic!("Aggregator sign failed: {:?}", e),
-            Ok(sig) => sig,
-        };
-
-        // now create a SchnorrProof from the frost signature
-        let proof = SchnorrProof::new(&sig).unwrap();
-
-        assert!(proof.verify(&sig_agg.poly[0].x(), msg));
-
-        // now ser/de the proof
-        let proof_bytes = proof.to_bytes();
-        let proof_deser = SchnorrProof::from(proof_bytes);
-
-        assert_eq!(proof, proof_deser);
-        assert!(proof_deser.verify(&sig_agg.poly[0].x(), msg));
-    }
-
-    #[test]
-    #[allow(non_snake_case)]
-    fn test_schnorr_sign_verify_v2() {
-        let mut rng = OsRng::default();
-
-        // First create and verify a frost signature
-        let msg = "It was many and many a year ago".as_bytes();
-        let Nk: u32 = 10;
-        let Np: u32 = 4;
-        let T: u32 = 7;
-        let signer_ids: Vec<Vec<u32>> = [
-            [0, 1, 2].to_vec(),
-            [3, 4].to_vec(),
-            [5, 6, 7].to_vec(),
-            [8, 9].to_vec(),
-        ]
-        .to_vec();
-        let mut signers: Vec<v2::Signer> = signer_ids
-            .iter()
-            .enumerate()
-            .map(|(id, ids)| v2::Signer::new(id.try_into().unwrap(), ids, Np, Nk, T, &mut rng))
-            .collect();
-
-        let A = match test_helpers::dkg(&mut signers, &mut rng, None) {
-            Ok(A) => A,
-            Err(secret_errors) => {
-                panic!("Got secret errors from DKG: {:?}", secret_errors);
-            }
-        };
-
-        let mut S = [signers[0].clone(), signers[1].clone(), signers[3].clone()].to_vec();
-        let key_ids = S.iter().flat_map(|s| s.get_key_ids()).collect::<Vec<u32>>();
-        let mut sig_agg =
-            v2::SignatureAggregator::new(Nk, T, A.clone()).expect("aggregator ctor failed");
-
-        let (nonces, sig_shares) = test_helpers::sign(&msg, &mut S, &mut rng);
-        let sig = match sig_agg.sign(&msg, &nonces, &sig_shares, &key_ids) {
-            Err(e) => panic!("Aggregator sign failed: {:?}", e),
-            Ok(sig) => sig,
-        };
-
-        // now create a SchnorrProof from the frost signature
-        let proof = SchnorrProof::new(&sig).unwrap();
-
-        assert!(proof.verify(&sig_agg.poly[0].x(), msg));
-
-        // now ser/de the proof
-        let proof_bytes = proof.to_bytes();
-        let proof_deser = SchnorrProof::from(proof_bytes);
-
-        assert_eq!(proof, proof_deser);
-        assert!(proof_deser.verify(&sig_agg.poly[0].x(), msg));
-    }
 
     #[test]
     #[allow(non_snake_case)]
@@ -354,11 +228,11 @@ mod test {
         let mut sig_agg =
             v1::SignatureAggregator::new(N, T, A.clone()).expect("aggregator ctor failed");
         let aggregate_public_key = sig_agg.poly[0];
-        let tweaked_public_key = compute::tweaked_public_key(&aggregate_public_key, &merkle_root);
+        let tweaked_public_key =
+            compute::tweaked_public_key(&aggregate_public_key, Some(merkle_root));
 
-        let (nonces, sig_shares) =
-            test_helpers::sign_tweaked(&msg, &mut S, &mut rng, &tweaked_public_key);
-        let sig = match sig_agg.sign_merkle_root(&msg, &nonces, &sig_shares, &merkle_root) {
+        let (nonces, sig_shares) = test_helpers::sign(&msg, &mut S, &mut rng, Some(merkle_root));
+        let sig = match sig_agg.sign_taproot(&msg, &nonces, &sig_shares, Some(merkle_root)) {
             Err(e) => panic!("Aggregator sign failed: {:?}", e),
             Ok(sig) => sig,
         };
@@ -413,15 +287,15 @@ mod test {
         let mut sig_agg =
             v2::SignatureAggregator::new(Nk, T, A.clone()).expect("aggregator ctor failed");
         let aggregate_public_key = sig_agg.poly[0];
-        let tweaked_public_key = compute::tweaked_public_key(&aggregate_public_key, &merkle_root);
+        let tweaked_public_key =
+            compute::tweaked_public_key(&aggregate_public_key, Some(merkle_root));
 
-        let (nonces, sig_shares) =
-            test_helpers::sign_tweaked(&msg, &mut S, &mut rng, &tweaked_public_key);
-        let sig = match sig_agg.sign_merkle_root(&msg, &nonces, &sig_shares, &key_ids, &merkle_root)
-        {
-            Err(e) => panic!("Aggregator sign failed: {:?}", e),
-            Ok(sig) => sig,
-        };
+        let (nonces, sig_shares) = test_helpers::sign(&msg, &mut S, &mut rng, Some(merkle_root));
+        let sig =
+            match sig_agg.sign_taproot(&msg, &nonces, &sig_shares, &key_ids, Some(merkle_root)) {
+                Err(e) => panic!("Aggregator sign failed: {:?}", e),
+                Ok(sig) => sig,
+            };
 
         // now create a SchnorrProof from the frost signature
         let proof = SchnorrProof::new(&sig).unwrap();

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -52,12 +52,12 @@ pub trait Signer {
     ) -> Vec<SignatureShare>;
 
     /// Sign `msg` using all this signer's keys and a tweaked public key
-    fn sign_tweaked(
+    fn sign_taproot(
         &self,
         msg: &[u8],
         signer_ids: &[u32],
         key_ids: &[u32],
         nonces: &[PublicNonce],
-        tweaked_public_key: &Point,
+        merkle_root: Option<[u8; 32]>,
     ) -> Vec<SignatureShare>;
 }

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -189,7 +189,7 @@ impl Party {
         }
     }
 
-    /// Sign `msg` with this party's share of the group private key, using the set of `sigers` and corresponding `nonces` with a precomputed `aggregate_nonce`
+    /// Sign `msg` with this party's share of the group private key, using the set of `sigers` and corresponding `nonces` with a precomputed `aggregate_nonce` and an optional tweak to the public key
     pub fn sign_precomputed(
         &self,
         msg: &[u8],
@@ -197,29 +197,20 @@ impl Party {
         nonces: &[PublicNonce],
         aggregate_nonce: &Point,
     ) -> SignatureShare {
-        let mut z = &self.nonce.d + &self.nonce.e * compute::binding(&self.id(), nonces, msg);
-        z += compute::challenge(&self.group_key, aggregate_nonce, msg)
-            * &self.private_key
-            * compute::lambda(self.id, signers);
-
-        SignatureShare {
-            id: self.id,
-            z_i: z,
-            key_ids: vec![self.id],
-        }
+        self.sign_precomputed_with_tweak(msg, signers, nonces, aggregate_nonce, &Scalar::from(0))
     }
 
-    /// Sign `msg` with this party's share of the group private key, using the set of `sigers` and corresponding `nonces` with a precomputed `aggregate_nonce` and a tweaked public key
-    pub fn sign_precomputed_tweaked(
+    /// Sign `msg` with this party's share of the group private key, using the set of `sigers` and corresponding `nonces` with a precomputed `aggregate_nonce` and an optional tweak to the public key
+    pub fn sign_precomputed_with_tweak(
         &self,
         msg: &[u8],
         signers: &[u32],
         nonces: &[PublicNonce],
         aggregate_nonce: &Point,
-        tweaked_public_key: &Point,
+        tweak: &Scalar,
     ) -> SignatureShare {
         let mut z = &self.nonce.d + &self.nonce.e * compute::binding(&self.id(), nonces, msg);
-        z += compute::challenge(tweaked_public_key, aggregate_nonce, msg)
+        z += compute::challenge(&(self.group_key + tweak * G), aggregate_nonce, msg)
             * &self.private_key
             * compute::lambda(self.id, signers);
 
@@ -285,12 +276,12 @@ impl SignatureAggregator {
     }
 
     /// Check and aggregate the party signatures using a merke root to make a tweak
-    pub fn sign_merkle_root(
+    pub fn sign_taproot(
         &mut self,
         msg: &[u8],
         nonces: &[PublicNonce],
         sig_shares: &[SignatureShare],
-        merkle_root: &[u8],
+        merkle_root: Option<[u8; 32]>,
     ) -> Result<Signature, AggregatorError> {
         let tweak = compute::tweak(&self.poly[0], merkle_root);
         self.sign_with_tweak(msg, nonces, sig_shares, &tweak)
@@ -516,26 +507,19 @@ impl crate::traits::Signer for Signer {
             .collect()
     }
 
-    fn sign_tweaked(
+    fn sign_taproot(
         &self,
         msg: &[u8],
         _signer_ids: &[u32],
         key_ids: &[u32],
         nonces: &[PublicNonce],
-        tweaked_public_key: &Point,
+        merkle_root: Option<[u8; 32]>,
     ) -> Vec<SignatureShare> {
         let aggregate_nonce = compute::aggregate_nonce(msg, key_ids, nonces).unwrap();
+        let tweak = compute::tweak(&self.parties[0].group_key, merkle_root);
         self.parties
             .iter()
-            .map(|p| {
-                p.sign_precomputed_tweaked(
-                    msg,
-                    key_ids,
-                    nonces,
-                    &aggregate_nonce,
-                    tweaked_public_key,
-                )
-            })
+            .map(|p| p.sign_precomputed_with_tweak(msg, key_ids, nonces, &aggregate_nonce, &tweak))
             .collect()
     }
 }

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -189,7 +189,7 @@ impl Party {
         }
     }
 
-    /// Sign `msg` with this party's share of the group private key, using the set of `sigers` and corresponding `nonces` with a precomputed `aggregate_nonce` and an optional tweak to the public key
+    /// Sign `msg` with this party's share of the group private key, using the set of `sigers` and corresponding `nonces` with a precomputed `aggregate_nonce`
     pub fn sign_precomputed(
         &self,
         msg: &[u8],
@@ -200,7 +200,7 @@ impl Party {
         self.sign_precomputed_with_tweak(msg, signers, nonces, aggregate_nonce, &Scalar::from(0))
     }
 
-    /// Sign `msg` with this party's share of the group private key, using the set of `sigers` and corresponding `nonces` with a precomputed `aggregate_nonce` and an optional tweak to the public key
+    /// Sign `msg` with this party's share of the group private key, using the set of `sigers` and corresponding `nonces` with a precomputed `aggregate_nonce` and a tweak to the public key
     pub fn sign_precomputed_with_tweak(
         &self,
         msg: &[u8],


### PR DESCRIPTION
When doing taproot signatures with distributed keys, it is necessary to always use tweaked keys even when there is no script spend path. This is because a malicious DKG actor can insert a hidden script spend if the key is not tweaked.

So for all taproot sign functions, the merkle root should be optional, but tweaking the keys is not. If there is no merkle root, then the tweak is the hash of the public key only.