### PR TITLE
Allow creating taproot signatures with aggregate nonces and tweaked public keys that have odd y-coordinates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           toolchain: stable
           override: true
       - run: cargo install cargo-tarpaulin
-      - run: cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml --avoid-cfg-tarpaulin
+      - run: cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out xml --avoid-cfg-tarpaulin
       - uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsts"
-version = "2.0.0"
+version = "3.0.0"
 edition = "2021"
 authors = ["Joey Yandle <xoloki@gmail.com>"]
 license = "Apache-2.0"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,8 @@
 use p256k1::{point::Error as PointError, scalar::Scalar};
 use thiserror::Error;
 
+use crate::taproot::Error as TaprootError;
+
 #[derive(Error, Debug, Clone)]
 /// Errors which can happen during distributed key generation
 pub enum DkgError {
@@ -48,4 +50,13 @@ pub enum AggregatorError {
     #[error("bad group sig")]
     /// The aggregate group signature failed to verify
     BadGroupSig,
+    #[error("taproot {0:?}")]
+    /// Taproot error
+    Taproot(TaprootError),
+}
+
+impl From<TaprootError> for AggregatorError {
+    fn from(e: TaprootError) -> Self {
+        AggregatorError::Taproot(e)
+    }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,8 +1,6 @@
 use p256k1::{point::Error as PointError, scalar::Scalar};
 use thiserror::Error;
 
-use crate::taproot::Error as TaprootError;
-
 #[derive(Error, Debug, Clone)]
 /// Errors which can happen during distributed key generation
 pub enum DkgError {
@@ -50,13 +48,4 @@ pub enum AggregatorError {
     #[error("bad group sig")]
     /// The aggregate group signature failed to verify
     BadGroupSig,
-    #[error("taproot {0:?}")]
-    /// Taproot error
-    Taproot(TaprootError),
-}
-
-impl From<TaprootError> for AggregatorError {
-    fn from(e: TaprootError) -> Self {
-        AggregatorError::Taproot(e)
-    }
 }

--- a/src/taproot.rs
+++ b/src/taproot.rs
@@ -1,19 +1,10 @@
 use p256k1::{
     field,
-    point::{Error as PointError, Point, G},
+    point::{Point, G},
     scalar::Scalar,
 };
 
 use crate::{common::Signature, compute};
-
-/// Errors from BIP-340 operations
-#[derive(Clone, Debug)]
-pub enum Error {
-    /// Point R is odd
-    OddR,
-    /// Error doing point operations
-    Point(PointError),
-}
 
 /// A SchnorrProof in BIP-340 format
 #[allow(non_snake_case)]
@@ -27,15 +18,11 @@ pub struct SchnorrProof {
 
 impl SchnorrProof {
     /// Construct a BIP-340 schnorr proof from a FROST signature
-    pub fn new(sig: &Signature) -> Result<Self, Error> {
-        /*if !sig.R.has_even_y() {
-            Err(Error::OddR)
-        } else {*/
-        Ok(Self {
+    pub fn new(sig: &Signature) -> Self {
+        Self {
             r: sig.R.x(),
             s: sig.z,
-        })
-        //}
+        }
     }
 
     /// Verify a BIP-340 schnorr proof

--- a/src/taproot.rs
+++ b/src/taproot.rs
@@ -208,15 +208,12 @@ mod test {
         let mut S = [signers[0].clone(), signers[1].clone(), signers[3].clone()].to_vec();
         let mut sig_agg =
             v1::SignatureAggregator::new(N, T, A.clone()).expect("aggregator ctor failed");
-
+        let tweaked_public_key = compute::tweaked_public_key(&sig_agg.poly[0], merkle_root);
         let (nonces, sig_shares) = test_helpers::sign(&msg, &mut S, &mut rng, merkle_root);
-        let (tweaked_public_key, proof) =
-            match sig_agg.sign_taproot(&msg, &nonces, &sig_shares, merkle_root) {
-                Err(e) => panic!("Aggregator sign failed: {:?}", e),
-                Ok((key, proof)) => (key, proof),
-            };
-
-        assert!(proof.verify(&tweaked_public_key.x(), msg));
+        let proof = match sig_agg.sign_taproot(&msg, &nonces, &sig_shares, merkle_root) {
+            Err(e) => panic!("Aggregator sign failed: {:?}", e),
+            Ok(proof) => proof,
+        };
 
         // now ser/de the proof
         let proof_bytes = proof.to_bytes();
@@ -274,14 +271,12 @@ mod test {
         let key_ids = S.iter().flat_map(|s| s.get_key_ids()).collect::<Vec<u32>>();
         let mut sig_agg =
             v2::SignatureAggregator::new(Nk, T, A.clone()).expect("aggregator ctor failed");
+        let tweaked_public_key = compute::tweaked_public_key(&sig_agg.poly[0], merkle_root);
         let (nonces, sig_shares) = test_helpers::sign(&msg, &mut S, &mut rng, merkle_root);
-        let (tweaked_public_key, proof) =
-            match sig_agg.sign_taproot(&msg, &nonces, &sig_shares, &key_ids, merkle_root) {
-                Err(e) => panic!("Aggregator sign failed: {:?}", e),
-                Ok((key, proof)) => (key, proof),
-            };
-
-        assert!(proof.verify(&tweaked_public_key.x(), msg));
+        let proof = match sig_agg.sign_taproot(&msg, &nonces, &sig_shares, &key_ids, merkle_root) {
+            Err(e) => panic!("Aggregator sign failed: {:?}", e),
+            Ok(proof) => proof,
+        };
 
         // now ser/de the proof
         let proof_bytes = proof.to_bytes();

--- a/src/taproot.rs
+++ b/src/taproot.rs
@@ -126,7 +126,6 @@ pub mod test_helpers {
 
     #[allow(non_snake_case)]
     fn sign_params<RNG: RngCore + CryptoRng, Signer: traits::Signer>(
-        _msg: &[u8],
         signers: &mut [Signer],
         rng: &mut RNG,
     ) -> (Vec<u32>, Vec<u32>, Vec<PublicNonce>) {
@@ -145,7 +144,7 @@ pub mod test_helpers {
         rng: &mut RNG,
         merkle_root: Option<[u8; 32]>,
     ) -> (Vec<PublicNonce>, Vec<SignatureShare>) {
-        let (signer_ids, key_ids, nonces) = sign_params(msg, signers, rng);
+        let (signer_ids, key_ids, nonces) = sign_params(signers, rng);
         let shares = signers
             .iter()
             .flat_map(|s| s.sign_taproot(msg, &signer_ids, &key_ids, &nonces, merkle_root))

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -300,13 +300,13 @@ impl SignatureAggregator {
         nonces: &[PublicNonce],
         sig_shares: &[SignatureShare],
         merkle_root: Option<[u8; 32]>,
-    ) -> Result<(Point, SchnorrProof), AggregatorError> {
+    ) -> Result<SchnorrProof, AggregatorError> {
         let tweak = compute::tweak(&self.poly[0], merkle_root);
         let (key, sig) = self.sign_with_tweak(msg, nonces, sig_shares, &tweak)?;
         let proof = SchnorrProof::new(&sig)?;
 
         if proof.verify(&key.x(), msg) {
-            Ok((key, proof))
+            Ok(proof)
         } else {
             Err(AggregatorError::BadGroupSig)
         }

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -303,7 +303,7 @@ impl SignatureAggregator {
     ) -> Result<SchnorrProof, AggregatorError> {
         let tweak = compute::tweak(&self.poly[0], merkle_root);
         let (key, sig) = self.sign_with_tweak(msg, nonces, sig_shares, &tweak)?;
-        let proof = SchnorrProof::new(&sig)?;
+        let proof = SchnorrProof::new(&sig);
 
         if proof.verify(&key.x(), msg) {
             Ok(proof)

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -331,7 +331,7 @@ impl SignatureAggregator {
     ) -> Result<SchnorrProof, AggregatorError> {
         let tweak = compute::tweak(&self.poly[0], merkle_root);
         let (key, sig) = self.sign_with_tweak(msg, nonces, sig_shares, key_ids, &tweak)?;
-        let proof = SchnorrProof::new(&sig)?;
+        let proof = SchnorrProof::new(&sig);
 
         if proof.verify(&key.x(), msg) {
             Ok(proof)

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -328,13 +328,13 @@ impl SignatureAggregator {
         sig_shares: &[SignatureShare],
         key_ids: &[u32],
         merkle_root: Option<[u8; 32]>,
-    ) -> Result<(Point, SchnorrProof), AggregatorError> {
+    ) -> Result<SchnorrProof, AggregatorError> {
         let tweak = compute::tweak(&self.poly[0], merkle_root);
         let (key, sig) = self.sign_with_tweak(msg, nonces, sig_shares, key_ids, &tweak)?;
         let proof = SchnorrProof::new(&sig)?;
 
         if proof.verify(&key.x(), msg) {
-            Ok((key, proof))
+            Ok(proof)
         } else {
             Err(AggregatorError::BadGroupSig)
         }


### PR DESCRIPTION
Taproot signatures use a 32-byte encoding of curve points, specifically for the public keys and the R value of the signature. This 32-byte value is just the x-coordinate of the curve point. Since there are two possible curve points for every x-coordinate, taproot assumes that we are referring to the point with an even y-coordinate.  If the curve point rather has an odd y-coordinate, we must tweak the math for the private nonces and keys; this is difficult in a distributed context where no one has direct access to this private data.

Until now, we have worked around this by repeating both DKG and nonce gathering until we get aggregate nonces and tweaked public keys with even y-coordinates.  In this PR we first removed the need for an even y-coordinate on the aggregate nonce, allowing us to skip repeating nonce gathering for each signature. This required a bit of math on both signer and aggregator.  Next we removed the corresponding requirement for tweaked public keys, using similar math on both signer and aggregator.  

Now we no longer have to repeat DKG or nonce gathering, and we can sign transactions with different merkle roots using the same aggregate key and thus different tweaked public keys.
