### PR TITLE
Add `Aggregator` trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsts"
-version = "3.0.0"
+version = "4.0.0"
 edition = "2021"
 authors = ["Joey Yandle <xoloki@gmail.com>"]
 license = "Apache-2.0"

--- a/src/common.rs
+++ b/src/common.rs
@@ -16,7 +16,6 @@ use crate::compute::challenge;
 use crate::schnorr::ID;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[allow(non_snake_case)]
 /// A commitment to a polynonial, with a Schnorr proof of ownership bound to the ID
 pub struct PolyCommitment {
     /// The party ID with a schnorr proof

--- a/src/common.rs
+++ b/src/common.rs
@@ -22,20 +22,20 @@ pub struct PolyCommitment {
     /// The party ID with a schnorr proof
     pub id: ID,
     /// The public polynomial which commits to the secret polynomial
-    pub A: Vec<Point>,
+    pub poly: Vec<Point>,
 }
 
 impl PolyCommitment {
     /// Verify the wrapped schnorr ID
     pub fn verify(&self) -> bool {
-        self.id.verify(&self.A[0])
+        self.id.verify(&self.poly[0])
     }
 }
 
 impl Display for PolyCommitment {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write!(f, "{}", self.id.id)?;
-        for p in &self.A {
+        for p in &self.poly {
             write!(f, " {}", p)?;
         }
         Ok(())
@@ -183,9 +183,9 @@ impl<'a> CheckPrivateShares<'a> {
     /// Construct a new CheckPrivateShares object
     pub fn new(id: Scalar, shares: &HashMap<u32, Scalar>, polys: &'a [PolyCommitment]) -> Self {
         let n: u32 = shares.len().try_into().unwrap();
-        let t: u32 = polys[0].A.len().try_into().unwrap();
+        let t: u32 = polys[0].poly.len().try_into().unwrap();
         let x = id;
-        let mut powers = Vec::with_capacity(polys[0].A.len());
+        let mut powers = Vec::with_capacity(polys[0].poly.len());
         let mut pow = Scalar::one();
 
         for _ in 0..t {
@@ -228,7 +228,7 @@ impl<'a> MultiMult for CheckPrivateShares<'a> {
             let j = i / u;
             let k = i % u;
 
-            &self.polys[j].A[k]
+            &self.polys[j].poly[k]
         } else {
             &G
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,11 @@
 use rand_core::OsRng;
 use std::{env, time};
 
-use wsts::{common::test_helpers::gen_signer_ids, v1, v2};
+use wsts::{
+    common::test_helpers::gen_signer_ids,
+    traits::Aggregator,
+    v1, v2,
+};
 
 #[allow(non_snake_case)]
 fn main() {
@@ -41,7 +45,7 @@ fn main() {
         let dkg_time = dkg_start.elapsed();
         let mut signers = signers[..(K * 3 / 4).try_into().unwrap()].to_vec();
 
-        let mut aggregator = v1::SignatureAggregator::new(N, T, A).expect("aggregator ctor failed");
+        let mut aggregator = v1::Aggregator::new(N, T, A).expect("aggregator ctor failed");
 
         let party_sign_start = time::Instant::now();
         let (nonces, sig_shares) = v1::test_helpers::sign(msg, &mut signers, &mut rng);
@@ -49,7 +53,7 @@ fn main() {
 
         let group_sign_start = time::Instant::now();
         let _sig = aggregator
-            .sign(msg, &nonces, &sig_shares)
+            .sign(msg, &nonces, &sig_shares, &[])
             .expect("v1 group sign failed");
         let group_sign_time = group_sign_start.elapsed();
 
@@ -76,7 +80,7 @@ fn main() {
         let dkg_time = dkg_start.elapsed();
         let mut signers = signers[..(K * 3 / 4).try_into().unwrap()].to_vec();
 
-        let mut aggregator = v2::SignatureAggregator::new(N, T, A).expect("aggregator ctor failed");
+        let mut aggregator = v2::Aggregator::new(N, T, A).expect("aggregator ctor failed");
 
         let party_sign_start = time::Instant::now();
         let (nonces, sig_shares, key_ids) = v2::test_helpers::sign(msg, &mut signers, &mut rng);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,7 @@
 use rand_core::OsRng;
 use std::{env, time};
 
-use wsts::{
-    common::test_helpers::gen_signer_ids,
-    traits::Aggregator,
-    v1, v2,
-};
+use wsts::{common::test_helpers::gen_signer_ids, traits::Aggregator, v1, v2};
 
 #[allow(non_snake_case)]
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,8 @@ fn main() {
         let dkg_time = dkg_start.elapsed();
         let mut signers = signers[..(K * 3 / 4).try_into().unwrap()].to_vec();
 
-        let mut aggregator = v1::Aggregator::new(N, T, A).expect("aggregator ctor failed");
+        let mut aggregator = v1::Aggregator::new(N, T);
+        aggregator.init(A).expect("aggregator init failed");
 
         let party_sign_start = time::Instant::now();
         let (nonces, sig_shares) = v1::test_helpers::sign(msg, &mut signers, &mut rng);
@@ -76,7 +77,8 @@ fn main() {
         let dkg_time = dkg_start.elapsed();
         let mut signers = signers[..(K * 3 / 4).try_into().unwrap()].to_vec();
 
-        let mut aggregator = v2::Aggregator::new(N, T, A).expect("aggregator ctor failed");
+        let mut aggregator = v2::Aggregator::new(N, T);
+        aggregator.init(A).expect("aggregator init failed");
 
         let party_sign_start = time::Instant::now();
         let (nonces, sig_shares, key_ids) = v2::test_helpers::sign(msg, &mut signers, &mut rng);

--- a/src/taproot.rs
+++ b/src/taproot.rs
@@ -145,7 +145,7 @@ pub mod test_helpers {
 mod test {
     use super::{test_helpers, SchnorrProof};
 
-    use crate::{compute, traits::Signer, v1, v2};
+    use crate::{compute, traits::Signer, traits::Aggregator, v1, v2};
     use rand_core::OsRng;
 
     #[test]
@@ -193,10 +193,10 @@ mod test {
 
         let mut S = [signers[0].clone(), signers[1].clone(), signers[3].clone()].to_vec();
         let mut sig_agg =
-            v1::SignatureAggregator::new(N, T, A.clone()).expect("aggregator ctor failed");
+            v1::Aggregator::new(N, T, A.clone()).expect("aggregator ctor failed");
         let tweaked_public_key = compute::tweaked_public_key(&sig_agg.poly[0], merkle_root);
         let (nonces, sig_shares) = test_helpers::sign(&msg, &mut S, &mut rng, merkle_root);
-        let proof = match sig_agg.sign_taproot(&msg, &nonces, &sig_shares, merkle_root) {
+        let proof = match sig_agg.sign_taproot(&msg, &nonces, &sig_shares, &[], merkle_root) {
             Err(e) => panic!("Aggregator sign failed: {:?}", e),
             Ok(proof) => proof,
         };
@@ -256,7 +256,7 @@ mod test {
         let mut S = [signers[0].clone(), signers[1].clone(), signers[3].clone()].to_vec();
         let key_ids = S.iter().flat_map(|s| s.get_key_ids()).collect::<Vec<u32>>();
         let mut sig_agg =
-            v2::SignatureAggregator::new(Nk, T, A.clone()).expect("aggregator ctor failed");
+            v2::Aggregator::new(Nk, T, A.clone()).expect("aggregator ctor failed");
         let tweaked_public_key = compute::tweaked_public_key(&sig_agg.poly[0], merkle_root);
         let (nonces, sig_shares) = test_helpers::sign(&msg, &mut S, &mut rng, merkle_root);
         let proof = match sig_agg.sign_taproot(&msg, &nonces, &sig_shares, &key_ids, merkle_root) {

--- a/src/taproot.rs
+++ b/src/taproot.rs
@@ -192,7 +192,8 @@ mod test {
         };
 
         let mut S = [signers[0].clone(), signers[1].clone(), signers[3].clone()].to_vec();
-        let mut sig_agg = v1::Aggregator::new(N, T, A.clone()).expect("aggregator ctor failed");
+        let mut sig_agg = v1::Aggregator::new(N, T);
+        sig_agg.init(A.clone()).expect("aggregator init failed");
         let tweaked_public_key = compute::tweaked_public_key(&sig_agg.poly[0], merkle_root);
         let (nonces, sig_shares) = test_helpers::sign(&msg, &mut S, &mut rng, merkle_root);
         let proof = match sig_agg.sign_taproot(&msg, &nonces, &sig_shares, &[], merkle_root) {
@@ -254,7 +255,8 @@ mod test {
 
         let mut S = [signers[0].clone(), signers[1].clone(), signers[3].clone()].to_vec();
         let key_ids = S.iter().flat_map(|s| s.get_key_ids()).collect::<Vec<u32>>();
-        let mut sig_agg = v2::Aggregator::new(Nk, T, A.clone()).expect("aggregator ctor failed");
+        let mut sig_agg = v2::Aggregator::new(Nk, T);
+        sig_agg.init(A.clone()).expect("aggregator init failed");
         let tweaked_public_key = compute::tweaked_public_key(&sig_agg.poly[0], merkle_root);
         let (nonces, sig_shares) = test_helpers::sign(&msg, &mut S, &mut rng, merkle_root);
         let proof = match sig_agg.sign_taproot(&msg, &nonces, &sig_shares, &key_ids, merkle_root) {

--- a/src/taproot.rs
+++ b/src/taproot.rs
@@ -145,7 +145,7 @@ pub mod test_helpers {
 mod test {
     use super::{test_helpers, SchnorrProof};
 
-    use crate::{compute, traits::Signer, traits::Aggregator, v1, v2};
+    use crate::{compute, traits::Aggregator, traits::Signer, v1, v2};
     use rand_core::OsRng;
 
     #[test]
@@ -192,8 +192,7 @@ mod test {
         };
 
         let mut S = [signers[0].clone(), signers[1].clone(), signers[3].clone()].to_vec();
-        let mut sig_agg =
-            v1::Aggregator::new(N, T, A.clone()).expect("aggregator ctor failed");
+        let mut sig_agg = v1::Aggregator::new(N, T, A.clone()).expect("aggregator ctor failed");
         let tweaked_public_key = compute::tweaked_public_key(&sig_agg.poly[0], merkle_root);
         let (nonces, sig_shares) = test_helpers::sign(&msg, &mut S, &mut rng, merkle_root);
         let proof = match sig_agg.sign_taproot(&msg, &nonces, &sig_shares, &[], merkle_root) {
@@ -255,8 +254,7 @@ mod test {
 
         let mut S = [signers[0].clone(), signers[1].clone(), signers[3].clone()].to_vec();
         let key_ids = S.iter().flat_map(|s| s.get_key_ids()).collect::<Vec<u32>>();
-        let mut sig_agg =
-            v2::Aggregator::new(Nk, T, A.clone()).expect("aggregator ctor failed");
+        let mut sig_agg = v2::Aggregator::new(Nk, T, A.clone()).expect("aggregator ctor failed");
         let tweaked_public_key = compute::tweaked_public_key(&sig_agg.poly[0], merkle_root);
         let (nonces, sig_shares) = test_helpers::sign(&msg, &mut S, &mut rng, merkle_root);
         let proof = match sig_agg.sign_taproot(&msg, &nonces, &sig_shares, &key_ids, merkle_root) {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -10,6 +10,16 @@ use crate::{
 
 /// A trait which provides a common `Signer` interface for `v1` and `v2`
 pub trait Signer {
+    /// Create a new `Signer`
+    fn new<RNG: RngCore + CryptoRng>(
+        party_id: u32,
+        key_ids: &[u32],
+        num_signers: u32,
+        num_keys: u32,
+        threshold: u32,
+        rng: &mut RNG,
+    ) -> Self;
+
     /// Get the signer ID for this signer
     fn get_id(&self) -> u32;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -75,6 +75,12 @@ pub trait Signer {
 
 /// A trait which provides a common `Aggregator` interface for `v1` and `v2`
 pub trait Aggregator {
+    /// Construct an Aggregator with the passed parameters
+    fn new(num_keys: u32, threshold: u32) -> Self;
+
+    /// Initialize an Aggregator with the passed polynomial commitments
+    fn init(&mut self, poly_comms: Vec<PolyCommitment>) -> Result<(), AggregatorError>;
+
     /// Check and aggregate the signature shares into a `Signature`
     fn sign(
         &mut self,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -3,7 +3,7 @@ use p256k1::{point::Point, scalar::Scalar};
 use rand_core::{CryptoRng, RngCore};
 
 use crate::{
-    common::{PolyCommitment, PublicNonce, SignatureShare, Signature},
+    common::{PolyCommitment, PublicNonce, Signature, SignatureShare},
     errors::{AggregatorError, DkgError},
     taproot::SchnorrProof,
 };

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -3,11 +3,12 @@ use p256k1::{point::Point, scalar::Scalar};
 use rand_core::{CryptoRng, RngCore};
 
 use crate::{
-    common::{PolyCommitment, PublicNonce, SignatureShare},
-    errors::DkgError,
+    common::{PolyCommitment, PublicNonce, SignatureShare, Signature},
+    errors::{AggregatorError, DkgError},
+    taproot::SchnorrProof,
 };
 
-/// A trait which provides a common interface for `v1` and `v2`
+/// A trait which provides a common `Signer` interface for `v1` and `v2`
 pub trait Signer {
     /// Get the signer ID for this signer
     fn get_id(&self) -> u32;
@@ -60,4 +61,26 @@ pub trait Signer {
         nonces: &[PublicNonce],
         merkle_root: Option<[u8; 32]>,
     ) -> Vec<SignatureShare>;
+}
+
+/// A trait which provides a common `Aggregator` interface for `v1` and `v2`
+pub trait Aggregator {
+    /// Check and aggregate the signature shares into a `Signature`
+    fn sign(
+        &mut self,
+        msg: &[u8],
+        nonces: &[PublicNonce],
+        sig_shares: &[SignatureShare],
+        key_ids: &[u32],
+    ) -> Result<Signature, AggregatorError>;
+
+    /// Check and aggregate the signature shares into a `SchnorrProof`
+    fn sign_taproot(
+        &mut self,
+        msg: &[u8],
+        nonces: &[PublicNonce],
+        sig_shares: &[SignatureShare],
+        key_ids: &[u32],
+        merkle_root: Option<[u8; 32]>,
+    ) -> Result<SchnorrProof, AggregatorError>;
 }

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -713,8 +713,7 @@ mod tests {
         // signers [0,1,3] who have T keys
         {
             let mut signers = [signers[0].clone(), signers[1].clone(), signers[3].clone()].to_vec();
-            let mut sig_agg =
-                v1::Aggregator::new(N, T, A.clone()).expect("aggregator ctor failed");
+            let mut sig_agg = v1::Aggregator::new(N, T, A.clone()).expect("aggregator ctor failed");
 
             let (nonces, sig_shares) = v1::test_helpers::sign(&msg, &mut signers, &mut rng);
             if let Err(e) = sig_agg.sign(&msg, &nonces, &sig_shares, &[]) {

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -467,6 +467,17 @@ impl Signer {
 }
 
 impl traits::Signer for Signer {
+    fn new<RNG: RngCore + CryptoRng>(
+        party_id: u32,
+        key_ids: &[u32],
+        _num_signers: u32,
+        num_keys: u32,
+        threshold: u32,
+        rng: &mut RNG,
+    ) -> Self {
+        Signer::new(party_id, key_ids, num_keys, threshold, rng)
+    }
+
     fn get_id(&self) -> u32 {
         self.id
     }

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -28,7 +28,6 @@ pub struct PartyState {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[allow(non_snake_case)]
 /// A FROST party, which encapsulates a single polynomial, nonce, and key
 pub struct Party {
     /// The ID
@@ -45,7 +44,6 @@ pub struct Party {
 }
 
 impl Party {
-    #[allow(non_snake_case)]
     /// Construct a random Party with the passed ID and parameters
     pub fn new<RNG: RngCore + CryptoRng>(id: u32, n: u32, t: u32, rng: &mut RNG) -> Self {
         Self {
@@ -87,12 +85,11 @@ impl Party {
         PublicNonce::from(&self.nonce)
     }
 
-    #[allow(non_snake_case)]
     /// Get a public commitment to the private polynomial
     pub fn get_poly_commitment<RNG: RngCore + CryptoRng>(&self, rng: &mut RNG) -> PolyCommitment {
         PolyCommitment {
             id: ID::new(&self.id(), &self.f.data()[0], rng),
-            A: (0..self.f.data().len())
+            poly: (0..self.f.data().len())
                 .map(|i| &self.f.data()[i] * G)
                 .collect(),
         }
@@ -113,12 +110,11 @@ impl Party {
         shares
     }
 
-    #[allow(non_snake_case)]
     /// Compute this party's share of the group secret key
     pub fn compute_secret(
         &mut self,
         shares: HashMap<u32, Scalar>,
-        A: &[PolyCommitment],
+        comms: &[PolyCommitment],
     ) -> Result<(), DkgError> {
         let mut missing_shares = Vec::new();
         for i in 0..self.n {
@@ -136,7 +132,7 @@ impl Party {
         let bad_ids: Vec<u32> = shares
             .keys()
             .cloned()
-            .filter(|i| !A[usize::try_from(*i).unwrap()].verify())
+            .filter(|i| !comms[usize::try_from(*i).unwrap()].verify())
             .collect();
         if !bad_ids.is_empty() {
             return Err(DkgError::BadIds(bad_ids));
@@ -145,14 +141,14 @@ impl Party {
 
         // building a vector of scalars and points from public poly evaluations and expected values takes too much memory
         // instead make an object which implements p256k1 MultiMult trait, using the existing powers of x and shares
-        let mut check_shares = CheckPrivateShares::new(self.id(), &shares, A);
+        let mut check_shares = CheckPrivateShares::new(self.id(), &shares, comms);
 
         // if the batch verify fails then check them one by one and find the bad ones
         if Point::multimult_trait(&mut check_shares)? != Point::zero() {
             let mut bad_shares = Vec::new();
             for (i, s) in shares.iter() {
-                let Ai = &A[usize::try_from(*i).unwrap()];
-                if s * G != compute::poly(&self.id(), &Ai.A)? {
+                let comm = &comms[usize::try_from(*i).unwrap()];
+                if s * G != compute::poly(&self.id(), &comm.poly)? {
                     bad_shares.push(*i);
                 }
             }
@@ -160,10 +156,10 @@ impl Party {
         }
 
         for (i, s) in shares.iter() {
-            let Ai = &A[usize::try_from(*i).unwrap()];
+            let comm = &comms[usize::try_from(*i).unwrap()];
 
             self.private_key += s;
-            self.group_key += Ai.A[0];
+            self.group_key += comm.poly[0];
         }
         self.public_key = self.private_key * G;
 
@@ -175,12 +171,11 @@ impl Party {
         compute::id(self.id)
     }
 
-    #[allow(non_snake_case)]
     /// Sign `msg` with this party's share of the group private key, using the set of `signers` and corresponding `nonces`
     pub fn sign(&self, msg: &[u8], signers: &[u32], nonces: &[PublicNonce]) -> SignatureShare {
-        let (_R_vec, R) = compute::intermediate(msg, signers, nonces);
+        let (_, aggregate_nonce) = compute::intermediate(msg, signers, nonces);
         let mut z = &self.nonce.d + &self.nonce.e * compute::binding(&self.id(), nonces, msg);
-        z += compute::challenge(&self.group_key, &R, msg)
+        z += compute::challenge(&self.group_key, &aggregate_nonce, msg)
             * &self.private_key
             * compute::lambda(self.id, signers);
 
@@ -260,7 +255,7 @@ impl Aggregator {
         }
 
         let signers: Vec<u32> = sig_shares.iter().map(|ss| ss.id).collect();
-        let (R_vec, R) = compute::intermediate(msg, &signers, nonces);
+        let (Rs, R) = compute::intermediate(msg, &signers, nonces);
         let mut z = Scalar::zero();
         let mut bad_party_keys = Vec::new();
         let mut bad_party_sigs = Vec::new();
@@ -291,7 +286,7 @@ impl Aggregator {
             let z_i = sig_shares[i].z_i;
 
             if z_i * G
-                != r_sign * R_vec[i]
+                != r_sign * Rs[i]
                     + cx_sign * (compute::lambda(sig_shares[i].id, &signers) * c * public_key)
             {
                 bad_party_sigs.push(sig_shares[i].id);
@@ -325,18 +320,17 @@ impl traits::Aggregator for Aggregator {
         }
     }
 
-    #[allow(non_snake_case)]
     /// Initialize the Aggregator polynomial
-    fn init(&mut self, A: Vec<PolyCommitment>) -> Result<(), AggregatorError> {
+    fn init(&mut self, comms: Vec<PolyCommitment>) -> Result<(), AggregatorError> {
         let len = self.num_keys.try_into().unwrap();
-        if A.len() != len {
-            return Err(AggregatorError::BadPolyCommitmentLen(len, A.len()));
+        if comms.len() != len {
+            return Err(AggregatorError::BadPolyCommitmentLen(len, comms.len()));
         }
 
         let mut bad_poly_commitments = Vec::new();
-        for A_i in &A {
-            if !A_i.verify() {
-                bad_poly_commitments.push(A_i.id.id);
+        for comm in &comms {
+            if !comm.verify() {
+                bad_poly_commitments.push(comm.id.id);
             }
         }
         if !bad_poly_commitments.is_empty() {
@@ -347,8 +341,8 @@ impl traits::Aggregator for Aggregator {
 
         for i in 0..poly.capacity() {
             poly.push(Point::zero());
-            for p in &A {
-                poly[i] += &p.A[i];
+            for p in &comms {
+                poly[i] += &p.poly[i];
             }
         }
 
@@ -357,7 +351,6 @@ impl traits::Aggregator for Aggregator {
         Ok(())
     }
 
-    #[allow(non_snake_case)]
     /// Check and aggregate the party signatures
     fn sign(
         &mut self,
@@ -595,13 +588,12 @@ pub mod test_helpers {
     use hashbrown::HashMap;
     use rand_core::{CryptoRng, RngCore};
 
-    #[allow(non_snake_case)]
     /// Run a distributed key generation round
     pub fn dkg<RNG: RngCore + CryptoRng>(
         signers: &mut [v1::Signer],
         rng: &mut RNG,
     ) -> Result<Vec<PolyCommitment>, HashMap<u32, DkgError>> {
-        let A: Vec<PolyCommitment> = signers
+        let comms: Vec<PolyCommitment> = signers
             .iter()
             .flat_map(|s| s.get_poly_commitments(rng))
             .collect();
@@ -615,13 +607,13 @@ pub mod test_helpers {
 
         let mut secret_errors = HashMap::new();
         for signer in signers.iter_mut() {
-            if let Err(signer_secret_errors) = signer.compute_secrets(&private_shares, &A) {
+            if let Err(signer_secret_errors) = signer.compute_secrets(&private_shares, &comms) {
                 secret_errors.extend(signer_secret_errors.into_iter());
             }
         }
 
         if secret_errors.is_empty() {
-            Ok(A)
+            Ok(comms)
         } else {
             Err(secret_errors)
         }
@@ -724,8 +716,8 @@ mod tests {
             .map(|(id, ids)| v1::Signer::new(id.try_into().unwrap(), ids, N, T, &mut rng))
             .collect();
 
-        let A = match v1::test_helpers::dkg(&mut signers, &mut rng) {
-            Ok(A) => A,
+        let comms = match v1::test_helpers::dkg(&mut signers, &mut rng) {
+            Ok(comms) => comms,
             Err(secret_errors) => {
                 panic!("Got secret errors from DKG: {:?}", secret_errors);
             }
@@ -735,7 +727,7 @@ mod tests {
         {
             let mut signers = [signers[0].clone(), signers[1].clone(), signers[3].clone()].to_vec();
             let mut sig_agg = v1::Aggregator::new(N, T);
-            sig_agg.init(A.clone()).expect("aggregator init failed");
+            sig_agg.init(comms.clone()).expect("aggregator init failed");
 
             let (nonces, sig_shares) = v1::test_helpers::sign(&msg, &mut signers, &mut rng);
             if let Err(e) = sig_agg.sign(&msg, &nonces, &sig_shares, &[]) {

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -420,7 +420,18 @@ pub type SignerState = PartyState;
 /// Typedef so we can use the same tokens for v1 and v2
 pub type Signer = Party;
 
-impl crate::traits::Signer for Party {
+impl traits::Signer for Party {
+    fn new<RNG: RngCore + CryptoRng>(
+        party_id: u32,
+        key_ids: &[u32],
+        num_signers: u32,
+        num_keys: u32,
+        threshold: u32,
+        rng: &mut RNG,
+    ) -> Self {
+        Party::new(party_id, key_ids, num_signers, num_keys, threshold, rng)
+    }
+
     fn get_id(&self) -> u32 {
         self.party_id
     }


### PR DESCRIPTION
This PR adds `traits::Aggregator`, which allows us to write generic `Aggregator` code across `v1` and `v2`, to complement the existing `traits::Signer`.  

For consistency, the existing `SignatureAggregator` objects are renamed as `Aggregator`, which matches the error and now the trait.