### PR TITLE
Add network messages and state machines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ p256k1 = "5.4"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"
 thiserror = "1.0"
+tracing = "0.1.37"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["cryptography"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+aes-gcm = "0.10"
 bs58 = "0.5"
 hashbrown = { version = "0.14", features = ["serde"] }
 hex = "0.4.3"

--- a/src/common.rs
+++ b/src/common.rs
@@ -15,6 +15,9 @@ use serde::{Deserialize, Serialize};
 use crate::compute::challenge;
 use crate::schnorr::ID;
 
+/// A merkle root is a 256 bit hash
+pub type MerkleRoot = [u8; 32];
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 /// A commitment to a polynonial, with a Schnorr proof of ownership bound to the ID
 pub struct PolyCommitment {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@ pub mod errors;
 pub mod net;
 /// Schnorr utility types
 pub mod schnorr;
+/// State machines
+pub mod state_machine;
 /// Functions for doing BIP-340 schnorr proofs and other taproot actions
 pub mod taproot;
 /// Traits which are used for v1 and v2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,13 +7,15 @@ pub mod common;
 pub mod compute;
 /// Errors which are returned from objects and functions
 pub mod errors;
+/// Network messages
+pub mod net;
 /// Schnorr utility types
 pub mod schnorr;
 /// Functions for doing BIP-340 schnorr proofs and other taproot actions
 pub mod taproot;
 /// Traits which are used for v1 and v2
 pub mod traits;
-/// Utilities for hashing scalars
+/// Utilities for hashing and encryption
 pub mod util;
 /// Version 1 of WSTS, which encapsulates a number of parties using vanilla FROST
 pub mod v1;

--- a/src/net.rs
+++ b/src/net.rs
@@ -3,7 +3,7 @@ use p256k1::{ecdsa, scalar::Scalar};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::common::{PolyCommitment, PublicNonce, SignatureShare};
+use crate::common::{MerkleRoot, PolyCommitment, PublicNonce, SignatureShare};
 
 /// Trait to encapsulate sign/verify, users only need to impl hash
 pub trait Signable {
@@ -225,6 +225,10 @@ pub struct SignatureShareRequest {
     pub nonce_responses: Vec<NonceResponse>,
     /// Bytes to sign
     pub message: Vec<u8>,
+    /// Whether to make a taproot signature
+    pub is_taproot: bool,
+    /// Taproot merkle root
+    pub merkle_root: Option<MerkleRoot>,
 }
 
 impl Signable for SignatureShareRequest {
@@ -238,6 +242,11 @@ impl Signable for SignatureShareRequest {
         }
 
         hasher.update(self.message.as_slice());
+
+        hasher.update((self.is_taproot as u16).to_be_bytes());
+        if let Some(merkle_root) = self.merkle_root {
+            hasher.update(merkle_root);
+        }
     }
 }
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,14 +1,9 @@
 use hashbrown::HashMap;
-use p256k1::{
-    ecdsa,
-    scalar::Scalar,
-};
+use p256k1::{ecdsa, scalar::Scalar};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::{
-    common::{PolyCommitment, PublicNonce, SignatureShare},
-};
+use crate::common::{PolyCommitment, PublicNonce, SignatureShare};
 
 /// Trait to encapsulate sign/verify, users only need to impl hash
 pub trait Signable {
@@ -96,7 +91,7 @@ pub struct DkgPublicShares {
     /// Signer ID
     pub signer_id: u32,
     /// (party_id, commitment)
-    pub comms: Vec<(u32, PolyCommitment)>, 
+    pub comms: Vec<(u32, PolyCommitment)>,
 }
 
 impl Signable for DkgPublicShares {

--- a/src/net.rs
+++ b/src/net.rs
@@ -51,10 +51,12 @@ pub enum DkgStatus {
 #[derive(Clone, Serialize, Deserialize, Debug)]
 /// Encapsulation of all possible network message types
 pub enum Message {
-    /// Tell signers to begin DKG
+    /// Tell signers to begin DKG by sending DKG public shares
     DkgBegin(DkgBegin),
     /// Send DKG public shares
     DkgPublicShares(DkgPublicShares),
+    /// Tell signers to send DKG private shares
+    DkgPrivateBegin(DkgBegin),
     /// Send DKG private shares
     DkgPrivateShares(DkgPrivateShares),
     /// Tell coordinator that DKG is complete
@@ -64,7 +66,7 @@ pub enum Message {
     /// Tell coordinator signing nonces
     NonceResponse(NonceResponse),
     /// Tell signers to construct signature shares
-    SigmatureShareRequest(SignatureShareRequest),
+    SignatureShareRequest(SignatureShareRequest),
     /// Tell coordinator signature shares
     SignatureShareResponse(SignatureShareResponse),
 }
@@ -266,4 +268,10 @@ impl Signable for SignatureShareResponse {
             hasher.update(signature_share.z_i.to_bytes());
         }
     }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Packet {
+    pub msg: Message,
+    pub sig: Vec<u8>,
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,0 +1,274 @@
+use hashbrown::HashMap;
+use p256k1::{
+    ecdsa,
+    scalar::Scalar,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::{
+    common::{PolyCommitment, PublicNonce, SignatureShare},
+};
+
+/// Trait to encapsulate sign/verify, users only need to impl hash
+pub trait Signable {
+    /// Hash this object in a consistent way so it can be signed/verified
+    fn hash(&self, hasher: &mut Sha256);
+
+    /// Sign a hash of this object using the passed private key
+    fn sign(&self, private_key: &Scalar) -> Result<Vec<u8>, ecdsa::Error> {
+        let mut hasher = Sha256::new();
+
+        self.hash(&mut hasher);
+
+        let hash = hasher.finalize();
+        match ecdsa::Signature::new(hash.as_slice(), private_key) {
+            Ok(sig) => Ok(sig.to_bytes().to_vec()),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Verify a hash of this object using the passed public key
+    fn verify(&self, signature: &[u8], public_key: &ecdsa::PublicKey) -> bool {
+        let mut hasher = Sha256::new();
+
+        self.hash(&mut hasher);
+
+        let hash = hasher.finalize();
+        let sig = match ecdsa::Signature::try_from(signature) {
+            Ok(sig) => sig,
+            Err(_) => return false,
+        };
+
+        sig.verify(hash.as_slice(), public_key)
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+/// Final DKG status after receiving public and private shares
+pub enum DkgStatus {
+    /// DKG completed successfully
+    Success,
+    /// DKG failed with error
+    Failure(String),
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+/// Encapsulation of all possible network message types
+pub enum Message {
+    /// Tell signers to begin DKG
+    DkgBegin(DkgBegin),
+    /// Send DKG public shares
+    DkgPublicShares(DkgPublicShares),
+    /// Send DKG private shares
+    DkgPrivateShares(DkgPrivateShares),
+    /// Tell coordinator that DKG is complete
+    DkgEnd(DkgEnd),
+    /// Tell signers to send signing nonces
+    NonceRequest(NonceRequest),
+    /// Tell coordinator signing nonces
+    NonceResponse(NonceResponse),
+    /// Tell signers to construct signature shares
+    SigmatureShareRequest(SignatureShareRequest),
+    /// Tell coordinator signature shares
+    SignatureShareResponse(SignatureShareResponse),
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+/// DKG begin message from coordinator to signers
+pub struct DkgBegin {
+    /// DKG round ID
+    pub dkg_id: u64,
+}
+
+impl Signable for DkgBegin {
+    fn hash(&self, hasher: &mut Sha256) {
+        hasher.update("DKG_BEGIN".as_bytes());
+        hasher.update(self.dkg_id.to_be_bytes());
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+/// DKG public shares message from signer to all signers and coordinator
+pub struct DkgPublicShares {
+    /// DKG round ID
+    pub dkg_id: u64,
+    /// Signer ID
+    pub signer_id: u32,
+    /// (party_id, commitment)
+    pub comms: Vec<(u32, PolyCommitment)>, 
+}
+
+impl Signable for DkgPublicShares {
+    fn hash(&self, hasher: &mut Sha256) {
+        hasher.update("DKG_PUBLIC_SHARES".as_bytes());
+        hasher.update(self.dkg_id.to_be_bytes());
+        hasher.update(self.signer_id.to_be_bytes());
+        for (party_id, comm) in &self.comms {
+            hasher.update(party_id.to_be_bytes());
+            for a in &comm.poly {
+                hasher.update(a.compress().as_bytes());
+            }
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+/// DKG private shares message from signer to all signers and coordinator
+pub struct DkgPrivateShares {
+    /// DKG round ID
+    pub dkg_id: u64,
+    /// Signer ID
+    pub signer_id: u32,
+    /// Set of (src_key_id, (dst_key_id, encrypted_share))
+    pub shares: Vec<(u32, HashMap<u32, Vec<u8>>)>,
+}
+
+impl Signable for DkgPrivateShares {
+    fn hash(&self, hasher: &mut Sha256) {
+        hasher.update("DKG_PRIVATE_SHARES".as_bytes());
+        hasher.update(self.dkg_id.to_be_bytes());
+        hasher.update(self.signer_id.to_be_bytes());
+        // make sure we iterate sequentially
+        for (src_id, share) in &self.shares {
+            hasher.update(src_id.to_be_bytes());
+            for dst_id in 0..share.len() as u32 {
+                hasher.update(dst_id.to_be_bytes());
+                hasher.update(&share[&dst_id]);
+            }
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+/// DKG end message from signers to coordinator
+pub struct DkgEnd {
+    /// DKG round ID
+    pub dkg_id: u64,
+    /// Signer ID
+    pub signer_id: u32,
+    /// DKG status for this Signer after receiving public/private shares
+    pub status: DkgStatus,
+}
+
+impl Signable for DkgEnd {
+    fn hash(&self, hasher: &mut Sha256) {
+        hasher.update("DKG_END".as_bytes());
+        hasher.update(self.dkg_id.to_be_bytes());
+        hasher.update(self.signer_id.to_be_bytes());
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+/// Nonce request message from coordinator to signers
+pub struct NonceRequest {
+    /// DKG round ID
+    pub dkg_id: u64,
+    /// Signing round ID
+    pub sign_id: u64,
+    /// Signing round iteration ID
+    pub sign_iter_id: u64,
+}
+
+impl Signable for NonceRequest {
+    fn hash(&self, hasher: &mut Sha256) {
+        hasher.update("NONCE_REQUEST".as_bytes());
+        hasher.update(self.dkg_id.to_be_bytes());
+        hasher.update(self.sign_id.to_be_bytes());
+        hasher.update(self.sign_iter_id.to_be_bytes());
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+/// Nonce response message from signers to coordinator
+pub struct NonceResponse {
+    /// DKG round ID
+    pub dkg_id: u64,
+    /// Signing round ID
+    pub sign_id: u64,
+    /// Signing round iteration ID
+    pub sign_iter_id: u64,
+    /// Signer ID
+    pub signer_id: u32,
+    /// Key IDs
+    pub key_ids: Vec<u32>,
+    /// Public nonces
+    pub nonces: Vec<PublicNonce>,
+}
+
+impl Signable for NonceResponse {
+    fn hash(&self, hasher: &mut Sha256) {
+        hasher.update("NONCE_RESPONSE".as_bytes());
+        hasher.update(self.dkg_id.to_be_bytes());
+        hasher.update(self.sign_id.to_be_bytes());
+        hasher.update(self.sign_iter_id.to_be_bytes());
+        hasher.update(self.signer_id.to_be_bytes());
+
+        for key_id in &self.key_ids {
+            hasher.update(key_id.to_be_bytes());
+        }
+
+        for nonce in &self.nonces {
+            hasher.update(nonce.D.compress().as_bytes());
+            hasher.update(nonce.E.compress().as_bytes());
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+/// Signature share request message from coordinator to signers
+pub struct SignatureShareRequest {
+    /// DKG round ID
+    pub dkg_id: u64,
+    /// Signing round ID
+    pub sign_id: u64,
+    /// Signing round iteration ID
+    pub sign_iter_id: u64,
+    /// Nonces responses used for this signature
+    pub nonce_responses: Vec<NonceResponse>,
+    /// Bytes to sign
+    pub message: Vec<u8>,
+}
+
+impl Signable for SignatureShareRequest {
+    fn hash(&self, hasher: &mut Sha256) {
+        hasher.update("SIGNATURE_SHARE_REQUEST".as_bytes());
+        hasher.update(self.dkg_id.to_be_bytes());
+        hasher.update(self.sign_id.to_be_bytes());
+
+        for nonce_response in &self.nonce_responses {
+            nonce_response.hash(hasher);
+        }
+
+        hasher.update(self.message.as_slice());
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+/// Signature share response message from signers to coordinator
+pub struct SignatureShareResponse {
+    /// DKG round ID
+    pub dkg_id: u64,
+    /// Signing round ID
+    pub sign_id: u64,
+    /// Signing round iteration ID
+    pub sign_iter_id: u64,
+    /// Signer ID
+    pub signer_id: u32,
+    /// Signature shares from this Signer
+    pub signature_shares: Vec<SignatureShare>,
+}
+
+impl Signable for SignatureShareResponse {
+    fn hash(&self, hasher: &mut Sha256) {
+        hasher.update("SIGNATURE_SHARE_RESPONSE".as_bytes());
+        hasher.update(self.dkg_id.to_be_bytes());
+        hasher.update(self.sign_id.to_be_bytes());
+        hasher.update(self.signer_id.to_be_bytes());
+
+        for signature_share in &self.signature_shares {
+            hasher.update(signature_share.id.to_be_bytes());
+            hasher.update(signature_share.z_i.to_bytes());
+        }
+    }
+}

--- a/src/net.rs
+++ b/src/net.rs
@@ -271,7 +271,10 @@ impl Signable for SignatureShareResponse {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+/// Network packets need to be signed so they can be verified
 pub struct Packet {
+    /// The message to sign
     pub msg: Message,
+    /// The bytes of the signature
     pub sig: Vec<u8>,
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -92,7 +92,7 @@ pub struct DkgPublicShares {
     pub dkg_id: u64,
     /// Signer ID
     pub signer_id: u32,
-    /// (party_id, commitment)
+    /// List of (party_id, commitment)
     pub comms: Vec<(u32, PolyCommitment)>,
 }
 
@@ -117,7 +117,7 @@ pub struct DkgPrivateShares {
     pub dkg_id: u64,
     /// Signer ID
     pub signer_id: u32,
-    /// Set of (src_key_id, (dst_key_id, encrypted_share))
+    /// List of (src_key_id, Map(dst_key_id, encrypted_share))
     pub shares: Vec<(u32, HashMap<u32, Vec<u8>>)>,
 }
 

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -539,6 +539,11 @@ pub mod coordinator {
                     .flat_map(|nr| nr.nonces.clone())
                     .collect::<Vec<PublicNonce>>();
 
+                let key_ids = nonce_responses
+                    .iter()
+                    .flat_map(|nr| nr.key_ids.clone())
+                    .collect::<Vec<u32>>();
+
                 let shares = &self
                     .public_nonces
                     .iter()
@@ -554,13 +559,12 @@ pub mod coordinator {
 
                 self.aggregator.init(polys)?;
 
-                // XXX need key_ids for v2
                 if is_taproot {
                     self.schnorr_proof = self.aggregator.sign_taproot(
                         &self.message,
                         &nonces,
                         shares,
-                        &[],
+                        &key_ids,
                         merkle_root,
                     )?;
                     info!(
@@ -568,7 +572,9 @@ pub mod coordinator {
                         self.schnorr_proof.r, self.schnorr_proof.s
                     );
                 } else {
-                    self.signature = self.aggregator.sign(&self.message, &nonces, shares, &[])?;
+                    self.signature =
+                        self.aggregator
+                            .sign(&self.message, &nonces, shares, &key_ids)?;
                     info!("Signature ({}, {})", self.signature.R, self.signature.z);
                 }
 

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -279,6 +279,7 @@ pub mod coordinator {
         /// Ask signers to send DKG public shares
         pub fn start_public_shares(&mut self) -> Result<Packet, Error> {
             self.dkg_public_shares.clear();
+            self.party_polynomials.clear();
             info!(
                 "DKG Round #{}: Starting Public Share Distribution",
                 self.current_dkg_id,
@@ -374,6 +375,7 @@ pub mod coordinator {
         }
 
         fn request_nonces(&mut self) -> Result<Packet, Error> {
+            self.public_nonces.clear();
             info!(
                 "Sign Round #{} Nonce round #{} Requesting Nonces",
                 self.current_sign_id, self.current_sign_iter_id,
@@ -431,6 +433,7 @@ pub mod coordinator {
         }
 
         fn request_sig_shares(&mut self) -> Result<Packet, Error> {
+            self.signature_shares.clear();
             info!(
                 "Sign Round #{} Requesting Signature Shares",
                 self.current_sign_id,
@@ -632,6 +635,7 @@ pub mod coordinator {
         fn reset(&mut self) {
             self.state = State::Idle;
             self.dkg_public_shares.clear();
+            self.party_polynomials.clear();
             self.public_nonces.clear();
             self.signature_shares.clear();
             self.ids_to_await = (0..self.total_signers).collect();

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -36,7 +36,7 @@ pub mod coordinator {
     use hashbrown::HashSet;
     use p256k1::{point::Point, scalar::Scalar};
     use std::collections::BTreeMap;
-    use tracing::{info, warn};
+    use tracing::info;
 
     use crate::{
         common::{MerkleRoot, PolyCommitment, PublicNonce, Signature, SignatureShare},

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -1,0 +1,886 @@
+use p256k1::point::Point;
+
+use crate::{
+    common::Signature,
+    taproot::SchnorrProof,
+};
+
+/// A generic state machine
+pub trait StateMachine<S, E> {
+    /// Attempt to move the state machine to a new state
+    fn move_to(&mut self, state: S) -> Result<(), E>;
+    /// Check if the state machine can move to a new state
+    fn can_move_to(&self, state: &S) -> Result<(), E>;
+}
+
+/// Result of a DKG or sign operation
+#[allow(dead_code)]
+pub enum OperationResult {
+    /// The DKG result
+    Dkg(Point),
+    /// The sign result
+    Sign(Signature, SchnorrProof),
+}
+
+pub mod coordinator {
+    use hashbrown::HashSet;
+    use p256k1::{point::Point, scalar::Scalar};
+    use std::collections::BTreeMap;    
+    use tracing::{info, warn};
+
+    use crate::{
+        common::{PolyCommitment, PublicNonce, Signature, SignatureShare},
+        compute,
+        errors::AggregatorError,
+        net::{DkgBegin, DkgPublicShares, NonceRequest, NonceResponse, SignatureShareRequest, Signable, Message, Packet},
+        taproot::SchnorrProof,
+        traits::Aggregator,
+        v1,
+    };
+
+    use super::{OperationResult, StateMachine};
+
+    #[derive(Debug, PartialEq)]
+    /// Coordinator states
+    pub enum State {
+        /// The coordinator is idle
+        Idle,
+        /// The coordinator is distributing public shares
+        DkgPublicDistribute,
+        /// The coordinator is gathering public shares
+        DkgPublicGather,
+        /// The coordinator is distributing private shares
+        DkgPrivateDistribute,
+        /// The coordinator is gathering DKG End messages
+        DkgEndGather,
+        /// The coordinator is requesting nonces
+        NonceRequest,
+        /// The coordinator is gathering nonces
+        NonceGather,
+        /// The coordinator is requesting signature shares
+        SigShareRequest,
+        /// The coordinator is gathering signature shares
+        SigShareGather,
+    }
+
+    
+    #[derive(thiserror::Error, Debug)]
+    /// The error type for the coordinator
+    pub enum Error {
+        /// A bad state change was made
+        #[error("Bad State Change: {0}")]
+        BadStateChange(String),
+        /// A bad dkg_id in received message
+        #[error("Bad dkg_id: got {0} expected {1}")]
+        BadDkgId(u64, u64),
+        /// A bad dkg_public_id in received message
+        #[error("Bad dkg_public_id: got {0} expected {1}")]
+        BadDkgPublicId(u64, u64),
+        /// A bad sign_id in received message
+        #[error("Bad sign_id: got {0} expected {1}")]
+        BadSignId(u64, u64),
+        /// A bad sign_nonce_id in received message
+        #[error("Bad sign_nonce_id: got {0} expected {1}")]
+        BadSignNonceId(u64, u64),
+        /// SignatureAggregator error
+        #[error("Aggregator: {0}")]
+        Aggregator(AggregatorError),
+        /// Schnorr proof failed to verify
+        #[error("Schnorr Proof failed to verify")]
+        SchnorrProofFailed,
+    }
+    
+    impl From<AggregatorError> for Error {
+        fn from(err: AggregatorError) -> Self {
+            Error::Aggregator(err)
+        }
+    }
+
+    /// The coordinator for the FROST algorithm
+    pub struct Coordinator {
+        current_dkg_id: u64,
+        current_dkg_public_id: u64,
+        current_sign_id: u64,
+        current_sign_nonce_id: u64,
+        total_signers: u32, // Assuming the signers cover all id:s in {1, 2, ..., total_signers}
+        total_keys: u32,
+        threshold: u32,
+        dkg_public_shares: BTreeMap<u32, DkgPublicShares>,
+        party_polynomials: BTreeMap<u32, PolyCommitment>,
+        public_nonces: BTreeMap<u32, NonceResponse>,
+        signature_shares: BTreeMap<u32, Vec<SignatureShare>>,
+        aggregate_public_key: Point,
+        signature: Signature,
+        schnorr_proof: SchnorrProof,
+        message_private_key: Scalar,
+        ids_to_await: HashSet<u32>,
+        message: Vec<u8>,
+        state: State,
+    }
+
+    impl Coordinator {
+        /// Create a new coordinator
+        pub fn new(
+            total_signers: u32,
+            total_keys: u32,
+            threshold: u32,
+            message_private_key: Scalar,
+        ) -> Self {
+            Self {
+                current_dkg_id: 0,
+                current_dkg_public_id: 0,
+                current_sign_id: 0,
+                current_sign_nonce_id: 0,
+                total_signers,
+                total_keys,
+                threshold,
+                dkg_public_shares: Default::default(),
+                party_polynomials: Default::default(),
+                public_nonces: Default::default(),
+                signature_shares: Default::default(),
+                aggregate_public_key: Point::default(),
+                signature: Signature {
+                    R: Default::default(),
+                    z: Default::default(),
+                },
+                schnorr_proof: SchnorrProof {
+                    r: Default::default(),
+                    s: Default::default(),
+                },
+                message: Default::default(),
+                message_private_key,
+                ids_to_await: (0..total_signers).collect(),
+                state: State::Idle,
+            }
+        }
+    }
+
+    impl Coordinator {
+        pub fn process_message(
+            &mut self,
+            packet: &Packet,
+        ) -> Result<(Option<Packet>, Option<OperationResult>), Error> {
+            loop {
+                match self.state {
+                    State::Idle => {
+                        // do nothing
+                        // We are the coordinator and should be the only thing triggering messages right now
+                        return Ok((None, None));
+                    }
+                    State::DkgPublicDistribute => {
+                        let packet = self.start_public_shares()?;
+                        return Ok((Some(packet), None));
+                    }
+                    State::DkgPublicGather => {
+                        self.gather_public_shares(packet)?;
+                        if self.state == State::DkgPublicGather {
+                            // We need more data
+                            return Ok((None, None));
+                        }
+                    }
+                    State::DkgPrivateDistribute => {
+                        let packet = self.start_private_shares()?;
+                        return Ok((Some(packet), None));
+                    }
+                    State::DkgEndGather => {
+                        self.gather_dkg_end(packet)?;
+                        if self.state == State::DkgEndGather {
+                            // We need more data
+                            return Ok((None, None));
+                        } else if self.state == State::Idle {
+                            // We are done with the DKG round! Return the operation result
+                            return Ok((None, Some(OperationResult::Dkg(self.aggregate_public_key))));
+                        }
+                    }
+                    State::NonceRequest => {
+                        let packet = self.request_nonces()?;
+                        return Ok((Some(packet), None));
+                    }
+                    State::NonceGather => {
+                        self.gather_nonces(packet)?;
+                        if self.state == State::NonceGather {
+                            // We need more data
+                            return Ok((None, None));
+                        }
+                    }
+                    State::SigShareRequest => {
+                        let packet = self.request_sig_shares()?;
+                        return Ok((Some(packet), None));
+                    }
+                    State::SigShareGather => {
+                        self.gather_sig_shares(packet)?;
+                        if self.state == State::SigShareGather {
+                            // We need more data
+                            return Ok((None, None));
+                        } else if self.state == State::Idle {
+                            // We are done with the DKG round! Return the operation result
+                            return Ok((
+                                None,
+                                Some(OperationResult::Sign(
+                                    Signature {
+                                        R: self.signature.R,
+                                        z: self.signature.z,
+                                    },
+                                    SchnorrProof {
+                                        r: self.schnorr_proof.r,
+                                        s: self.schnorr_proof.s,
+                                    },
+                                )),
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        /// Start a DKG round
+        pub fn start_dkg_round(&mut self) -> Result<Packet, Error> {
+            self.current_dkg_id = self.current_dkg_id.wrapping_add(1);
+            info!("Starting DKG round #{}", self.current_dkg_id);
+            self.move_to(State::DkgPublicDistribute)?;
+            self.start_public_shares()
+        }
+
+        /// Start a signing round
+        pub fn start_signing_round(&mut self) -> Result<Packet, Error> {
+            self.current_sign_id = self.current_sign_id.wrapping_add(1);
+            info!("Starting signing round #{}", self.current_sign_id);
+            self.move_to(State::NonceRequest)?;
+            self.request_nonces()
+        }
+
+        fn start_public_shares(&mut self) -> Result<Packet, Error> {
+            self.dkg_public_shares.clear();
+            info!(
+                "DKG Round #{}: Starting Public Share Distribution Round #{}",
+                self.current_dkg_id, self.current_dkg_public_id
+            );
+            let dkg_begin = DkgBegin {
+                dkg_id: self.current_dkg_id,
+            };
+
+            let dkg_begin_packet = Packet {
+                sig: dkg_begin.sign(&self.message_private_key).expect(""),
+                msg: Message::DkgBegin(dkg_begin),
+            };
+            self.move_to(State::DkgPublicGather)?;
+            Ok(dkg_begin_packet)
+        }
+
+        fn start_private_shares(&mut self) -> Result<Packet, Error> {
+            info!(
+                "DKG Round #{}: Starting Private Share Distribution",
+                self.current_dkg_id
+            );
+            let dkg_begin = DkgBegin {
+                dkg_id: self.current_dkg_id,
+            };
+            let dkg_private_begin_msg = Packet {
+                sig: dkg_begin.sign(&self.message_private_key).expect(""),
+                msg: Message::DkgPrivateBegin(dkg_begin),
+            };
+            self.move_to(State::DkgEndGather)?;
+            Ok(dkg_private_begin_msg)
+        }
+
+        fn gather_public_shares(&mut self, packet: &Packet) -> Result<(), Error> {
+            match &packet.msg {
+                Message::DkgPublicShares(dkg_public_shares) => {
+                    if dkg_public_shares.dkg_id != self.current_dkg_id {
+                        return Err(Error::BadDkgId(
+                            dkg_public_shares.dkg_id,
+                            self.current_dkg_id,
+                        ));
+                    }
+
+                    self.ids_to_await.remove(&dkg_public_shares.signer_id);
+
+                    self.dkg_public_shares
+                        .insert(dkg_public_shares.signer_id, dkg_public_shares.clone());
+                    for (party_id, comm) in &dkg_public_shares {
+                        self.party_polynomials.insert(party_id, comm.clone());
+                    }
+
+                    info!(
+                        "DKG round #{} DkgPublicShares from signer #{}",
+                        dkg_public_shares.dkg_id,
+                        dkg_public_shares.signer_id
+                    );
+                }
+                _ => {}
+            }
+            if self.ids_to_await.is_empty() {
+                // Calculate the aggregate public key
+                let key = self
+                    .dkg_public_shares
+                    .iter()
+                    .fold(Point::default(), |s, (_, dps)| s + dps.public_share.A[0]);
+                // check to see if aggregate public key has even y
+                if key.has_even_y() {
+                    info!("Aggregate public key has even y coord!");
+                    info!("Aggregate public key: {}", key);
+                    self.aggregate_public_key = key;
+                    self.move_to(State::DkgPrivateDistribute)?;
+                } else {
+                    warn!("DKG Round #{} Failed: Aggregate public key does not have even y coord, re-running dkg.", self.current_dkg_id);
+                    // TODO: SigningRound seems to break if we inc dkg_public_id
+                    // self.current_dkg_public_id = self.current_dkg_public_id.wrapping_add(1);
+                    self.move_to(State::DkgPublicDistribute)?;
+                }
+                self.ids_to_await = (0..self.total_signers).collect();
+            }
+            Ok(())
+        }
+
+        fn gather_dkg_end(&mut self, packet: &Packet) -> Result<(), Error> {
+            info!(
+                "DKG Round #{}: waiting for Dkg End from signers {:?}",
+                self.current_dkg_id, self.ids_to_await
+            );
+            if let Message::DkgEnd(dkg_end) = &packet.msg {
+                if dkg_end.dkg_id != self.current_dkg_id {
+                    return Err(Error::BadDkgId(dkg_end.dkg_id, self.current_dkg_id));
+                }
+                self.ids_to_await.remove(&dkg_end.signer_id);
+                info!(
+                    "DKG_End round #{} from signer #{}. Waiting on {:?}",
+                    dkg_end.dkg_id, dkg_end.signer_id, self.ids_to_await
+                );
+            }
+
+            if self.ids_to_await.is_empty() {
+                self.ids_to_await = (0..self.total_signers).collect();
+                self.move_to(State::Idle)?;
+            }
+            Ok(())
+        }
+
+        fn request_nonces(&mut self) -> Result<Packet, Error> {
+            info!(
+                "Sign Round #{} Nonce round #{} Requesting Nonces",
+                self.current_sign_id, self.current_sign_nonce_id,
+            );
+            let nonce_request = NonceRequest {
+                dkg_id: self.current_dkg_id,
+                sign_id: self.current_sign_id,
+                sign_nonce_id: self.current_sign_nonce_id,
+            };
+            let nonce_request_msg = Packet {
+                sig: nonce_request.sign(&self.message_private_key).expect(""),
+                msg: Message::NonceRequest(nonce_request),
+            };
+            self.ids_to_await = (0..self.total_signers).collect();
+            self.move_to(State::NonceGather)?;
+            Ok(nonce_request_msg)
+        }
+
+        fn gather_nonces(&mut self, packet: &Packet) -> Result<(), Error> {
+            if let Message::NonceResponse(nonce_response) = &packet.msg {
+                if nonce_response.dkg_id != self.current_dkg_id {
+                    return Err(Error::BadDkgId(nonce_response.dkg_id, self.current_dkg_id));
+                }
+                if nonce_response.sign_id != self.current_sign_id {
+                    return Err(Error::BadSignId(
+                        nonce_response.sign_id,
+                        self.current_sign_id,
+                    ));
+                }
+                if nonce_response.sign_nonce_id != self.current_sign_nonce_id {
+                    return Err(Error::BadSignNonceId(
+                        nonce_response.sign_nonce_id,
+                        self.current_sign_nonce_id,
+                    ));
+                }
+
+                self.public_nonces
+                    .insert(nonce_response.signer_id, nonce_response.clone());
+                self.ids_to_await.remove(&nonce_response.signer_id);
+                info!(
+                    "Sign round #{} nonce round #{} NonceResponse from signer #{}. Waiting on {:?}",
+                    nonce_response.sign_id,
+                    nonce_response.sign_nonce_id,
+                    nonce_response.signer_id,
+                    self.ids_to_await
+                );
+            }
+            if self.ids_to_await.is_empty() {
+                // Calculate the aggregate nonce
+                let aggregate_nonce = self.compute_aggregate_nonce();
+
+                // check to see if aggregate public key has even y
+                if aggregate_nonce.has_even_y() {
+                    info!("Aggregate nonce has even y coord!");
+                    info!("Aggregate nonce: {}", aggregate_nonce);
+                    self.move_to(State::SigShareRequest)?;
+                } else {
+                    warn!("Sign Round #{} Nonce Round #{} Failed: Aggregate nonce does not have even y coord, requesting new nonces.", self.current_sign_id, self.current_sign_nonce_id);
+                    self.current_sign_nonce_id += 1;
+                    self.move_to(State::NonceRequest)?;
+                }
+            }
+            Ok(())
+        }
+
+        fn request_sig_shares(&mut self) -> Result<Packet, Error> {
+            info!(
+                "Sign Round #{} Requesting Signature Shares",
+                self.current_sign_id,
+            );
+            let nonce_responses = (0..self.total_signers)
+                .map(|i| self.public_nonces[&i].clone())
+                .collect::<Vec<NonceResponse>>();
+            let sig_share_request = SignatureShareRequest {
+                dkg_id: self.current_dkg_id,
+                sign_id: self.current_sign_id,
+                nonce_responses,
+                message: self.message.clone(),
+            };
+            let sig_share_request_msg = Packet {
+                sig: sig_share_request.sign(&self.message_private_key).expect(""),
+                msg: Message::SignatureShareRequest(sig_share_request),
+            };
+            self.ids_to_await = (0..self.total_signers).collect();
+            self.move_to(State::SigShareGather)?;
+            Ok(sig_share_request_msg)
+        }
+
+        fn gather_sig_shares(&mut self, packet: &Packet) -> Result<(), Error> {
+            if let Message::SignatureShareResponse(sig_share_response) = &packet.msg {
+                if sig_share_response.dkg_id != self.current_dkg_id {
+                    return Err(Error::BadDkgId(
+                        sig_share_response.dkg_id,
+                        self.current_dkg_id,
+                    ));
+                }
+                if sig_share_response.sign_id != self.current_sign_id {
+                    return Err(Error::BadSignId(
+                        sig_share_response.sign_id,
+                        self.current_sign_id,
+                    ));
+                }
+                self.signature_shares.insert(
+                    sig_share_response.signer_id,
+                    sig_share_response.signature_shares.clone(),
+                );
+                self.ids_to_await.remove(&sig_share_response.signer_id);
+                info!(
+                    "Sign round #{} SignatureShareResponse from signer #{}. Waiting on {:?}",
+                    sig_share_response.sign_id, sig_share_response.signer_id, self.ids_to_await
+                );
+            }
+            if self.ids_to_await.is_empty() {
+                // Calculate the aggregate signature
+                let polys: Vec<PolyCommitment> = self
+                    .dkg_public_shares
+                    .values()
+                    .map(|ps| ps.public_share.clone())
+                    .collect();
+
+                let nonce_responses = (0..self.total_signers)
+                    .map(|i| self.public_nonces[&i].clone())
+                    .collect::<Vec<NonceResponse>>();
+
+                let nonces = nonce_responses
+                    .iter()
+                    .flat_map(|nr| nr.nonces.clone())
+                    .collect::<Vec<PublicNonce>>();
+
+                let shares = &self
+                    .public_nonces
+                    .iter()
+                    .flat_map(|(i, _)| self.signature_shares[i].clone())
+                    .collect::<Vec<SignatureShare>>();
+
+                info!(
+                    "aggregator.sign({:?}, {:?}, {:?})",
+                    self.message,
+                    nonces.len(),
+                    shares.len()
+                );
+
+                let mut aggregator =
+                    v1::Aggregator::new(self.total_keys, self.threshold);
+
+                aggregator.init(polys);
+
+                let sig = aggregator.sign(&self.message, &nonces, shares)?;
+
+                info!("Signature ({}, {})", sig.R, sig.z);
+
+                let proof = SchnorrProof::new(&sig)?;
+
+                info!("SchnorrProof ({}, {})", proof.r, proof.s);
+
+                if !proof.verify(&self.aggregate_public_key.x(), &self.message) {
+                    warn!("SchnorrProof failed to verify!");
+                    return Err(Error::SchnorrProofFailed);
+                }
+
+                self.move_to(State::Idle)?;
+            }
+            Ok(())
+        }
+
+        #[allow(non_snake_case)]
+        fn compute_aggregate_nonce(&self) -> Point {
+            // XXX this needs to be key_ids for v1 and signer_ids for v2
+            let party_ids = self
+                .public_nonces
+                .values()
+                .flat_map(|pn| pn.key_ids.clone())
+                .collect::<Vec<u32>>();
+            let nonces = self
+                .public_nonces
+                .values()
+                .flat_map(|pn| pn.nonces.clone())
+                .collect::<Vec<PublicNonce>>();
+            let (_, R) = compute::intermediate(&self.message, &party_ids, &nonces);
+
+            R
+        }
+    }
+
+    impl StateMachine<State, Error> for Coordinator {
+        fn move_to(&mut self, state: State) -> Result<(), Error> {
+            self.can_move_to(&state)?;
+            self.state = state;
+            Ok(())
+        }
+
+        fn can_move_to(&self, state: &State) -> Result<(), Error> {
+            let prev_state = &self.state;
+            let accepted = match state {
+                State::Idle => true,
+                State::DkgPublicDistribute => {
+                    prev_state == &State::Idle
+                        || prev_state == &State::DkgPublicGather
+                        || prev_state == &State::DkgEndGather
+                }
+                State::DkgPublicGather => {
+                    prev_state == &State::DkgPublicDistribute || prev_state == &State::DkgPublicGather
+                }
+                State::DkgPrivateDistribute => prev_state == &State::DkgPublicGather,
+                State::DkgEndGather => prev_state == &State::DkgPrivateDistribute,
+                State::NonceRequest => {
+                    prev_state == &State::Idle
+                        || prev_state == &State::DkgEndGather
+                        || prev_state == &State::NonceGather
+                }
+                State::NonceGather => {
+                    prev_state == &State::NonceRequest || prev_state == &State::NonceGather
+                }
+                State::SigShareRequest => prev_state == &State::NonceGather,
+                State::SigShareGather => {
+                    prev_state == &State::SigShareRequest || prev_state == &State::SigShareGather
+                }
+            };
+            if accepted {
+                info!("state change from {:?} to {:?}", prev_state, state);
+                Ok(())
+            } else {
+                Err(Error::BadStateChange(format!(
+                    "{:?} to {:?}",
+                    prev_state, state
+                )))
+            }
+        }
+    }
+}
+
+/*
+impl Coordinatable for Coordinator {
+    /// Process inbound messages
+    fn process_inbound_messages(
+        &mut self,
+        messages: Vec<Message>,
+    ) -> Result<(Vec<Message>, Vec<OperationResult>), crate::crypto::Error> {
+        let mut outbound_messages = vec![];
+        let mut operation_results = vec![];
+        for message in &messages {
+            let (outbound_message, operation_result) = self.process_message(message)?;
+            if let Some(outbound_message) = outbound_message {
+                outbound_messages.push(outbound_message);
+            }
+            if let Some(operation_result) = operation_result {
+                operation_results.push(operation_result);
+            }
+        }
+        Ok((outbound_messages, operation_results))
+    }
+
+    /// Retrieve the aggregate public key
+    fn get_aggregate_public_key(&self) -> Point {
+        self.aggregate_public_key
+    }
+
+    /// Trigger a DKG round
+    fn start_distributed_key_generation(&mut self) -> Result<Message, CryptoError> {
+        let message = self.start_dkg_round()?;
+        Ok(message)
+    }
+
+    // Trigger a signing round
+    fn start_signing_message(&mut self, message: &[u8]) -> Result<Message, CryptoError> {
+        self.message = message.to_vec();
+        let message = self.start_signing_round()?;
+        Ok(message)
+    }
+
+    // Reset internal state
+    fn reset(&mut self) {
+        self.state = State::Idle;
+        self.dkg_public_shares.clear();
+        self.public_nonces.clear();
+        self.signature_shares.clear();
+        self.ids_to_await = (0..self.total_signers).collect();
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use crate::runloop::process_inbound_messages;
+
+    use super::*;
+    use frost_signer::{config::PublicKeys, signing_round::SigningRound};
+    use hashbrown::HashMap;
+    use p256k1::ecdsa;
+    use rand_core::OsRng;
+
+    #[test]
+    fn test_state_machine() {
+        let mut rng = OsRng;
+        let message_private_key = Scalar::random(&mut rng);
+
+        let mut coordinator = Coordinator::new(3, 3, 3, message_private_key);
+        assert!(coordinator.can_move_to(&State::DkgPublicDistribute).is_ok());
+        assert!(coordinator.can_move_to(&State::DkgPublicGather).is_err());
+        assert!(coordinator
+            .can_move_to(&State::DkgPrivateDistribute)
+            .is_err());
+        assert!(coordinator.can_move_to(&State::DkgEndGather).is_err());
+        assert!(coordinator.can_move_to(&State::Idle).is_ok());
+
+        coordinator.move_to(State::DkgPublicDistribute).unwrap();
+        assert!(coordinator
+            .can_move_to(&State::DkgPublicDistribute)
+            .is_err());
+        assert!(coordinator.can_move_to(&State::DkgPublicGather).is_ok());
+        assert!(coordinator
+            .can_move_to(&State::DkgPrivateDistribute)
+            .is_err());
+        assert!(coordinator.can_move_to(&State::DkgEndGather).is_err());
+        assert!(coordinator.can_move_to(&State::Idle).is_ok());
+
+        coordinator.move_to(State::DkgPublicGather).unwrap();
+        assert!(coordinator.can_move_to(&State::DkgPublicDistribute).is_ok());
+        assert!(coordinator.can_move_to(&State::DkgPublicGather).is_ok());
+        assert!(coordinator
+            .can_move_to(&State::DkgPrivateDistribute)
+            .is_ok());
+        assert!(coordinator.can_move_to(&State::DkgEndGather).is_err());
+        assert!(coordinator.can_move_to(&State::Idle).is_ok());
+
+        coordinator.move_to(State::DkgPrivateDistribute).unwrap();
+        assert!(coordinator
+            .can_move_to(&State::DkgPublicDistribute)
+            .is_err());
+        assert!(coordinator.can_move_to(&State::DkgPublicGather).is_err());
+        assert!(coordinator
+            .can_move_to(&State::DkgPrivateDistribute)
+            .is_err());
+        assert!(coordinator.can_move_to(&State::DkgEndGather).is_ok());
+        assert!(coordinator.can_move_to(&State::Idle).is_ok());
+
+        coordinator.move_to(State::DkgEndGather).unwrap();
+        assert!(coordinator.can_move_to(&State::DkgPublicDistribute).is_ok());
+    }
+
+    #[test]
+    fn test_new_coordinator() {
+        let total_signers = 10;
+        let total_keys = 40;
+        let threshold = 28;
+        let mut rng = OsRng;
+        let message_private_key = Scalar::random(&mut rng);
+
+        let coordinator =
+            Coordinator::new(total_signers, total_keys, threshold, message_private_key);
+
+        assert_eq!(coordinator.total_signers, total_signers);
+        assert_eq!(coordinator.total_keys, total_keys);
+        assert_eq!(coordinator.threshold, threshold);
+        assert_eq!(coordinator.message_private_key, message_private_key);
+        assert_eq!(coordinator.ids_to_await.len(), total_signers as usize);
+        assert_eq!(coordinator.state, State::Idle);
+    }
+
+    #[test]
+    fn test_start_dkg_round() {
+        let total_signers = 10;
+        let total_keys = 40;
+        let threshold = 28;
+        let mut rng = OsRng;
+        let message_private_key = Scalar::random(&mut rng);
+        let mut coordinator =
+            Coordinator::new(total_signers, total_keys, threshold, message_private_key);
+
+        let result = coordinator.start_dkg_round();
+
+        assert!(result.is_ok());
+        assert!(matches!(result.unwrap().msg, Message::DkgBegin(_)));
+        assert_eq!(coordinator.state, State::DkgPublicGather);
+        assert_eq!(coordinator.current_dkg_id, 1);
+    }
+
+    #[test]
+    fn test_start_public_shares() {
+        let total_signers = 10;
+        let total_keys = 40;
+        let threshold = 28;
+        let mut rng = OsRng;
+        let message_private_key = Scalar::random(&mut rng);
+        let mut coordinator =
+            Coordinator::new(total_signers, total_keys, threshold, message_private_key);
+        coordinator.state = State::DkgPublicDistribute; // Must be in this state before calling start public shares
+
+        let result = coordinator.start_public_shares().unwrap();
+
+        assert!(matches!(result.msg, Message::DkgBegin(_)));
+        assert_eq!(coordinator.state, State::DkgPublicGather);
+        assert_eq!(coordinator.current_dkg_id, 0);
+    }
+
+    #[test]
+    fn test_start_private_shares() {
+        let total_signers = 10;
+        let total_keys = 40;
+        let threshold = 28;
+        let mut rng = OsRng;
+        let message_private_key = Scalar::random(&mut rng);
+        let mut coordinator =
+            Coordinator::new(total_signers, total_keys, threshold, message_private_key);
+        coordinator.state = State::DkgPrivateDistribute; // Must be in this state before calling start private shares
+
+        let message = coordinator.start_private_shares().unwrap();
+        assert!(matches!(message.msg, Message::DkgPrivateBegin(_)));
+        assert_eq!(coordinator.state, State::DkgEndGather);
+        assert_eq!(coordinator.current_dkg_id, 0);
+    }
+
+    fn setup() -> (Coordinator, Vec<SigningRound>) {
+        let mut rng = OsRng;
+        let total_signers = 5;
+        let threshold = total_signers / 10 + 7;
+        let keys_per_signer = 3;
+        let total_keys = total_signers * keys_per_signer;
+        let key_pairs = (0..total_signers)
+            .map(|_| {
+                let private_key = Scalar::random(&mut rng);
+                let public_key = ecdsa::PublicKey::new(&private_key).unwrap();
+                (private_key, public_key)
+            })
+            .collect::<Vec<(Scalar, ecdsa::PublicKey)>>();
+        let mut key_id: u32 = 0;
+        let mut signer_ids_map = HashMap::new();
+        let mut key_ids_map = HashMap::new();
+        let mut key_ids = Vec::new();
+        for (i, (_private_key, public_key)) in key_pairs.iter().enumerate() {
+            for _ in 0..keys_per_signer {
+                key_ids_map.insert(key_id + 1, *public_key);
+                key_ids.push(key_id);
+                key_id += 1;
+            }
+            signer_ids_map.insert(i as u32, *public_key);
+        }
+        let public_keys = PublicKeys {
+            signers: signer_ids_map,
+            key_ids: key_ids_map,
+        };
+
+        let signing_rounds = key_pairs
+            .iter()
+            .enumerate()
+            .map(|(signer_id, (private_key, _public_key))| {
+                SigningRound::new(
+                    threshold,
+                    total_signers,
+                    total_keys,
+                    signer_id as u32,
+                    key_ids.clone(),
+                    *private_key,
+                    public_keys.clone(),
+                )
+            })
+            .collect::<Vec<SigningRound>>();
+
+        let coordinator = Coordinator::new(total_signers, total_keys, threshold, key_pairs[0].0);
+        (coordinator, signing_rounds)
+    }
+
+    /// Helper function for feeding messages back from the processor into the signing rounds and coordinator
+    fn feedback_messages(
+        coordinator: &mut Coordinator,
+        signing_rounds: &mut Vec<SigningRound>,
+        messages: Vec<Message>,
+    ) -> (Vec<Message>, Vec<OperationResult>) {
+        let mut inbound_messages = vec![];
+        let mut feedback_messages = vec![];
+        for signing_round in signing_rounds.as_mut_slice() {
+            let outbound_messages =
+                process_inbound_messages(signing_round, messages.clone()).unwrap();
+            feedback_messages.extend_from_slice(outbound_messages.as_slice());
+            inbound_messages.extend(outbound_messages);
+        }
+        for signing_round in signing_rounds.as_mut_slice() {
+            let outbound_messages =
+                process_inbound_messages(signing_round, feedback_messages.clone()).unwrap();
+            inbound_messages.extend(outbound_messages);
+        }
+        coordinator
+            .process_inbound_messages(inbound_messages)
+            .unwrap()
+    }
+
+    #[test]
+    fn test_process_inbound_messages_dkg() {
+        let (mut coordinator, mut signing_rounds) = setup();
+        // We have started a dkg round
+        let message = coordinator.start_dkg_round().unwrap();
+        assert_eq!(coordinator.aggregate_public_key, Point::default());
+        assert_eq!(coordinator.state, State::DkgPublicGather);
+        // we have to loop in case we get an invalid y coord...
+        loop {
+            // Send the DKG Begin message to all signers and gather responses by sharing with all other signers and coordinator
+            let (outbound_messages, operation_results) =
+                feedback_messages(&mut coordinator, &mut signing_rounds, vec![message.clone()]);
+            assert!(operation_results.is_empty());
+            if coordinator.state == State::DkgEndGather {
+                // Successfully got an Aggregate Public Key...
+                assert_eq!(outbound_messages.len(), 1);
+                match &outbound_messages[0].msg {
+                    Message::DkgPrivateBegin(_) => {}
+                    _ => {
+                        panic!("Expected DkgPrivateBegin message");
+                    }
+                }
+                // Send the DKG Private Begin message to all signers and share their responses with the coordinator and signers
+                let (outbound_messages, operation_results) =
+                    feedback_messages(&mut coordinator, &mut signing_rounds, outbound_messages);
+                assert!(outbound_messages.is_empty());
+                assert_eq!(operation_results.len(), 1);
+                match operation_results[0] {
+                    OperationResult::Dkg(point) => {
+                        assert_ne!(point, Point::default());
+                        assert_eq!(coordinator.aggregate_public_key, point);
+                        assert_eq!(coordinator.state, State::Idle);
+                        break;
+                    }
+                    _ => panic!("Expected Dkg Operation result"),
+                }
+            }
+        }
+        assert_ne!(coordinator.aggregate_public_key, Point::default());
+    }
+}
+*/

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -288,30 +288,28 @@ pub mod coordinator {
         }
 
         fn gather_public_shares(&mut self, packet: &Packet) -> Result<(), Error> {
-            match &packet.msg {
-                Message::DkgPublicShares(dkg_public_shares) => {
-                    if dkg_public_shares.dkg_id != self.current_dkg_id {
-                        return Err(Error::BadDkgId(
-                            dkg_public_shares.dkg_id,
-                            self.current_dkg_id,
-                        ));
-                    }
-
-                    self.ids_to_await.remove(&dkg_public_shares.signer_id);
-
-                    self.dkg_public_shares
-                        .insert(dkg_public_shares.signer_id, dkg_public_shares.clone());
-                    for (party_id, comm) in &dkg_public_shares.comms {
-                        self.party_polynomials.insert(*party_id, comm.clone());
-                    }
-
-                    info!(
-                        "DKG round #{} DkgPublicShares from signer #{}",
-                        dkg_public_shares.dkg_id, dkg_public_shares.signer_id
-                    );
+            if let Message::DkgPublicShares(dkg_public_shares) = &packet.msg {
+                if dkg_public_shares.dkg_id != self.current_dkg_id {
+                    return Err(Error::BadDkgId(
+                        dkg_public_shares.dkg_id,
+                        self.current_dkg_id,
+                    ));
                 }
-                _ => {}
+
+                self.ids_to_await.remove(&dkg_public_shares.signer_id);
+
+                self.dkg_public_shares
+                    .insert(dkg_public_shares.signer_id, dkg_public_shares.clone());
+                for (party_id, comm) in &dkg_public_shares.comms {
+                    self.party_polynomials.insert(*party_id, comm.clone());
+                }
+
+                info!(
+                    "DKG round #{} DkgPublicShares from signer #{}",
+                    dkg_public_shares.dkg_id, dkg_public_shares.signer_id
+                );
             }
+
             if self.ids_to_await.is_empty() {
                 // Calculate the aggregate public key
                 let key = self

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -457,11 +457,7 @@ pub mod coordinator {
             }
             if self.ids_to_await.is_empty() {
                 // Calculate the aggregate signature
-                let polys: Vec<PolyCommitment> = self
-                    .party_polynomials
-                    .values()
-                    .map(|pp| pp.clone())
-                    .collect();
+                let polys: Vec<PolyCommitment> = self.party_polynomials.values().cloned().collect();
 
                 let nonce_responses = (0..self.total_signers)
                     .map(|i| self.public_nonces[&i].clone())

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -98,13 +98,16 @@ pub mod coordinator {
 
     /// The coordinator for the FROST algorithm
     pub struct Coordinator {
-        current_dkg_id: u64,
-        current_dkg_public_id: u64,
+        /// current DKG round ID
+        pub current_dkg_id: u64,
         current_sign_id: u64,
         current_sign_iter_id: u64,
-        total_signers: u32, // Assuming the signers cover all id:s in {1, 2, ..., total_signers}
-        total_keys: u32,
-        threshold: u32,
+        /// total number of signers
+        pub total_signers: u32, // Assuming the signers cover all id:s in {1, 2, ..., total_signers}
+        /// total number of keys 
+        pub total_keys: u32,
+        /// the threshold of the keys needed for a valid signature
+        pub threshold: u32,
         dkg_public_shares: BTreeMap<u32, DkgPublicShares>,
         party_polynomials: BTreeMap<u32, PolyCommitment>,
         public_nonces: BTreeMap<u32, NonceResponse>,
@@ -112,10 +115,14 @@ pub mod coordinator {
         aggregate_public_key: Point,
         signature: Signature,
         schnorr_proof: SchnorrProof,
-        message_private_key: Scalar,
-        ids_to_await: HashSet<u32>,
-        message: Vec<u8>,
-        state: State,
+        /// key used to sign packet messages
+        pub message_private_key: Scalar,
+        /// which signers we're currently waiting on
+        pub ids_to_await: HashSet<u32>,
+        /// the bytes that we're signing
+        pub message: Vec<u8>,
+        /// current state of the state machine
+        pub state: State,
     }
 
     impl Coordinator {
@@ -128,7 +135,6 @@ pub mod coordinator {
         ) -> Self {
             Self {
                 current_dkg_id: 0,
-                current_dkg_public_id: 0,
                 current_sign_id: 0,
                 current_sign_iter_id: 0,
                 total_signers,
@@ -253,11 +259,12 @@ pub mod coordinator {
             self.request_nonces()
         }
 
-        fn start_public_shares(&mut self) -> Result<Packet, Error> {
+        /// Ask signers to send DKG public shares
+        pub fn start_public_shares(&mut self) -> Result<Packet, Error> {
             self.dkg_public_shares.clear();
             info!(
-                "DKG Round #{}: Starting Public Share Distribution Round #{}",
-                self.current_dkg_id, self.current_dkg_public_id
+                "DKG Round #{}: Starting Public Share Distribution",
+                self.current_dkg_id,
             );
             let dkg_begin = DkgBegin {
                 dkg_id: self.current_dkg_id,
@@ -271,7 +278,8 @@ pub mod coordinator {
             Ok(dkg_begin_packet)
         }
 
-        fn start_private_shares(&mut self) -> Result<Packet, Error> {
+        /// Ask signers to send DKG private shares
+        pub fn start_private_shares(&mut self) -> Result<Packet, Error> {
             info!(
                 "DKG Round #{}: Starting Private Share Distribution",
                 self.current_dkg_id
@@ -616,17 +624,19 @@ impl Coordinatable for Coordinator {
         self.ids_to_await = (0..self.total_signers).collect();
     }
 }
-
+*/
 #[cfg(test)]
 mod test {
+    //use frost_signer::{config::PublicKeys, signing_round::SigningRound};
+    //use hashbrown::HashMap;
+    use p256k1::scalar::Scalar;
+    use rand_core::OsRng;
 
-    use crate::runloop::process_inbound_messages;
+    //use crate::runloop::process_inbound_messages;
+    use crate::net::{Message};
 
     use super::*;
-    use frost_signer::{config::PublicKeys, signing_round::SigningRound};
-    use hashbrown::HashMap;
-    use p256k1::ecdsa;
-    use rand_core::OsRng;
+    use super::coordinator::*;
 
     #[test]
     fn test_state_machine() {
@@ -748,7 +758,7 @@ mod test {
         assert_eq!(coordinator.state, State::DkgEndGather);
         assert_eq!(coordinator.current_dkg_id, 0);
     }
-
+/*
     fn setup() -> (Coordinator, Vec<SigningRound>) {
         let mut rng = OsRng;
         let total_signers = 5;
@@ -863,5 +873,5 @@ mod test {
         }
         assert_ne!(coordinator.aggregate_public_key, Point::default());
     }
-}
 */
+}

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -619,15 +619,13 @@ pub mod coordinator {
 
         /// Trigger a DKG round
         fn start_distributed_key_generation(&mut self) -> Result<Packet, Error> {
-            let packet = self.start_dkg_round()?;
-            Ok(packet)
+            self.start_dkg_round()
         }
 
         // Trigger a signing round
         fn start_signing_message(&mut self, message: &[u8]) -> Result<Packet, Error> {
             self.message = message.to_vec();
-            let packet = self.start_signing_round()?;
-            Ok(packet)
+            self.start_signing_round()
         }
 
         // Reset internal state

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -26,6 +26,9 @@ pub trait Signer {
     /// Get all key IDs for this signer
     fn get_key_ids(&self) -> Vec<u32>;
 
+    /// Get the total number of parties
+    fn get_num_parties(&self) -> u32;
+
     /// Get all poly commitments for this signer
     fn get_poly_commitments<RNG: RngCore + CryptoRng>(&self, rng: &mut RNG) -> Vec<PolyCommitment>;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -3,7 +3,7 @@ use p256k1::{point::Point, scalar::Scalar};
 use rand_core::{CryptoRng, RngCore};
 
 use crate::{
-    common::{PolyCommitment, PublicNonce, Signature, SignatureShare},
+    common::{MerkleRoot, PolyCommitment, PublicNonce, Signature, SignatureShare},
     errors::{AggregatorError, DkgError},
     taproot::SchnorrProof,
 };
@@ -69,7 +69,7 @@ pub trait Signer {
         signer_ids: &[u32],
         key_ids: &[u32],
         nonces: &[PublicNonce],
-        merkle_root: Option<[u8; 32]>,
+        merkle_root: Option<MerkleRoot>,
     ) -> Vec<SignatureShare>;
 }
 
@@ -97,6 +97,6 @@ pub trait Aggregator {
         nonces: &[PublicNonce],
         sig_shares: &[SignatureShare],
         key_ids: &[u32],
-        merkle_root: Option<[u8; 32]>,
+        merkle_root: Option<MerkleRoot>,
     ) -> Result<SchnorrProof, AggregatorError>;
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,10 @@
-use p256k1::scalar::Scalar;
+use aes_gcm::{aead::Aead, Aes256Gcm, Error as AesGcmError, KeyInit, Nonce};
+use p256k1::{point::Point, scalar::Scalar};
+use rand_core::{CryptoRng, RngCore};
 use sha2::{Digest, Sha256};
+
+/// Size of the AES-GCM nonce
+pub const AES_GCM_NONCE_SIZE: usize = 12;
 
 #[allow(dead_code)]
 /// Digest the hasher to a Scalar
@@ -10,4 +15,97 @@ pub fn hash_to_scalar(hasher: &mut Sha256) -> Scalar {
     hash_bytes.clone_from_slice(hash.as_slice());
 
     Scalar::from(hash_bytes)
+}
+
+/// Do a Diffie-Hellman key exchange to create a shared secret from the passed private and public keys
+pub fn make_shared_secret(private_key: &Scalar, public_key: &Point) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    let shared_key = private_key * public_key;
+
+    hasher.update("DH_SHARED_SECRET_KEY/".as_bytes());
+    hasher.update(shared_key.compress().as_bytes());
+
+    let hash = hasher.finalize();
+    let mut bytes = [0u8; 32];
+
+    bytes.clone_from_slice(hash.as_slice());
+    bytes
+}
+
+/// Encrypt the passed data using the key
+pub fn encrypt<RNG: RngCore + CryptoRng>(
+    key: &[u8; 32],
+    data: &[u8],
+    rng: &mut RNG,
+) -> Result<Vec<u8>, AesGcmError> {
+    let mut nonce_bytes = [0u8; AES_GCM_NONCE_SIZE];
+
+    rng.fill_bytes(&mut nonce_bytes);
+
+    let nonce_vec = nonce_bytes.to_vec();
+    let nonce = Nonce::from_slice(&nonce_vec);
+    let cipher = Aes256Gcm::new(key.into());
+    let cipher_vec = cipher.encrypt(nonce, data.to_vec().as_ref())?;
+    let mut bytes = Vec::new();
+
+    bytes.extend_from_slice(&nonce_vec);
+    bytes.extend_from_slice(&cipher_vec);
+
+    Ok(bytes)
+}
+
+/// Decrypt the passed data using the key
+pub fn decrypt(key: &[u8; 32], data: &[u8]) -> Result<Vec<u8>, AesGcmError> {
+    let nonce_vec = data[..AES_GCM_NONCE_SIZE].to_vec();
+    let cipher_vec = data[AES_GCM_NONCE_SIZE..].to_vec();
+    let nonce = Nonce::from_slice(&nonce_vec);
+    let cipher = Aes256Gcm::new(key.into());
+
+    cipher.decrypt(nonce, cipher_vec.as_ref())
+}
+
+#[cfg(test)]
+mod test {
+    use p256k1::{point::Point, scalar::Scalar};
+    use rand_core::OsRng;
+
+    use super::*;
+
+    #[test]
+    #[allow(non_snake_case)]
+    fn test_shared_secret() {
+        let mut rng = OsRng;
+
+        let x = Scalar::random(&mut rng);
+        let y = Scalar::random(&mut rng);
+
+        let X = Point::from(x);
+        let Y = Point::from(y);
+
+        let xy = make_shared_secret(&x, &Y);
+        let yx = make_shared_secret(&y, &X);
+
+        assert_eq!(xy, yx);
+    }
+
+    #[test]
+    #[allow(non_snake_case)]
+    fn test_encrypt_decrypt() {
+        let mut rng = OsRng;
+        let msg = "It was many and many a year ago, in a kingdom by the sea...";
+
+        let x = Scalar::random(&mut rng);
+        let y = Scalar::random(&mut rng);
+
+        let X = Point::from(x);
+        let Y = Point::from(y);
+
+        let xy = make_shared_secret(&x, &Y);
+        let yx = make_shared_secret(&y, &X);
+
+        let cipher = encrypt(&xy, msg.as_bytes(), &mut rng).unwrap();
+        let plain = decrypt(&yx, &cipher).unwrap();
+
+        assert_eq!(msg.as_bytes(), &plain);
+    }
 }

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -395,7 +395,7 @@ pub struct SignerState {
     /// The associated ID
     id: u32,
     /// The total number of keys
-    n: u32,
+    num_keys: u32,
     /// The aggregate group public key
     group_key: Point,
     /// The set of states for the parties which this object encapsulates, indexed by their party/key IDs
@@ -408,7 +408,7 @@ pub struct Signer {
     /// The associated signer ID
     id: u32,
     /// The total number of keys
-    n: u32,
+    num_keys: u32,
     /// The aggregate group public key
     group_key: Point,
     /// The parties which this object encapsulates
@@ -420,17 +420,17 @@ impl Signer {
     pub fn new<RNG: RngCore + CryptoRng>(
         id: u32,
         key_ids: &[u32],
-        n: u32,
-        t: u32,
+        num_keys: u32,
+        threshold: u32,
         rng: &mut RNG,
     ) -> Self {
         let parties = key_ids
             .iter()
-            .map(|id| Party::new(*id, n, t, rng))
+            .map(|id| Party::new(*id, num_keys, threshold, rng))
             .collect();
         Signer {
             id,
-            n,
+            num_keys,
             group_key: Point::zero(),
             parties,
         }
@@ -441,12 +441,12 @@ impl Signer {
         let parties = state
             .parties
             .iter()
-            .map(|(id, ps)| Party::load(*id, state.n, &state.group_key, ps))
+            .map(|(id, ps)| Party::load(*id, state.num_keys, &state.group_key, ps))
             .collect();
 
         Self {
             id: state.id,
-            n: state.n,
+            num_keys: state.num_keys,
             group_key: state.group_key,
             parties,
         }
@@ -462,7 +462,7 @@ impl Signer {
 
         SignerState {
             id: self.id,
-            n: self.n,
+            num_keys: self.num_keys,
             group_key: self.group_key,
             parties,
         }
@@ -487,6 +487,10 @@ impl traits::Signer for Signer {
 
     fn get_key_ids(&self) -> Vec<u32> {
         self.parties.iter().map(|p| p.id).collect()
+    }
+
+    fn get_num_parties(&self) -> u32 {
+        self.num_keys
     }
 
     fn get_poly_commitments<RNG: RngCore + CryptoRng>(&self, rng: &mut RNG) -> Vec<PolyCommitment> {

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -435,6 +435,10 @@ impl traits::Signer for Party {
         self.key_ids.clone()
     }
 
+    fn get_num_parties(&self) -> u32 {
+        self.num_parties
+    }
+
     fn get_poly_commitments<RNG: RngCore + CryptoRng>(&self, rng: &mut RNG) -> Vec<PolyCommitment> {
         vec![self.get_poly_commitment(rng)]
     }

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -168,7 +168,8 @@ impl Party {
 
         let mut not_enough_shares = Vec::new();
         for key_id in &self.key_ids {
-            if shares[key_id].len() != self.num_parties.try_into().unwrap() {
+            let num_parties: usize = self.num_parties.try_into().unwrap();
+            if shares[key_id].len() != num_parties {
                 not_enough_shares.push(*key_id);
             }
         }


### PR DESCRIPTION
In order to use `wsts` in a network context, it is necessary to pass signed messages between the signers and the coordinator.  Some of these messages must be encrypted for various recipients.  This PR adds them to the base repo so they will not need to be implemented by everyone who uses `wsts` to make distributed signatures.

These messages will interact in specific ways with `Signers` and `Coordinators`, so we also add relevant state machines to describe what happens when messages are received, and what messages should be sent in response.  The messages are also optimized so that each `Signer` will only need to send one message of each type for any particular `dkg` or `signing` round.

Currently this PR includes all of the network messages, and the state machines for`Coordinator` and `SigningRound`.  The state machines are not yet generic over `v1` / `v2`.