### PR TITLE
Make signature proof key optionals

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![doc = include_str!("../README.md")]
 
 /// Types which are common to both v1 and v2
+#[allow(clippy::op_ref)]
 pub mod common;
 /// Functions to perform various computations needed for v1 and v2
 pub mod compute;
@@ -10,6 +11,7 @@ pub mod errors;
 /// Network messages
 pub mod net;
 /// Schnorr utility types
+#[allow(clippy::op_ref)]
 pub mod schnorr;
 /// State machines
 pub mod state_machine;
@@ -20,8 +22,10 @@ pub mod traits;
 /// Utilities for hashing and encryption
 pub mod util;
 /// Version 1 of WSTS, which encapsulates a number of parties using vanilla FROST
+#[allow(clippy::op_ref)]
 pub mod v1;
-/// Version 2 of WSTS, which optimizes the protocol for speed and bandwidth
+/// Version 1 of WSTS, which encapsulates a number of parties using vanilla FROST
+#[allow(clippy::op_ref)]
 pub mod v2;
 /// Shamir secret sharing, using in distributed key generation
 pub mod vss;

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -317,6 +317,10 @@ pub mod coordinator {
             is_taproot: bool,
             merkle_root: Option<MerkleRoot>,
         ) -> Result<Packet, Error> {
+            // We cannot sign if we haven't first set DKG (either manually or via DKG round).
+            if self.aggregate_public_key.is_none() {
+                return Err(Error::MissingAggregatePublicKey);
+            }
             self.current_sign_id = self.current_sign_id.wrapping_add(1);
             info!("Starting signing round {}", self.current_sign_id);
             self.move_to(State::NonceRequest(is_taproot, merkle_root))?;

--- a/src/taproot.rs
+++ b/src/taproot.rs
@@ -165,7 +165,7 @@ mod test {
 
     #[allow(non_snake_case)]
     fn taproot_sign_verify_v1(merkle_root: Option<[u8; 32]>) {
-        let mut rng = OsRng::default();
+        let mut rng = OsRng;
 
         // First create and verify a frost signature
         let msg = "It was many and many a year ago".as_bytes();
@@ -195,8 +195,8 @@ mod test {
         let mut sig_agg = v1::Aggregator::new(N, T);
         sig_agg.init(A.clone()).expect("aggregator init failed");
         let tweaked_public_key = compute::tweaked_public_key(&sig_agg.poly[0], merkle_root);
-        let (nonces, sig_shares) = test_helpers::sign(&msg, &mut S, &mut rng, merkle_root);
-        let proof = match sig_agg.sign_taproot(&msg, &nonces, &sig_shares, &[], merkle_root) {
+        let (nonces, sig_shares) = test_helpers::sign(msg, &mut S, &mut rng, merkle_root);
+        let proof = match sig_agg.sign_taproot(msg, &nonces, &sig_shares, &[], merkle_root) {
             Err(e) => panic!("Aggregator sign failed: {:?}", e),
             Ok(proof) => proof,
         };
@@ -226,7 +226,7 @@ mod test {
 
     #[allow(non_snake_case)]
     fn taproot_sign_verify_v2(merkle_root: Option<[u8; 32]>) {
-        let mut rng = OsRng::default();
+        let mut rng = OsRng;
 
         // First create and verify a frost signature
         let msg = "It was many and many a year ago".as_bytes();
@@ -258,8 +258,8 @@ mod test {
         let mut sig_agg = v2::Aggregator::new(Nk, T);
         sig_agg.init(A.clone()).expect("aggregator init failed");
         let tweaked_public_key = compute::tweaked_public_key(&sig_agg.poly[0], merkle_root);
-        let (nonces, sig_shares) = test_helpers::sign(&msg, &mut S, &mut rng, merkle_root);
-        let proof = match sig_agg.sign_taproot(&msg, &nonces, &sig_shares, &key_ids, merkle_root) {
+        let (nonces, sig_shares) = test_helpers::sign(msg, &mut S, &mut rng, merkle_root);
+        let proof = match sig_agg.sign_taproot(msg, &nonces, &sig_shares, &key_ids, merkle_root) {
             Err(e) => panic!("Aggregator sign failed: {:?}", e),
             Ok(proof) => proof,
         };

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -650,7 +650,7 @@ mod tests {
 
     #[test]
     fn signer_new() {
-        let mut rng = OsRng::default();
+        let mut rng = OsRng;
         let id = 1;
         let key_ids = [1, 2, 3];
         let n: u32 = 10;
@@ -663,7 +663,7 @@ mod tests {
 
     #[test]
     fn signer_gen_nonces() {
-        let mut rng = OsRng::default();
+        let mut rng = OsRng;
         let id = 1;
         let key_ids = [1, 2, 3];
         let n: u32 = 10;
@@ -686,7 +686,7 @@ mod tests {
 
     #[test]
     fn signer_save_load() {
-        let mut rng = OsRng::default();
+        let mut rng = OsRng;
         let id = 1;
         let key_ids = [1, 2, 3];
         let n: u32 = 10;
@@ -703,7 +703,7 @@ mod tests {
     #[allow(non_snake_case)]
     #[test]
     fn aggregator_sign() {
-        let mut rng = OsRng::default();
+        let mut rng = OsRng;
         let msg = "It was many and many a year ago".as_bytes();
         let N: u32 = 10;
         let T: u32 = 7;
@@ -733,8 +733,8 @@ mod tests {
             let mut sig_agg = v1::Aggregator::new(N, T);
             sig_agg.init(comms.clone()).expect("aggregator init failed");
 
-            let (nonces, sig_shares) = v1::test_helpers::sign(&msg, &mut signers, &mut rng);
-            if let Err(e) = sig_agg.sign(&msg, &nonces, &sig_shares, &[]) {
+            let (nonces, sig_shares) = v1::test_helpers::sign(msg, &mut signers, &mut rng);
+            if let Err(e) = sig_agg.sign(msg, &nonces, &sig_shares, &[]) {
                 panic!("Aggregator sign failed: {:?}", e);
             }
         }

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -593,7 +593,7 @@ mod tests {
 
     #[test]
     fn party_save_load() {
-        let mut rng = OsRng::default();
+        let mut rng = OsRng;
         let key_ids = [1, 2, 3];
         let n: u32 = 10;
         let t: u32 = 7;
@@ -609,7 +609,7 @@ mod tests {
     #[allow(non_snake_case)]
     #[test]
     fn aggregator_sign() {
-        let mut rng = OsRng::default();
+        let mut rng = OsRng;
         let msg = "It was many and many a year ago".as_bytes();
         let Nk: u32 = 10;
         let T: u32 = 7;
@@ -641,9 +641,8 @@ mod tests {
 
             sig_agg.init(comms.clone()).expect("aggregator init failed");
 
-            let (nonces, sig_shares, key_ids) =
-                v2::test_helpers::sign(&msg, &mut signers, &mut rng);
-            if let Err(e) = sig_agg.sign(&msg, &nonces, &sig_shares, &key_ids) {
+            let (nonces, sig_shares, key_ids) = v2::test_helpers::sign(msg, &mut signers, &mut rng);
+            if let Err(e) = sig_agg.sign(msg, &nonces, &sig_shares, &key_ids) {
                 panic!("Aggregator sign failed: {:?}", e);
             }
         }


### PR DESCRIPTION
I need a setter I think for ease of use of frost. We might for example want to run a sign round with a custom DKG key. (i.e. a signer comes online in the middle of a reward cycle and needs to set the key to what is in the contract. and then participate in the signing)

Changes
- Clippy fixes that were bothering me
- Added setter to DKG aggregate key
- Made Key, Signature, and Proof into optionals to be explicitly clear