### PR TITLE
Add granular process_inbound_message

### DIFF
--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -67,11 +67,11 @@ impl From<AggregatorError> for Error {
 
 /// Coordinatable trait for handling the coordination of DKG and sign messages
 pub trait Coordinatable {
-    /// Process inbound messages
-    fn process_inbound_messages(
+    /// Process a packet and return any outbound packet response and operation result
+    fn process_packet(
         &mut self,
-        packets: &[Packet],
-    ) -> Result<(Vec<Packet>, Vec<OperationResult>), Error>;
+        packet: &Packet,
+    ) -> Result<(Option<Packet>, Option<OperationResult>), Error>;
     /// Retrieve the aggregate public key
     fn get_aggregate_public_key(&self) -> Option<Point>;
     /// Set the aggregate public key


### PR DESCRIPTION
Perhaps this isn't the best approach? But I think we need more granular control so we can keep track of which messages we have successfully responded to (process a message, send our response, process next message, send response for that) As is now, its hard to knlow what we have successfully processed fully and what we have not/which response messages belong to which inbound messages. This seperates it into two functions. One with a default implementation that uses the other, but that enables a user of the library to optionally handle each inbound and outbound message with additional control.