### PR TITLE
feat: Derive traits for `common::Signature`

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -124,6 +124,7 @@ pub struct SignatureShare {
     pub key_ids: Vec<u32>,
 }
 
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[allow(non_snake_case)]
 /// An aggregated group signature
 pub struct Signature {


### PR DESCRIPTION
Single line change to derive some traits for `common::Signature`. Need these traits to use the struct in `TenureChange` in stacks-core