### PR TITLE
Export all of p256k1 as curve

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -7,7 +7,15 @@ use num_traits::{One, Zero};
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
-use crate::{compute::challenge, schnorr::ID, MultiMult, Point, Scalar, G};
+use crate::{
+    compute::challenge,
+    curve::{
+        point::{Point, G},
+        scalar::Scalar,
+        traits::MultiMult,
+    },
+    schnorr::ID,
+};
 
 /// A merkle root is a 256 bit hash
 pub type MerkleRoot = [u8; 32];

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -2,7 +2,14 @@ use core::iter::zip;
 use num_traits::{One, Zero};
 use sha2::{Digest, Sha256};
 
-use crate::{common::PublicNonce, util::hash_to_scalar, Compressed, Point, PointError, Scalar, G};
+use crate::{
+    common::PublicNonce,
+    curve::{
+        point::{Compressed, Error as PointError, Point, G},
+        scalar::Scalar,
+    },
+    util::hash_to_scalar,
+};
 
 #[allow(non_snake_case)]
 /// Compute a binding value from the party ID, public nonces, and signed message

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-use crate::{PointError, Scalar};
+use crate::curve::{point::Error as PointError, scalar::Scalar};
 
 #[derive(Error, Debug, Clone)]
 /// Errors which can happen during distributed key generation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,9 +30,4 @@ pub mod v2;
 /// Shamir secret sharing, using in distributed key generation
 pub mod vss;
 
-pub use p256k1::{
-    ecdsa, field,
-    point::{Compressed, Error as PointError, Point, G, N},
-    scalar::{Error as ScalarError, Scalar},
-    traits::MultiMult,
-};
+pub use p256k1 as curve;

--- a/src/net.rs
+++ b/src/net.rs
@@ -4,7 +4,7 @@ use sha2::{Digest, Sha256};
 
 use crate::{
     common::{MerkleRoot, PolyCommitment, PublicNonce, SignatureShare},
-    ecdsa, Scalar,
+    curve::{ecdsa, scalar::Scalar},
 };
 
 /// Trait to encapsulate sign/verify, users only need to impl hash

--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -2,7 +2,13 @@ use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::{util::hash_to_scalar, Point, Scalar, G};
+use crate::{
+    curve::{
+        point::{Point, G},
+        scalar::Scalar,
+    },
+    util::hash_to_scalar,
+};
 
 #[allow(non_snake_case)]
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -783,6 +783,7 @@ impl<Aggregator: AggregatorTrait> CoordinatorTrait for Coordinator<Aggregator> {
 #[cfg(test)]
 pub mod test {
     use crate::{
+        curve::{point::Point, scalar::Scalar},
         net::Message,
         state_machine::{
             coordinator::{
@@ -796,7 +797,7 @@ pub mod test {
             DkgError, OperationResult, SignError,
         },
         traits::{Aggregator as AggregatorTrait, Signer as SignerTrait},
-        v1, v2, Point, Scalar,
+        v1, v2,
     };
     use rand_core::OsRng;
     use std::{thread, time::Duration};

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -5,6 +5,7 @@ use tracing::{debug, error, info, warn};
 use crate::{
     common::{MerkleRoot, PolyCommitment, PublicNonce, Signature, SignatureShare},
     compute,
+    curve::point::Point,
     net::{
         DkgBegin, DkgPublicShares, Message, NonceRequest, NonceResponse, Packet, Signable,
         SignatureShareRequest,
@@ -15,7 +16,6 @@ use crate::{
     },
     taproot::SchnorrProof,
     traits::Aggregator as AggregatorTrait,
-    Point,
 };
 
 /// The coordinator for the FIRE algorithm

--- a/src/state_machine/coordinator/frost.rs
+++ b/src/state_machine/coordinator/frost.rs
@@ -5,6 +5,7 @@ use tracing::{debug, info};
 use crate::{
     common::{MerkleRoot, PolyCommitment, PublicNonce, Signature, SignatureShare},
     compute,
+    curve::point::Point,
     net::{
         DkgBegin, DkgPublicShares, Message, NonceRequest, NonceResponse, Packet, Signable,
         SignatureShareRequest,
@@ -15,7 +16,6 @@ use crate::{
     },
     taproot::SchnorrProof,
     traits::Aggregator as AggregatorTrait,
-    Point,
 };
 
 /// The coordinator for the FROST algorithm

--- a/src/state_machine/coordinator/frost.rs
+++ b/src/state_machine/coordinator/frost.rs
@@ -596,6 +596,7 @@ impl<Aggregator: AggregatorTrait> CoordinatorTrait for Coordinator<Aggregator> {
 #[cfg(test)]
 pub mod test {
     use crate::{
+        curve::scalar::Scalar,
         net::Message,
         state_machine::coordinator::{
             frost::Coordinator as FrostCoordinator,
@@ -606,7 +607,7 @@ pub mod test {
             Config, Coordinator as CoordinatorTrait, State,
         },
         traits::Aggregator as AggregatorTrait,
-        v1, v2, Scalar,
+        v1, v2,
     };
     use rand_core::OsRng;
 

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -1,6 +1,9 @@
 use crate::{
-    common::MerkleRoot, errors::AggregatorError, net::Packet, state_machine::OperationResult,
-    Point, Scalar,
+    common::MerkleRoot,
+    curve::{point::Point, scalar::Scalar},
+    errors::AggregatorError,
+    net::Packet,
+    state_machine::OperationResult,
 };
 use hashbrown::{HashMap, HashSet};
 use std::time::Duration;

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -198,7 +198,7 @@ pub mod test {
     use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
     use crate::{
-        ecdsa,
+        curve::{ecdsa, point::Point, scalar::Scalar},
         net::{Message, Packet},
         state_machine::{
             coordinator::{Config, Coordinator as CoordinatorTrait, Error, State},
@@ -206,7 +206,6 @@ pub mod test {
             OperationResult, PublicKeys, StateMachine,
         },
         traits::Signer as SignerTrait,
-        Point, Scalar,
     };
 
     static mut LOG_INIT: AtomicBool = AtomicBool::new(false);

--- a/src/state_machine/mod.rs
+++ b/src/state_machine/mod.rs
@@ -3,10 +3,9 @@ use thiserror::Error;
 
 use crate::{
     common::Signature,
-    ecdsa,
+    curve::{ecdsa, point::Point},
     errors::{AggregatorError, DkgError as DkgCryptoError},
     taproot::SchnorrProof,
-    Point,
 };
 
 /// A generic state machine

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -5,6 +5,10 @@ use tracing::{debug, info, trace, warn};
 
 use crate::{
     common::{PolyCommitment, PublicNonce},
+    curve::{
+        point::{Compressed, Point},
+        scalar::Scalar,
+    },
     net::{
         DkgBegin, DkgEnd, DkgPrivateShares, DkgPublicShares, DkgStatus, Message, NonceRequest,
         NonceResponse, Packet, Signable, SignatureShareRequest, SignatureShareResponse,
@@ -12,7 +16,6 @@ use crate::{
     state_machine::{PublicKeys, StateMachine},
     traits::Signer as SignerTrait,
     util::{decrypt, encrypt, make_shared_secret},
-    Compressed, Point, Scalar,
 };
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -582,11 +582,12 @@ pub mod test {
 
     use crate::{
         common::PolyCommitment,
+        curve::scalar::Scalar,
         net::{DkgPublicShares, DkgStatus, Message},
         schnorr::ID,
         state_machine::signer::{Signer, State as SignerState},
         traits::Signer as SignerTrait,
-        v1, v2, Scalar,
+        v1, v2,
     };
 
     #[test]

--- a/src/taproot.rs
+++ b/src/taproot.rs
@@ -1,4 +1,12 @@
-use crate::{common::Signature, compute, field, Point, Scalar, G};
+use crate::{
+    common::Signature,
+    compute,
+    curve::{
+        field,
+        point::{Point, G},
+        scalar::Scalar,
+    },
+};
 
 /// A SchnorrProof in BIP-340 format
 #[allow(non_snake_case)]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -3,9 +3,9 @@ use rand_core::{CryptoRng, RngCore};
 
 use crate::{
     common::{MerkleRoot, PolyCommitment, PublicNonce, Signature, SignatureShare},
+    curve::{point::Point, scalar::Scalar},
     errors::{AggregatorError, DkgError},
     taproot::SchnorrProof,
-    Point, Scalar,
 };
 
 /// A trait which provides a common `Signer` interface for `v1` and `v2`

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,7 +2,7 @@ use aes_gcm::{aead::Aead, Aes256Gcm, Error as AesGcmError, KeyInit, Nonce};
 use rand_core::{CryptoRng, RngCore};
 use sha2::{Digest, Sha256};
 
-use crate::{Point, Scalar};
+use crate::curve::{point::Point, scalar::Scalar};
 
 /// Size of the AES-GCM nonce
 pub const AES_GCM_NONCE_SIZE: usize = 12;

--- a/src/util.rs
+++ b/src/util.rs
@@ -70,7 +70,7 @@ mod test {
     use rand_core::OsRng;
 
     use super::*;
-    use crate::{Point, Scalar};
+    use crate::curve::{point::Point, scalar::Scalar};
 
     #[test]
     #[allow(non_snake_case)]

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -7,12 +7,15 @@ use serde::{Deserialize, Serialize};
 use crate::{
     common::{CheckPrivateShares, Nonce, PolyCommitment, PublicNonce, Signature, SignatureShare},
     compute,
+    curve::{
+        point::{Point, G},
+        scalar::Scalar,
+    },
     errors::{AggregatorError, DkgError},
     schnorr::ID,
     taproot::SchnorrProof,
     traits,
     vss::VSS,
-    Point, Scalar, G,
 };
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -7,12 +7,15 @@ use serde::{Deserialize, Serialize};
 use crate::{
     common::{Nonce, PolyCommitment, PublicNonce, Signature, SignatureShare},
     compute,
+    curve::{
+        point::{Point, G},
+        scalar::Scalar,
+    },
     errors::{AggregatorError, DkgError},
     schnorr::ID,
     taproot::SchnorrProof,
     traits,
     vss::VSS,
-    Point, Scalar, G,
 };
 
 /// A map of private keys indexed by key ID

--- a/src/vss.rs
+++ b/src/vss.rs
@@ -1,7 +1,7 @@
 use polynomial::Polynomial;
 use rand_core::{CryptoRng, RngCore};
 
-use crate::Scalar;
+use crate::curve::scalar::Scalar;
 
 /// A verifiable secret share algorithm
 pub struct VSS {}


### PR DESCRIPTION
This PR exports all of the `p256k` dependency with the generic name `curve`, and updates all source files to use that path.

This will have two benefits: first, it means that we can easily replace the `p256k1` dependency in the future, since the code will not be internally hardwired to use it.  Also, anyone who uses this crate will not have to explicitly include the `p256k1` dependency, since they will be able to refer to anything inside it using `wsts::curve`.