### PR TITLE
Process coordinator messages to duplicate state between multiple coordinators

### DIFF
--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -368,6 +368,9 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
             dkg_id: self.current_dkg_id,
             sign_id: self.current_sign_id,
             sign_iter_id: self.current_sign_iter_id,
+            message: self.message.clone(),
+            is_taproot,
+            merkle_root,
         };
         let nonce_request_msg = Packet {
             sig: nonce_request
@@ -1329,7 +1332,7 @@ pub mod test {
         let num_keys = config.num_keys as f64;
         let threshold = config.threshold as f64;
         let num_signers_to_remove =
-            (((num_keys - threshold) / keys_per_signer as f64).floor() + 1 as f64) as usize;
+            (((num_keys - threshold) / keys_per_signer as f64).floor() + 1_f64) as usize;
         let mut insufficient_coordinator = coordinator.clone();
         let mut insufficient_signers = signers.clone();
 
@@ -1447,8 +1450,8 @@ pub mod test {
         );
 
         // put the malicious signers back in
-        while !malicious.is_empty() {
-            insufficient_signers.push(malicious.pop().unwrap());
+        while let Some(element) = malicious.pop() {
+            insufficient_signers.push(element);
         }
 
         // Send the NonceRequest message to all signers and share their responses with the coordinator and signers

--- a/src/state_machine/coordinator/frost.rs
+++ b/src/state_machine/coordinator/frost.rs
@@ -56,8 +56,27 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
         loop {
             match self.state {
                 State::Idle => {
-                    // do nothing
-                    // We are the coordinator and should be the only thing triggering messages right now
+                    // Did we receive a coordinator message?
+                    if let Message::DkgBegin(dkg_begin) = &packet.msg {
+                        // Set the current sign id to one before the current message to ensure
+                        // that we start the next round at the correct id. (Do this rather
+                        // then overwriting afterwards to ensure logging is accurate)
+                        self.current_dkg_id = dkg_begin.dkg_id.wrapping_sub(1);
+                        let packet = self.start_dkg_round()?;
+                        return Ok((Some(packet), None));
+                    } else if let Message::NonceRequest(nonce_request) = &packet.msg {
+                        // Set the current sign id to one before the current message to ensure
+                        // that we start the next round at the correct id. (Do this rather
+                        // then overwriting afterwards to ensure logging is accurate)
+                        self.current_sign_id = nonce_request.sign_id.wrapping_sub(1);
+                        self.current_sign_iter_id = nonce_request.sign_iter_id;
+                        let packet = self.start_signing_round(
+                            nonce_request.message.as_slice(),
+                            nonce_request.is_taproot,
+                            nonce_request.merkle_root,
+                        )?;
+                        return Ok((Some(packet), None));
+                    }
                     return Ok((None, None));
                 }
                 State::DkgPublicDistribute => {
@@ -254,6 +273,9 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
             dkg_id: self.current_dkg_id,
             sign_id: self.current_sign_id,
             sign_iter_id: self.current_sign_iter_id,
+            message: self.message.clone(),
+            is_taproot,
+            merkle_root,
         };
         let nonce_request_msg = Packet {
             sig: nonce_request


### PR DESCRIPTION
This enables signers and coordinators to all duplicate state by attempting to process received coordinator messages as they arrive (only processing them if they are in the expected state. otherwise the message is ignored.)

I also added verify_msg and tests for it to the network crate as it seems like it should live here and not in stacks signer itself. 

TODO: if this is approved. I will go about the process of updating FIRE. But am wary to do so until this is given the green light. Also until we have a FIRE test in stacks-core to verfy I don't eff things up.