### PR TITLE
Make `DKG` fully robust against non-participation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsts"
-version = "6.1.0"
+version = "7.0.0"
 edition = "2021"
 authors = ["Joey Yandle <xoloki@gmail.com>"]
 license = "Apache-2.0"

--- a/src/common.rs
+++ b/src/common.rs
@@ -192,9 +192,8 @@ impl CheckPrivateShares {
         polys: HashMap<u32, PolyCommitment>,
     ) -> Self {
         let mut l: usize = 0;
-        for (_id, comm) in &polys {
+        if let Some((_id, comm)) = (&polys).into_iter().next() {
             l = comm.poly.len();
-            break;
         }
         let n: u32 = shares.len().try_into().unwrap();
         let t: u32 = l.try_into().unwrap();

--- a/src/common.rs
+++ b/src/common.rs
@@ -171,7 +171,7 @@ pub mod test_helpers {
 /// These evaluations take the form of s * G == \Sum{k=0}{T+1}(a_k * x^k) where the a vals are the coeffs of the polys
 /// There is 1 share per poly, N polys, and each poly is degree T-1 (so T coeffs)
 /// First we evaluate each poly, then we subtract each s * G
-pub struct CheckPrivateShares<'a> {
+pub struct CheckPrivateShares {
     /// number of keys
     n: u32,
     /// threshold, where the degree of each poly is (t-1)
@@ -181,16 +181,25 @@ pub struct CheckPrivateShares<'a> {
     /// Negated DKG private shares for the receiving key ID, indexed by sending key ID
     pub neg_shares: HashMap<u32, Scalar>,
     /// Polynomial commitments for each key ID
-    polys: &'a [PolyCommitment],
+    polys: HashMap<u32, PolyCommitment>,
 }
 
-impl<'a> CheckPrivateShares<'a> {
+impl CheckPrivateShares {
     /// Construct a new CheckPrivateShares object
-    pub fn new(id: Scalar, shares: &HashMap<u32, Scalar>, polys: &'a [PolyCommitment]) -> Self {
+    pub fn new(
+        id: Scalar,
+        shares: &HashMap<u32, Scalar>,
+        polys: HashMap<u32, PolyCommitment>,
+    ) -> Self {
+        let mut l: usize = 0;
+        for (_id, comm) in &polys {
+            l = comm.poly.len();
+            break;
+        }
         let n: u32 = shares.len().try_into().unwrap();
-        let t: u32 = polys[0].poly.len().try_into().unwrap();
+        let t: u32 = l.try_into().unwrap();
         let x = id;
-        let mut powers = Vec::with_capacity(polys[0].poly.len());
+        let mut powers = Vec::with_capacity(l);
         let mut pow = Scalar::one();
 
         for _ in 0..t {
@@ -213,27 +222,29 @@ impl<'a> CheckPrivateShares<'a> {
     }
 }
 
-impl<'a> MultiMult for CheckPrivateShares<'a> {
+impl MultiMult for CheckPrivateShares {
     /// The first n*t scalars will be powers, the last n will be the negation of shares
     fn get_scalar(&self, i: usize) -> &Scalar {
+        println!("get_scalar({})", i);
         let h: u32 = i.try_into().unwrap();
         let u: usize = self.t.try_into().unwrap();
         if h < self.n * self.t {
             &self.powers[i % u]
         } else {
-            &self.neg_shares[&(h - (self.t * self.n))]
+            &self.neg_shares[&(h - (self.t * self.n) + 1)]
         }
     }
 
     /// The first n*t points will be poly coeffs, the last n will be G
     fn get_point(&self, i: usize) -> &Point {
+        println!("get_point({})", i);
         let h: u32 = i.try_into().unwrap();
         let u: usize = self.t.try_into().unwrap();
         if h < self.n * self.t {
             let j = i / u;
             let k = i % u;
 
-            &self.polys[j].poly[k]
+            &self.polys[&((j + 1) as u32)].poly[k]
         } else {
             &G
         }

--- a/src/common.rs
+++ b/src/common.rs
@@ -224,7 +224,6 @@ impl CheckPrivateShares {
 impl MultiMult for CheckPrivateShares {
     /// The first n*t scalars will be powers, the last n will be the negation of shares
     fn get_scalar(&self, i: usize) -> &Scalar {
-        println!("get_scalar({})", i);
         let h: u32 = i.try_into().unwrap();
         let u: usize = self.t.try_into().unwrap();
         if h < self.n * self.t {
@@ -236,7 +235,6 @@ impl MultiMult for CheckPrivateShares {
 
     /// The first n*t points will be poly coeffs, the last n will be G
     fn get_point(&self, i: usize) -> &Point {
-        println!("get_point({})", i);
         let h: u32 = i.try_into().unwrap();
         let u: usize = self.t.try_into().unwrap();
         if h < self.n * self.t {

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -114,7 +114,7 @@ pub fn aggregate_nonce(
 
 /// Compute a one-based Scalar from a zero-based integer
 pub fn id(i: u32) -> Scalar {
-    Scalar::from(i + 1)
+    Scalar::from(i)
 }
 
 /// Evaluate the public polynomial `f` at scalar `x` using multi-exponentiation

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,12 +37,12 @@ fn main() {
             .collect();
 
         let dkg_start = time::Instant::now();
-        let A = v1::test_helpers::dkg(&mut signers, &mut rng).expect("v1 dkg failed");
+        let polys = v1::test_helpers::dkg(&mut signers, &mut rng).expect("v1 dkg failed");
         let dkg_time = dkg_start.elapsed();
         let mut signers = signers[..(K * 3 / 4).try_into().unwrap()].to_vec();
 
         let mut aggregator = v1::Aggregator::new(N, T);
-        aggregator.init(A).expect("aggregator init failed");
+        aggregator.init(&polys).expect("aggregator init failed");
 
         let party_sign_start = time::Instant::now();
         let (nonces, sig_shares) = v1::test_helpers::sign(msg, &mut signers, &mut rng);
@@ -73,12 +73,12 @@ fn main() {
             .collect();
 
         let dkg_start = time::Instant::now();
-        let A = v2::test_helpers::dkg(&mut signers, &mut rng).expect("v2 dkg failed");
+        let polys = v2::test_helpers::dkg(&mut signers, &mut rng).expect("v2 dkg failed");
         let dkg_time = dkg_start.elapsed();
         let mut signers = signers[..(K * 3 / 4).try_into().unwrap()].to_vec();
 
         let mut aggregator = v2::Aggregator::new(N, T);
-        aggregator.init(A).expect("aggregator init failed");
+        aggregator.init(&polys).expect("aggregator init failed");
 
         let party_sign_start = time::Instant::now();
         let (nonces, sig_shares, key_ids) = v2::test_helpers::sign(msg, &mut signers, &mut rng);

--- a/src/net.rs
+++ b/src/net.rs
@@ -156,12 +156,14 @@ impl Signable for DkgPrivateShares {
         hasher.update("DKG_PRIVATE_SHARES".as_bytes());
         hasher.update(self.dkg_id.to_be_bytes());
         hasher.update(self.signer_id.to_be_bytes());
-        // make sure we iterate sequentially
+        // make sure we hash consistently by sorting the keys
         for (src_id, share) in &self.shares {
             hasher.update(src_id.to_be_bytes());
-            for dst_id in 0..share.len() as u32 {
+            let mut dst_ids = share.keys().cloned().collect::<Vec<u32>>();
+            dst_ids.sort();
+            for dst_id in &dst_ids {
                 hasher.update(dst_id.to_be_bytes());
-                hasher.update(&share[&dst_id]);
+                hasher.update(&share[dst_id]);
             }
         }
     }

--- a/src/net.rs
+++ b/src/net.rs
@@ -121,6 +121,8 @@ impl Signable for DkgPublicShares {
 pub struct DkgPrivateBegin {
     /// DKG round ID
     pub dkg_id: u64,
+    /// Signer IDs who responded in time for this DKG round
+    pub signer_ids: Vec<u32>,
     /// Key IDs who responded in time for this DKG round
     pub key_ids: Vec<u32>,
 }
@@ -131,6 +133,9 @@ impl Signable for DkgPrivateBegin {
         hasher.update(self.dkg_id.to_be_bytes());
         for key_id in &self.key_ids {
             hasher.update(key_id.to_be_bytes());
+        }
+        for signer_id in &self.signer_ids {
+            hasher.update(signer_id.to_be_bytes());
         }
     }
 }
@@ -167,6 +172,8 @@ impl Signable for DkgPrivateShares {
 pub struct DkgEndBegin {
     /// DKG round ID
     pub dkg_id: u64,
+    /// Signer IDs who responded in time for this DKG round
+    pub signer_ids: Vec<u32>,
     /// Key IDs who responded in time for this DKG round
     pub key_ids: Vec<u32>,
 }
@@ -177,6 +184,9 @@ impl Signable for DkgEndBegin {
         hasher.update(self.dkg_id.to_be_bytes());
         for key_id in &self.key_ids {
             hasher.update(key_id.to_be_bytes());
+        }
+        for signer_id in &self.signer_ids {
+            hasher.update(signer_id.to_be_bytes());
         }
     }
 }
@@ -510,6 +520,7 @@ mod test {
         let dkg_private_begin = DkgPrivateBegin {
             dkg_id: 0,
             key_ids: Default::default(),
+            signer_ids: Default::default(),
         };
         let msg = Message::DkgBegin(dkg_begin.clone());
         let coordinator_packet_dkg_begin = Packet {

--- a/src/net.rs
+++ b/src/net.rs
@@ -63,6 +63,8 @@ pub enum Message {
     DkgPrivateBegin(DkgPrivateBegin),
     /// Send DKG private shares
     DkgPrivateShares(DkgPrivateShares),
+    /// Tell signers to compute shares and send DKG end
+    DkgEndBegin(DkgEndBegin),
     /// Tell coordinator that DKG is complete
     DkgEnd(DkgEnd),
     /// Tell signers to send signing nonces
@@ -125,7 +127,7 @@ pub struct DkgPrivateBegin {
 
 impl Signable for DkgPrivateBegin {
     fn hash(&self, hasher: &mut Sha256) {
-        hasher.update("DKG_PRIVATE_SHARES".as_bytes());
+        hasher.update("DKG_PRIVATE_BEGIN".as_bytes());
         hasher.update(self.dkg_id.to_be_bytes());
         for key_id in &self.key_ids {
             hasher.update(key_id.to_be_bytes());
@@ -156,6 +158,25 @@ impl Signable for DkgPrivateShares {
                 hasher.update(dst_id.to_be_bytes());
                 hasher.update(&share[&dst_id]);
             }
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+/// DKG end begin message from signer to all signers and coordinator
+pub struct DkgEndBegin {
+    /// DKG round ID
+    pub dkg_id: u64,
+    /// Key IDs who responded in time for this DKG round
+    pub key_ids: Vec<u32>,
+}
+
+impl Signable for DkgEndBegin {
+    fn hash(&self, hasher: &mut Sha256) {
+        hasher.update("DKG_END_BEGIN".as_bytes());
+        hasher.update(self.dkg_id.to_be_bytes());
+        for key_id in &self.key_ids {
+            hasher.update(key_id.to_be_bytes());
         }
     }
 }
@@ -340,6 +361,12 @@ impl Packet {
             Message::DkgPrivateBegin(msg) => {
                 if !msg.verify(&self.sig, coordinator_public_key) {
                     warn!("Received a DkgPrivateBegin message with an invalid signature.");
+                    return false;
+                }
+            }
+            Message::DkgEndBegin(msg) => {
+                if !msg.verify(&self.sig, coordinator_public_key) {
+                    warn!("Received a DkgEndBegin message with an invalid signature.");
                     return false;
                 }
             }

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -311,12 +311,10 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
         self.dkg_public_shares.clear();
         self.party_polynomials.clear();
         self.dkg_wait_signer_ids = (0..self.config.num_signers).collect();
-
         info!(
             "DKG Round {}: Starting Public Share Distribution",
             self.current_dkg_id,
         );
-
         let dkg_begin = DkgBegin {
             dkg_id: self.current_dkg_id,
         };
@@ -449,7 +447,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
 
             self.dkg_private_shares
                 .insert(dkg_private_shares.signer_id, dkg_private_shares.clone());
-            debug!(
+            info!(
                 "DKG round {} DkgPrivateShares from signer {}",
                 dkg_private_shares.dkg_id, dkg_private_shares.signer_id
             );

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -1394,7 +1394,7 @@ pub mod test {
         assert!(operation_results.is_empty());
         assert_eq!(
             insufficient_coordinator.first().unwrap().state,
-            State::DkgEndGather
+            State::DkgPrivateGather
         );
 
         // Successfully got an Aggregate Public Key...
@@ -1421,7 +1421,7 @@ pub mod test {
         assert_eq!(operation_results.len(), 0);
         assert_eq!(
             insufficient_coordinator.first().unwrap().state,
-            State::DkgEndGather,
+            State::DkgPrivateGather,
         );
 
         // Sleep long enough to hit the timeout
@@ -1437,12 +1437,12 @@ pub mod test {
         assert_eq!(operation_results.len(), 1);
         assert_eq!(
             insufficient_coordinator.first().unwrap().state,
-            State::DkgEndGather,
+            State::DkgPrivateGather,
         );
         match &operation_results[0] {
             OperationResult::DkgError(dkg_error) => match dkg_error {
-                DkgError::DkgEndTimeout(_) => {}
-                _ => panic!("Expected DkgError::DkgEndTimeout"),
+                DkgError::DkgPrivateTimeout(_) => {}
+                _ => panic!("Expected DkgError::DkgPrivateTimeout"),
             },
             _ => panic!("Expected OperationResult::DkgError"),
         }

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -1545,7 +1545,7 @@ pub mod test {
             num_signers_to_remove -= (num_signers - signers.len() as u32) as usize;
         }
         for _ in 0..num_signers_to_remove {
-            //signers.pop();
+            signers.pop();
         }
 
         // Start a signing round

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -1641,10 +1641,9 @@ pub mod test {
             feedback_messages(&mut coordinators, &mut signers, &[message]);
         assert!(operation_results.is_empty());
         for coordinator in &coordinators {
-            assert_eq!(coordinator.state, State::DkgEndGather);
+            assert_eq!(coordinator.state, State::DkgPrivateGather);
         }
 
-        // Successfully got an Aggregate Public Key...
         assert_eq!(outbound_messages.len(), 1);
         match &outbound_messages[0].msg {
             Message::DkgPrivateBegin(_) => {}
@@ -1653,7 +1652,19 @@ pub mod test {
             }
         }
 
-        // Send the DKG Private Begin message to all signers and share their responses with the coordinator and signers
+        // Send the DKG Private Begin message to all signers and share their responses with the coordinators and signers
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
+        assert_eq!(operation_results.len(), 0);
+        assert_eq!(outbound_messages.len(), 1);
+        match &outbound_messages[0].msg {
+            Message::DkgEndBegin(_) => {}
+            _ => {
+                panic!("Expected DkgEndBegin message");
+            }
+        }
+
+        // Send the DKG End Begin message to all signers and share their responses with the coordinator and signers
         let (outbound_messages, operation_results) =
             feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
         assert!(outbound_messages.is_empty());

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -732,7 +732,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                 .flat_map(|(i, _)| self.signature_shares[i].clone())
                 .collect::<Vec<SignatureShare>>();
 
-            info!(
+            debug!(
                 "aggregator.sign({}, {:?}, {:?}, {})",
                 bs58::encode(&self.message).into_string(),
                 nonces.len(),

--- a/src/state_machine/coordinator/frost.rs
+++ b/src/state_machine/coordinator/frost.rs
@@ -7,8 +7,8 @@ use crate::{
     compute,
     curve::point::Point,
     net::{
-        DkgBegin, DkgPrivateBegin, DkgPublicShares, Message, NonceRequest, NonceResponse, Packet,
-        Signable, SignatureShareRequest,
+        DkgBegin, DkgEndBegin, DkgPrivateBegin, DkgPrivateShares, DkgPublicShares, Message,
+        NonceRequest, NonceResponse, Packet, Signable, SignatureShareRequest,
     },
     state_machine::{
         coordinator::{Config, Coordinator as CoordinatorTrait, Error, State},
@@ -30,6 +30,7 @@ pub struct Coordinator<Aggregator: AggregatorTrait> {
     /// current signing iteration ID
     current_sign_iter_id: u64,
     dkg_public_shares: BTreeMap<u32, DkgPublicShares>,
+    dkg_private_shares: BTreeMap<u32, DkgPrivateShares>,
     party_polynomials: BTreeMap<u32, PolyCommitment>,
     public_nonces: BTreeMap<u32, NonceResponse>,
     signature_shares: BTreeMap<u32, Vec<SignatureShare>>,
@@ -92,6 +93,17 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                 }
                 State::DkgPrivateDistribute => {
                     let packet = self.start_private_shares()?;
+                    return Ok((Some(packet), None));
+                }
+                State::DkgPrivateGather => {
+                    self.gather_private_shares(packet)?;
+                    if self.state == State::DkgPublicGather {
+                        // We need more data
+                        return Ok((None, None));
+                    }
+                }
+                State::DkgEndDistribute => {
+                    let packet = self.start_dkg_end()?;
                     return Ok((Some(packet), None));
                 }
                 State::DkgEndGather => {
@@ -197,8 +209,27 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
             sig: dkg_begin.sign(&self.config.message_private_key).expect(""),
             msg: Message::DkgPrivateBegin(dkg_begin),
         };
-        self.move_to(State::DkgEndGather)?;
+        self.move_to(State::DkgPrivateGather)?;
         Ok(dkg_private_begin_msg)
+    }
+
+    /// Ask signers to compute secrets and send DKG end
+    pub fn start_dkg_end(&mut self) -> Result<Packet, Error> {
+        self.ids_to_await = (0..self.config.num_signers).collect();
+        info!(
+            "DKG Round {}: Starting DKG End Distribution",
+            self.current_dkg_id
+        );
+        let dkg_begin = DkgEndBegin {
+            dkg_id: self.current_dkg_id,
+            key_ids: (0..self.config.num_keys).collect(),
+        };
+        let dkg_end_begin_msg = Packet {
+            sig: dkg_begin.sign(&self.config.message_private_key).expect(""),
+            msg: Message::DkgEndBegin(dkg_begin),
+        };
+        self.move_to(State::DkgEndGather)?;
+        Ok(dkg_end_begin_msg)
     }
 
     fn gather_public_shares(&mut self, packet: &Packet) -> Result<(), Error> {
@@ -225,14 +256,31 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
         }
 
         if self.ids_to_await.is_empty() {
-            // Calculate the aggregate public key
-            let key = self
-                .party_polynomials
-                .iter()
-                .fold(Point::default(), |s, (_, comm)| s + comm.poly[0]);
+            self.move_to(State::DkgPrivateDistribute)?;
+        }
+        Ok(())
+    }
 
-            info!("Aggregate public key: {}", key);
-            self.aggregate_public_key = Some(key);
+    fn gather_private_shares(&mut self, packet: &Packet) -> Result<(), Error> {
+        if let Message::DkgPrivateShares(dkg_private_shares) = &packet.msg {
+            if dkg_private_shares.dkg_id != self.current_dkg_id {
+                return Err(Error::BadDkgId(
+                    dkg_private_shares.dkg_id,
+                    self.current_dkg_id,
+                ));
+            }
+
+            self.ids_to_await.remove(&dkg_private_shares.signer_id);
+
+            self.dkg_private_shares
+                .insert(dkg_private_shares.signer_id, dkg_private_shares.clone());
+            debug!(
+                "DKG round {} DkgPrivateShares from signer {}",
+                dkg_private_shares.dkg_id, dkg_private_shares.signer_id
+            );
+        }
+
+        if self.ids_to_await.is_empty() {
             self.move_to(State::DkgPrivateDistribute)?;
         }
         Ok(())
@@ -255,6 +303,14 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
         }
 
         if self.ids_to_await.is_empty() {
+            // Calculate the aggregate public key
+            let key = self
+                .party_polynomials
+                .iter()
+                .fold(Point::default(), |s, (_, comm)| s + comm.poly[0]);
+
+            info!("Aggregate public key: {}", key);
+            self.aggregate_public_key = Some(key);
             self.move_to(State::Idle)?;
         }
         Ok(())
@@ -481,16 +537,16 @@ impl<Aggregator: AggregatorTrait> StateMachine<State, Error> for Coordinator<Agg
         let prev_state = &self.state;
         let accepted = match state {
             State::Idle => true,
-            State::DkgPublicDistribute => {
-                prev_state == &State::Idle
-                    || prev_state == &State::DkgPublicGather
-                    || prev_state == &State::DkgEndGather
-            }
+            State::DkgPublicDistribute => prev_state == &State::Idle,
             State::DkgPublicGather => {
                 prev_state == &State::DkgPublicDistribute || prev_state == &State::DkgPublicGather
             }
             State::DkgPrivateDistribute => prev_state == &State::DkgPublicGather,
-            State::DkgEndGather => prev_state == &State::DkgPrivateDistribute,
+            State::DkgPrivateGather => {
+                prev_state == &State::DkgPrivateDistribute || prev_state == &State::DkgPrivateGather
+            }
+            State::DkgEndDistribute => prev_state == &State::DkgPrivateGather,
+            State::DkgEndGather => prev_state == &State::DkgEndDistribute,
             State::NonceRequest(_, _) => {
                 prev_state == &State::Idle || prev_state == &State::DkgEndGather
             }
@@ -528,6 +584,7 @@ impl<Aggregator: AggregatorTrait> CoordinatorTrait for Coordinator<Aggregator> {
             current_sign_id: 0,
             current_sign_iter_id: 0,
             dkg_public_shares: Default::default(),
+            dkg_private_shares: Default::default(),
             party_polynomials: Default::default(),
             public_nonces: Default::default(),
             signature_shares: Default::default(),

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -366,7 +366,7 @@ pub mod test {
                 (private_key, public_key)
             })
             .collect::<Vec<(Scalar, ecdsa::PublicKey)>>();
-        let mut key_id: u32 = 0;
+        let mut key_id: u32 = 1;
         let mut signer_ids_map = HashMap::new();
         let mut signer_key_ids = HashMap::new();
         let mut signer_key_ids_set = HashMap::new();
@@ -375,7 +375,7 @@ pub mod test {
             let mut key_ids = Vec::new();
             let mut key_ids_set = HashSet::new();
             for _ in 0..keys_per_signer {
-                key_ids_map.insert(key_id + 1, *public_key);
+                key_ids_map.insert(key_id, *public_key);
                 key_ids.push(key_id);
                 key_ids_set.insert(key_id);
                 key_id += 1;
@@ -498,6 +498,7 @@ pub mod test {
         // Send the DKG Private Begin message to all signers and share their responses with the coordinator and signers
         let (outbound_messages, operation_results) =
             feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
+        assert_eq!(operation_results.len(), 0);
         assert_eq!(outbound_messages.len(), 1);
         match &outbound_messages[0].msg {
             Message::DkgEndBegin(_) => {}
@@ -505,6 +506,11 @@ pub mod test {
                 panic!("Expected DkgEndBegin message");
             }
         }
+
+        // Send the DKG Private Begin message to all signers and share their responses with the coordinator and signers
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
+        assert_eq!(outbound_messages.len(), 0);
         assert_eq!(operation_results.len(), 1);
         match operation_results[0] {
             OperationResult::Dkg(point) => {

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -507,7 +507,7 @@ pub mod test {
             }
         }
 
-        // Send the DKG Private Begin message to all signers and share their responses with the coordinator and signers
+        // Send the DkgEndBegin message to all signers and share their responses with the coordinator and signers
         let (outbound_messages, operation_results) =
             feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
         assert_eq!(outbound_messages.len(), 0);

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -485,10 +485,9 @@ pub mod test {
             feedback_messages(&mut coordinators, &mut signers, &[message]);
         assert!(operation_results.is_empty());
         for coordinator in coordinators.iter() {
-            assert_eq!(coordinator.get_state(), State::DkgEndGather);
+            assert_eq!(coordinator.get_state(), State::DkgPrivateGather);
         }
 
-        // Successfully got an Aggregate Public Key...
         assert_eq!(outbound_messages.len(), 1);
         match &outbound_messages[0].msg {
             Message::DkgPrivateBegin(_) => {}
@@ -499,7 +498,13 @@ pub mod test {
         // Send the DKG Private Begin message to all signers and share their responses with the coordinator and signers
         let (outbound_messages, operation_results) =
             feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
-        assert!(outbound_messages.is_empty());
+        assert_eq!(outbound_messages.len(), 1);
+        match &outbound_messages[0].msg {
+            Message::DkgEndBegin(_) => {}
+            _ => {
+                panic!("Expected DkgEndBegin message");
+            }
+        }
         assert_eq!(operation_results.len(), 1);
         match operation_results[0] {
             OperationResult::Dkg(point) => {

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -91,6 +91,8 @@ pub struct Config {
     pub message_private_key: Scalar,
     /// timeout to gather DkgPublicShares messages
     pub dkg_public_timeout: Option<Duration>,
+    /// timeout to gather DkgPrivateShares messages
+    pub dkg_private_timeout: Option<Duration>,
     /// timeout to gather DkgEnd messages
     pub dkg_end_timeout: Option<Duration>,
     /// timeout to gather nonces
@@ -116,6 +118,7 @@ impl Config {
             dkg_threshold: num_keys,
             message_private_key,
             dkg_public_timeout: None,
+            dkg_private_timeout: None,
             dkg_end_timeout: None,
             nonce_timeout: None,
             sign_timeout: None,
@@ -132,6 +135,7 @@ impl Config {
         dkg_threshold: u32,
         message_private_key: Scalar,
         dkg_public_timeout: Option<Duration>,
+        dkg_private_timeout: Option<Duration>,
         dkg_end_timeout: Option<Duration>,
         nonce_timeout: Option<Duration>,
         sign_timeout: Option<Duration>,
@@ -144,6 +148,7 @@ impl Config {
             dkg_threshold,
             message_private_key,
             dkg_public_timeout,
+            dkg_private_timeout,
             dkg_end_timeout,
             nonce_timeout,
             sign_timeout,
@@ -333,6 +338,7 @@ pub mod test {
             None,
             None,
             None,
+            None,
         )
     }
 
@@ -340,6 +346,7 @@ pub mod test {
         num_signers: u32,
         keys_per_signer: u32,
         dkg_public_timeout: Option<Duration>,
+        dkg_private_timeout: Option<Duration>,
         dkg_end_timeout: Option<Duration>,
         nonce_timeout: Option<Duration>,
         sign_timeout: Option<Duration>,
@@ -414,6 +421,7 @@ pub mod test {
                     dkg_threshold,
                     private_key,
                     dkg_public_timeout,
+                    dkg_private_timeout,
                     dkg_end_timeout,
                     nonce_timeout,
                     sign_timeout,

--- a/src/state_machine/mod.rs
+++ b/src/state_machine/mod.rs
@@ -31,9 +31,6 @@ pub enum DkgError {
     /// DKG crypto error
     #[error("DKG crypto error")]
     Crypto(#[from] DkgCryptoError),
-    /// Bad state for DKG
-    #[error("Bad state for DK")]
-    State,
 }
 
 /// Sign errors

--- a/src/state_machine/mod.rs
+++ b/src/state_machine/mod.rs
@@ -31,6 +31,9 @@ pub enum DkgError {
     /// DKG crypto error
     #[error("DKG crypto error")]
     Crypto(#[from] DkgCryptoError),
+    /// Bad state for DKG
+    #[error("Bad state for DK")]
+    State,
 }
 
 /// Sign errors

--- a/src/state_machine/mod.rs
+++ b/src/state_machine/mod.rs
@@ -22,6 +22,9 @@ pub enum DkgError {
     /// DKG public timeout
     #[error("DKG public timeout, waiting for {0:?}")]
     DkgPublicTimeout(Vec<u32>),
+    /// DKG private timeout
+    #[error("DKG private timeout, waiting for {0:?}")]
+    DkgPrivateTimeout(Vec<u32>),
     /// DKG end timeout
     #[error("DKG end timeout, waiting for {0:?}")]
     DkgEndTimeout(Vec<u32>),

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -94,10 +94,14 @@ pub struct Signer<SignerType: SignerTrait> {
     pub network_private_key: Scalar,
     /// the public keys for all signers and coordinator
     pub public_keys: PublicKeys,
-    dkg_public_shares: BTreeMap<u32, DkgPublicShares>,
-    dkg_private_shares: BTreeMap<u32, DkgPrivateShares>,
-    dkg_private_begin_msg: Option<DkgPrivateBegin>,
-    dkg_end_begin_msg: Option<DkgEndBegin>,
+    /// the DKG public shares received in this round
+    pub dkg_public_shares: BTreeMap<u32, DkgPublicShares>,
+    /// the DKG private shares received in this round
+    pub dkg_private_shares: BTreeMap<u32, DkgPrivateShares>,
+    /// the DKG private begin message received in this round
+    pub dkg_private_begin_msg: Option<DkgPrivateBegin>,
+    /// the DKG end begin message received in this round
+    pub dkg_end_begin_msg: Option<DkgEndBegin>,
 }
 
 impl<SignerType: SignerTrait> Signer<SignerType> {
@@ -701,7 +705,7 @@ pub mod test {
             )],
         };
         signer.dkg_public_share(&public_share).unwrap();
-        assert_eq!(1, signer.commitments.len())
+        assert_eq!(1, signer.dkg_public_shares.len())
     }
 
     #[test]

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -167,6 +167,10 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                             .sign(&self.network_private_key)
                             .expect("failed to sign DkgPrivateBegin")
                             .to_vec(),
+                        Message::DkgEndBegin(msg) => msg
+                            .sign(&self.network_private_key)
+                            .expect("failed to sign DkgEndBegin")
+                            .to_vec(),
                         Message::DkgEnd(msg) => msg
                             .sign(&self.network_private_key)
                             .expect("failed to sign DkgEnd")

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -281,12 +281,10 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                 .signer
                 .compute_secrets(&self.decrypted_shares, &self.commitments)
             {
-                Ok(()) => {
-                    DkgEnd {
-                        dkg_id: self.dkg_id,
-                        signer_id: self.signer_id,
-                        status: DkgStatus::Success,
-                    }
+                Ok(()) => DkgEnd {
+                    dkg_id: self.dkg_id,
+                    signer_id: self.signer_id,
+                    status: DkgStatus::Success,
                 },
                 Err(dkg_error_map) => DkgEnd {
                     dkg_id: self.dkg_id,

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -306,7 +306,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
 
     /// do we have all DkgPublicShares and DkgPrivateShares?
     pub fn can_dkg_end(&self) -> bool {
-        info!(
+        debug!(
             "can_dkg_end state {:?} DkgPrivateBegin {} DkgEndBegin {}",
             self.state,
             self.dkg_private_begin_msg.is_some(),
@@ -325,7 +325,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
 
                 if let Some(dkg_end_begin) = &self.dkg_end_begin_msg {
                     // need private shares from active signers
-                    for signer_id in &dkg_private_begin.signer_ids {
+                    for signer_id in &dkg_end_begin.signer_ids {
                         if !self.dkg_private_shares.contains_key(&signer_id) {
                             info!("can_dkg_end: private shares missing {} false", signer_id);
                             return false;
@@ -337,7 +337,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                 }
             }
         } else {
-            info!("can_dkg_end: bad state {:?} false", self.state);
+            debug!("can_dkg_end: bad state {:?} false", self.state);
             return false;
         }
         false

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -307,7 +307,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
     /// do we have all DkgPublicShares and DkgPrivateShares?
     pub fn can_dkg_end(&self) -> bool {
         debug!(
-            "can_dkg_end state {:?} DkgPrivateBegin {} DkgEndBegin {}",
+            "can_dkg_end: state {:?} DkgPrivateBegin {} DkgEndBegin {}",
             self.state,
             self.dkg_private_begin_msg.is_some(),
             self.dkg_end_begin_msg.is_some(),
@@ -318,7 +318,10 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                 // need public shares from active signers
                 for signer_id in &dkg_private_begin.signer_ids {
                     if !self.dkg_public_shares.contains_key(&signer_id) {
-                        info!("can_dkg_end: public shares missing {} false", signer_id);
+                        info!(
+                            "can_dkg_end: false, missing public shares from signer {}",
+                            signer_id
+                        );
                         return false;
                     }
                 }
@@ -327,7 +330,10 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                     // need private shares from active signers
                     for signer_id in &dkg_end_begin.signer_ids {
                         if !self.dkg_private_shares.contains_key(&signer_id) {
-                            info!("can_dkg_end: private shares missing {} false", signer_id);
+                            info!(
+                                "can_dkg_end: false, missing private shares from signer {}",
+                                signer_id
+                            );
                             return false;
                         }
                     }
@@ -337,7 +343,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                 }
             }
         } else {
-            debug!("can_dkg_end: bad state {:?} false", self.state);
+            debug!("can_dkg_end: false, bad state {:?}", self.state);
             return false;
         }
         false

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -262,7 +262,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             return Ok(Message::DkgEnd(DkgEnd {
                 dkg_id: self.dkg_id,
                 signer_id: self.signer_id,
-                status: DkgStatus::Failure(format!("Bad state")),
+                status: DkgStatus::Failure("Bad state".to_string()),
             }));
         }
 

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -254,7 +254,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
 
     /// DKG is done so compute secrets
     pub fn dkg_ended(&mut self) -> Result<Message, Error> {
-        for (_signer_id, shares) in &self.dkg_public_shares {
+        for shares in self.dkg_public_shares.values() {
             for (party_id, comm) in shares.comms.iter() {
                 self.commitments.insert(*party_id, comm.clone());
             }
@@ -317,7 +317,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             if let Some(dkg_private_begin) = &self.dkg_private_begin_msg {
                 // need public shares from active signers
                 for signer_id in &dkg_private_begin.signer_ids {
-                    if !self.dkg_public_shares.contains_key(&signer_id) {
+                    if !self.dkg_public_shares.contains_key(signer_id) {
                         info!(
                             "can_dkg_end: false, missing public shares from signer {}",
                             signer_id
@@ -329,7 +329,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                 if let Some(dkg_end_begin) = &self.dkg_end_begin_msg {
                     // need private shares from active signers
                     for signer_id in &dkg_end_begin.signer_ids {
-                        if !self.dkg_private_shares.contains_key(&signer_id) {
+                        if !self.dkg_private_shares.contains_key(signer_id) {
                             info!(
                                 "can_dkg_end: false, missing private shares from signer {}",
                                 signer_id

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -334,7 +334,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                 // need public shares from active signers
                 for signer_id in &dkg_private_begin.signer_ids {
                     if !self.dkg_public_shares.contains_key(signer_id) {
-                        info!(
+                        debug!(
                             "can_dkg_end: false, missing public shares from signer {}",
                             signer_id
                         );
@@ -346,14 +346,14 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                     // need private shares from active signers
                     for signer_id in &dkg_end_begin.signer_ids {
                         if !self.dkg_private_shares.contains_key(signer_id) {
-                            info!(
+                            debug!(
                                 "can_dkg_end: false, missing private shares from signer {}",
                                 signer_id
                             );
                             return false;
                         }
                     }
-                    info!("can_dkg_end: true");
+                    debug!("can_dkg_end: true");
 
                     return true;
                 }

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -663,7 +663,6 @@ impl<SignerType: SignerTrait> StateMachine<State, Error> for Signer<SignerType> 
 
 #[cfg(test)]
 pub mod test {
-    use hashbrown::HashMap;
     use rand_core::OsRng;
 
     use crate::{

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -775,8 +775,18 @@ pub mod test {
     }
 
     fn dkg_ended<SignerType: SignerTrait>() {
+        let mut rng = OsRng;
         let mut signer =
-            Signer::<SignerType>::new(1, 1, 1, 1, vec![1], Default::default(), Default::default());
+            Signer::<SignerType>::new(1, 1, 1, 0, vec![1], Default::default(), Default::default());
+        let polys = signer.signer.get_poly_commitments(&mut rng);
+        let dkg_public_shares = DkgPublicShares {
+            dkg_id: 1,
+            signer_id: 0,
+            comms: vec![(1, polys[0].clone())],
+        };
+        signer
+            .dkg_public_share(&dkg_public_shares)
+            .expect("failed to add public share");
         if let Ok(Message::DkgEnd(dkg_end)) = signer.dkg_ended() {
             match dkg_end.status {
                 DkgStatus::Failure(_) => {}

--- a/src/taproot.rs
+++ b/src/taproot.rs
@@ -175,10 +175,10 @@ mod test {
         let N: u32 = 10;
         let T: u32 = 7;
         let signer_ids: Vec<Vec<u32>> = [
-            [0, 1, 2].to_vec(),
-            [3, 4].to_vec(),
-            [5, 6, 7].to_vec(),
-            [8, 9].to_vec(),
+            [1, 2, 3].to_vec(),
+            [4, 5].to_vec(),
+            [6, 7, 8].to_vec(),
+            [9, 10].to_vec(),
         ]
         .to_vec();
         let mut signers: Vec<v1::Signer> = signer_ids
@@ -237,10 +237,10 @@ mod test {
         let Np: u32 = 4;
         let T: u32 = 7;
         let signer_ids: Vec<Vec<u32>> = [
-            [0, 1, 2].to_vec(),
-            [3, 4].to_vec(),
-            [5, 6, 7].to_vec(),
-            [8, 9].to_vec(),
+            [1, 2, 3].to_vec(),
+            [4, 5].to_vec(),
+            [6, 7, 8].to_vec(),
+            [9, 10].to_vec(),
         ]
         .to_vec();
         let mut signers: Vec<v2::Signer> = signer_ids

--- a/src/taproot.rs
+++ b/src/taproot.rs
@@ -86,10 +86,11 @@ pub mod test_helpers {
     pub fn dkg<RNG: RngCore + CryptoRng, Signer: traits::Signer>(
         signers: &mut [Signer],
         rng: &mut RNG,
-    ) -> Result<Vec<PolyCommitment>, HashMap<u32, DkgError>> {
-        let A: Vec<PolyCommitment> = signers
+    ) -> Result<HashMap<u32, PolyCommitment>, HashMap<u32, DkgError>> {
+        let polys: HashMap<u32, PolyCommitment> = signers
             .iter()
             .flat_map(|s| s.get_poly_commitments(rng))
+            .map(|comm| (comm.id.id.get_u32(), comm))
             .collect();
 
         let mut private_shares = HashMap::new();
@@ -101,13 +102,13 @@ pub mod test_helpers {
 
         let mut secret_errors = HashMap::new();
         for signer in signers.iter_mut() {
-            if let Err(signer_secret_errors) = signer.compute_secrets(&private_shares, &A) {
+            if let Err(signer_secret_errors) = signer.compute_secrets(&private_shares, &polys) {
                 secret_errors.extend(signer_secret_errors.into_iter());
             }
         }
 
         if secret_errors.is_empty() {
-            Ok(A)
+            Ok(polys)
         } else {
             Err(secret_errors)
         }
@@ -186,8 +187,8 @@ mod test {
             .map(|(id, ids)| v1::Signer::new(id.try_into().unwrap(), ids, N, T, &mut rng))
             .collect();
 
-        let A = match test_helpers::dkg(&mut signers, &mut rng) {
-            Ok(A) => A,
+        let polys = match test_helpers::dkg(&mut signers, &mut rng) {
+            Ok(polys) => polys,
             Err(secret_errors) => {
                 panic!("Got secret errors from DKG: {:?}", secret_errors);
             }
@@ -195,7 +196,7 @@ mod test {
 
         let mut S = [signers[0].clone(), signers[1].clone(), signers[3].clone()].to_vec();
         let mut sig_agg = v1::Aggregator::new(N, T);
-        sig_agg.init(A.clone()).expect("aggregator init failed");
+        sig_agg.init(&polys).expect("aggregator init failed");
         let tweaked_public_key = compute::tweaked_public_key(&sig_agg.poly[0], merkle_root);
         let (nonces, sig_shares) = test_helpers::sign(msg, &mut S, &mut rng, merkle_root);
         let proof = match sig_agg.sign_taproot(msg, &nonces, &sig_shares, &[], merkle_root) {
@@ -248,8 +249,8 @@ mod test {
             .map(|(id, ids)| v2::Signer::new(id.try_into().unwrap(), ids, Np, Nk, T, &mut rng))
             .collect();
 
-        let A = match test_helpers::dkg(&mut signers, &mut rng) {
-            Ok(A) => A,
+        let polys = match test_helpers::dkg(&mut signers, &mut rng) {
+            Ok(polys) => polys,
             Err(secret_errors) => {
                 panic!("Got secret errors from DKG: {:?}", secret_errors);
             }
@@ -258,7 +259,7 @@ mod test {
         let mut S = [signers[0].clone(), signers[1].clone(), signers[3].clone()].to_vec();
         let key_ids = S.iter().flat_map(|s| s.get_key_ids()).collect::<Vec<u32>>();
         let mut sig_agg = v2::Aggregator::new(Nk, T);
-        sig_agg.init(A.clone()).expect("aggregator init failed");
+        sig_agg.init(&polys).expect("aggregator init failed");
         let tweaked_public_key = compute::tweaked_public_key(&sig_agg.poly[0], merkle_root);
         let (nonces, sig_shares) = test_helpers::sign(msg, &mut S, &mut rng, merkle_root);
         let proof = match sig_agg.sign_taproot(msg, &nonces, &sig_shares, &key_ids, merkle_root) {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -42,7 +42,7 @@ pub trait Signer: Clone {
     fn compute_secrets(
         &mut self,
         shares: &HashMap<u32, HashMap<u32, Scalar>>,
-        polys: &[PolyCommitment],
+        polys: &HashMap<u32, PolyCommitment>,
     ) -> Result<(), HashMap<u32, DkgError>>;
 
     /// Generate all nonces for this signer
@@ -82,7 +82,7 @@ pub trait Aggregator: Clone {
     fn new(num_keys: u32, threshold: u32) -> Self;
 
     /// Initialize an Aggregator with the passed polynomial commitments
-    fn init(&mut self, poly_comms: Vec<PolyCommitment>) -> Result<(), AggregatorError>;
+    fn init(&mut self, poly_comms: &HashMap<u32, PolyCommitment>) -> Result<(), AggregatorError>;
 
     /// Check and aggregate the signature shares into a `Signature`
     fn sign(

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -148,9 +148,7 @@ impl Party {
         }
 
         if shares.len() != polys.len() {
-            let mut not_enough_shares = Vec::new();
-            not_enough_shares.push(self.id);
-            return Err(DkgError::NotEnoughShares(not_enough_shares));
+            return Err(DkgError::NotEnoughShares(vec![self.id]));
         }
 
         // let's optimize for the case where all shares are good, and test them as a batch

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -3,7 +3,6 @@ use num_traits::{One, Zero};
 use polynomial::Polynomial;
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use tracing::info;
 
 use crate::{
     common::{CheckPrivateShares, Nonce, PolyCommitment, PublicNonce, Signature, SignatureShare},
@@ -117,11 +116,6 @@ impl Party {
         shares: HashMap<u32, Scalar>,
         polys: &HashMap<u32, PolyCommitment>,
     ) -> Result<(), DkgError> {
-        println!(
-            "compute_secret {} shares {} polys",
-            shares.len(),
-            polys.len()
-        );
         let mut missing_shares = Vec::new();
         for i in polys.keys() {
             if shares.get(i).is_none() {
@@ -526,13 +520,11 @@ impl traits::Signer for Signer {
         private_shares: &HashMap<u32, HashMap<u32, Scalar>>,
         polys: &HashMap<u32, PolyCommitment>,
     ) -> Result<(), HashMap<u32, DkgError>> {
-        println!("compute_secrets {}", self.get_id());
         let mut dkg_errors = HashMap::new();
         for party in &mut self.parties {
             // go through the shares, looking for this party's
             let mut key_shares = HashMap::with_capacity(polys.len());
             for (signer_id, signer_shares) in private_shares.iter() {
-                println!("{signer_id} {}", party.id);
                 key_shares.insert(*signer_id, signer_shares[&party.id]);
             }
             if let Err(e) = party.compute_secret(key_shares, polys) {

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -117,6 +117,11 @@ impl Party {
         shares: HashMap<u32, Scalar>,
         polys: &HashMap<u32, PolyCommitment>,
     ) -> Result<(), DkgError> {
+        println!(
+            "compute_secret {} shares {} polys",
+            shares.len(),
+            polys.len()
+        );
         let mut missing_shares = Vec::new();
         for i in polys.keys() {
             if shares.get(i).is_none() {
@@ -130,7 +135,7 @@ impl Party {
         self.private_key = Scalar::zero();
         self.group_key = Point::zero();
 
-        let bad_ids: Vec<u32> = shares
+        let bad_ids: Vec<u32> = polys
             .keys()
             .cloned()
             .filter(|i| !polys[i].verify())

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -3,7 +3,6 @@ use num_traits::{One, Zero};
 use polynomial::Polynomial;
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use tracing::info;
 
 use crate::{
     common::{CheckPrivateShares, Nonce, PolyCommitment, PublicNonce, Signature, SignatureShare},
@@ -137,12 +136,6 @@ impl Party {
             }
             self.group_key += comm.poly[0];
         }
-        info!(
-            "compute_secret: {} {} {}",
-            shares.len(),
-            polys.len(),
-            self.group_key
-        );
         if !bad_ids.is_empty() {
             return Err(DkgError::BadIds(bad_ids));
         }

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -130,14 +130,19 @@ impl Party {
         self.private_key = Scalar::zero();
         self.group_key = Point::zero();
 
-        let mut bad_ids = Vec::new();//: Vec<u32> = polys
+        let mut bad_ids = Vec::new(); //: Vec<u32> = polys
         for (i, comm) in polys.iter() {
             if !comm.verify() {
                 bad_ids.push(*i);
             }
             self.group_key += comm.poly[0];
         }
-        info!("compute_secret: {} {} {}", shares.len(), polys.len(), self.group_key);
+        info!(
+            "compute_secret: {} {} {}",
+            shares.len(),
+            polys.len(),
+            self.group_key
+        );
         if !bad_ids.is_empty() {
             return Err(DkgError::BadIds(bad_ids));
         }
@@ -331,11 +336,6 @@ impl traits::Aggregator for Aggregator {
 
     /// Initialize the Aggregator polynomial
     fn init(&mut self, comms: &HashMap<u32, PolyCommitment>) -> Result<(), AggregatorError> {
-        let len = self.num_keys.try_into().unwrap();
-        if comms.len() != len {
-            return Err(AggregatorError::BadPolyCommitmentLen(len, comms.len()));
-        }
-
         let mut bad_poly_commitments = Vec::new();
         for (_id, comm) in comms {
             if !comm.verify() {

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -3,7 +3,6 @@ use num_traits::{One, Zero};
 use polynomial::Polynomial;
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use tracing::info;
 
 use crate::{
     common::{Nonce, PolyCommitment, PublicNonce, Signature, SignatureShare},
@@ -146,7 +145,6 @@ impl Party {
         shares: &HashMap<u32, HashMap<u32, Scalar>>,
         comms: &HashMap<u32, PolyCommitment>,
     ) -> Result<(), DkgError> {
-        info!("compute_secret: {} {}", shares.len(), comms.len());
         let mut missing_shares = Vec::new();
         for key_id in &self.key_ids {
             if shares.get(key_id).is_none() {

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -466,7 +466,6 @@ impl traits::Signer for Party {
         for key_id in self.get_key_ids() {
             let mut shares = HashMap::new();
             for (signer_id, signer_shares) in private_shares.iter() {
-                println!("{signer_id} {}", key_id);
                 shares.insert(*signer_id, signer_shares[&key_id]);
             }
             key_shares.insert(key_id, shares);

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -133,7 +133,7 @@ impl Party {
     /// Get the shares of this party's private polynomial for all keys
     pub fn get_shares(&self) -> HashMap<u32, Scalar> {
         let mut shares = HashMap::new();
-        for i in 0..self.num_keys {
+        for i in 1..self.num_keys + 1 {
             shares.insert(i, self.f.eval(compute::id(i)));
         }
         shares
@@ -466,6 +466,7 @@ impl traits::Signer for Party {
         for key_id in self.get_key_ids() {
             let mut shares = HashMap::new();
             for (signer_id, signer_shares) in private_shares.iter() {
+                println!("{signer_id} {}", key_id);
                 shares.insert(*signer_id, signer_shares[&key_id]);
             }
             key_shares.insert(key_id, shares);

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -619,10 +619,10 @@ mod tests {
         let Nk: u32 = 10;
         let T: u32 = 7;
         let party_key_ids: Vec<Vec<u32>> = [
-            [0, 1, 2].to_vec(),
-            [3, 4].to_vec(),
-            [5, 6, 7].to_vec(),
-            [8, 9].to_vec(),
+            [1, 2, 3].to_vec(),
+            [4, 5].to_vec(),
+            [6, 7, 8].to_vec(),
+            [9, 10].to_vec(),
         ]
         .to_vec();
         let Np = party_key_ids.len().try_into().unwrap();


### PR DESCRIPTION
The previous PR make `DKG` robust against non-participation during the `DkgPublicShares` phase.  When the timeout hits, if the threshold is met we can continue to `DkgPrivateShares`.  But once the `DKG` set was chosen, all participants in that set had to complete `DkgEnd` or else `DKG` failed. 

This PR updates the timeout handler for `DkgEnd` to check and see if the threshold is met, and complete `DKG` if so.