### PR TITLE
Handle malicious DKG private shares

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsts"
-version = "7.0.0"
+version = "8.0.0"
 edition = "2021"
 authors = ["Joey Yandle <xoloki@gmail.com>"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ num-traits = "0.2"
 polynomial = { version = "0.2.5", features = ["serde"] }
 primitive-types = "0.12"
 rand_core = "0.6"
-p256k1 = { version = "6.0", default-features = false }
+p256k1 = { version = "7.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"
 thiserror = "1.0"

--- a/benches/v1_bench.rs
+++ b/benches/v1_bench.rs
@@ -1,4 +1,5 @@
 use wsts::common::test_helpers::gen_signer_ids;
+use wsts::traits::Aggregator;
 use wsts::v1;
 use wsts::v1::test_helpers::{dkg, sign};
 
@@ -67,14 +68,14 @@ pub fn bench_aggregator_sign(c: &mut Criterion) {
 
     let mut signers = signers[..(K * 3 / 4).try_into().unwrap()].to_vec();
 
-    let mut aggregator =
-        v1::SignatureAggregator::new(N, T, A.clone()).expect("aggregator ctor failed");
+    let mut aggregator = v1::Aggregator::new(N, T);
+    aggregator.init(&A).expect("aggregator init failed");
 
     let (nonces, sig_shares) = sign(&msg, &mut signers, &mut rng);
 
     let s = format!("v1 group sign N={} T={} K={}", N, T, K);
     c.bench_function(&s, |b| {
-        b.iter(|| aggregator.sign(&msg, &nonces, &sig_shares))
+        b.iter(|| aggregator.sign(&msg, &nonces, &sig_shares, &[]))
     });
 }
 

--- a/benches/v2_bench.rs
+++ b/benches/v2_bench.rs
@@ -1,4 +1,5 @@
 use wsts::common::test_helpers::gen_signer_ids;
+use wsts::traits::Aggregator;
 use wsts::v2;
 use wsts::v2::test_helpers::{dkg, sign};
 
@@ -93,8 +94,9 @@ pub fn bench_aggregator_sign(c: &mut Criterion) {
     };
 
     let mut signers = signers[..(K * 3 / 4).try_into().unwrap()].to_vec();
-    let mut aggregator =
-        v2::SignatureAggregator::new(N, T, A.clone()).expect("aggregator ctor failed");
+    let mut aggregator = v2::Aggregator::new(N, T);
+
+    aggregator.init(&A).expect("aggregator init failed");
 
     let (nonces, sig_shares, key_ids) = sign(&msg, &mut signers, &mut rng);
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -190,6 +190,7 @@ impl TupleProof {
         (self.z * G == self.R + s * A) && (self.z * B == self.rB + s * K)
     }
 
+    #[allow(non_snake_case)]
     fn challenge(A: &Point, B: &Point, K: &Point, R: &Point) -> Scalar {
         let mut hasher = Sha256::new();
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -157,7 +157,7 @@ pub struct TupleProof {
     pub R: Point,
     /// rB = r*B
     pub rB: Point,
-    /// z = a*s where s = H(G,A,B,K,R)
+    /// z = r + a*s where s = H(G,A,B,K,R) as per Fiat-Shamir
     pub z: Scalar,
 }
 
@@ -176,7 +176,7 @@ impl TupleProof {
         let s = Self::challenge(A, B, K, &R);
 
         Self {
-            R: r * G,
+            R,
             rB: r * B,
             z: r + a * s,
         }

--- a/src/common.rs
+++ b/src/common.rs
@@ -299,7 +299,7 @@ pub mod test_helpers {
 
         for i in 0..k {
             let mut pids = Vec::new();
-            for j in 0..m {
+            for j in 1..m + 1 {
                 pids.push(i * m + j);
             }
             ids.push(pids);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,8 +1,10 @@
+use hashbrown::HashMap;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::curve::{point::Error as PointError, scalar::Scalar};
 
-#[derive(Error, Debug, Clone)]
+#[derive(Error, Debug, Clone, Serialize, Deserialize, PartialEq)]
 /// Errors which can happen during distributed key generation
 pub enum DkgError {
     #[error("missing shares from {0:?}")]
@@ -28,7 +30,7 @@ impl From<PointError> for DkgError {
     }
 }
 
-#[derive(Error, Debug, Clone)]
+#[derive(Error, Debug, Clone, Serialize, Deserialize, PartialEq)]
 /// Errors which can happen during signature aggregation
 pub enum AggregatorError {
     #[error("bad poly commitment length (expected {0} got {1})")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,3 @@
-use hashbrown::HashMap;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -171,8 +171,15 @@ pub struct DkgPrivateShares {
     pub dkg_id: u64,
     /// Signer ID
     pub signer_id: u32,
-    /// List of (src_key_id, Map(dst_key_id, encrypted_share))
+    /// List of (src_party_id, Map(dst_key_id, encrypted_share))
     pub shares: Vec<(u32, HashMap<u32, Vec<u8>>)>,
+}
+
+impl DkgPrivateShares {
+    ///
+    pub fn verify() -> bool {
+        true
+    }
 }
 
 impl Signable for DkgPrivateShares {

--- a/src/net.rs
+++ b/src/net.rs
@@ -46,10 +46,10 @@ pub trait Signable {
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 ///
 pub struct BadPrivateShare {
-    src_party_id: u32,
-    dst_key_id: u32,
-    shared_key: Point,
-    tuple_proof: TupleProof,
+    ///
+    pub shared_key: Point,
+    ///
+    pub tuple_proof: TupleProof,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
@@ -64,7 +64,7 @@ pub enum DkgFailure {
     /// DKG private shares were missing from these signer_ids
     MissingPrivateShares(HashSet<u32>),
     /// DKG private shares were bad from these signer_ids
-    BadPrivateShares(HashMap<u32, Vec<BadPrivateShare>>),
+    BadPrivateShares(HashMap<u32, BadPrivateShare>),
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]

--- a/src/net.rs
+++ b/src/net.rs
@@ -6,7 +6,6 @@ use tracing::warn;
 use crate::{
     common::{MerkleRoot, PolyCommitment, PublicNonce, SignatureShare},
     curve::{ecdsa, scalar::Scalar},
-    errors::DkgError,
     state_machine::PublicKeys,
 };
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -4,8 +4,8 @@ use sha2::{Digest, Sha256};
 use tracing::warn;
 
 use crate::{
-    common::{MerkleRoot, PolyCommitment, PublicNonce, SignatureShare},
-    curve::{ecdsa, scalar::Scalar},
+    common::{MerkleRoot, PolyCommitment, PublicNonce, SignatureShare, TupleProof},
+    curve::{ecdsa, point::Point, scalar::Scalar},
     state_machine::PublicKeys,
 };
 
@@ -44,6 +44,15 @@ pub trait Signable {
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+///
+pub struct BadPrivateShare {
+    src_party_id: u32,
+    dst_key_id: u32,
+    shared_key: Point,
+    tuple_proof: TupleProof,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 /// Final DKG status after receiving public and private shares
 pub enum DkgFailure {
     /// Signer was in the wrong internal state to complete DKG
@@ -55,7 +64,7 @@ pub enum DkgFailure {
     /// DKG private shares were missing from these signer_ids
     MissingPrivateShares(HashSet<u32>),
     /// DKG private shares were bad from these signer_ids
-    BadPrivateShares(HashMap<u32, [u8; 32]>),
+    BadPrivateShares(HashMap<u32, Vec<BadPrivateShare>>),
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -534,31 +534,28 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
         if self.dkg_wait_signer_ids.is_empty() {
             // if there are any errors, mark signers malicious and retry
             for (signer_id, dkg_end) in &self.dkg_end_messages {
-                match &dkg_end.status {
-                    DkgStatus::Failure(dkg_failure) => {
-                        match dkg_failure {
-                            DkgFailure::BadState => {
-                                self.malicious_dkg_signer_ids.insert(*signer_id);
-                            }
-                            DkgFailure::BadPublicShares(bad_shares) => {
-                                // bad_shares is a set of signer_ids
-                                for bad_signer_id in bad_shares {
-                                    // TODO: verify public shares are bad
-                                    self.malicious_dkg_signer_ids.insert(*bad_signer_id);
-                                }
-                            }
-                            DkgFailure::BadPrivateShares(bad_shares) => {
-                                // bad_shares is a map of signer_id to shared secret
-                                for (bad_signer_id, _bad_private_share) in bad_shares {
-                                    // TODO: verify private shares are bad
-                                    self.malicious_dkg_signer_ids.insert(*bad_signer_id);
-                                }
-                            }
-                            _ => (),
+                if let DkgStatus::Failure(dkg_failure) = &dkg_end.status {
+                    match dkg_failure {
+                        DkgFailure::BadState => {
+                            self.malicious_dkg_signer_ids.insert(*signer_id);
                         }
-                        dkg_failures.insert(*signer_id, dkg_failure.clone());
+                        DkgFailure::BadPublicShares(bad_shares) => {
+                            // bad_shares is a set of signer_ids
+                            for bad_signer_id in bad_shares {
+                                // TODO: verify public shares are bad
+                                self.malicious_dkg_signer_ids.insert(*bad_signer_id);
+                            }
+                        }
+                        DkgFailure::BadPrivateShares(bad_shares) => {
+                            // bad_shares is a map of signer_id to shared secret
+                            for (bad_signer_id, _bad_private_share) in bad_shares {
+                                // TODO: verify private shares are bad
+                                self.malicious_dkg_signer_ids.insert(*bad_signer_id);
+                            }
+                        }
+                        _ => (),
                     }
-                    DkgStatus::Success => (),
+                    dkg_failures.insert(*signer_id, dkg_failure.clone());
                 }
             }
             if dkg_failures.is_empty() {

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -544,7 +544,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                             _ => (),
                         }
                     }
-                    _ => {}
+                    DkgStatus::Success => (),
                 }
             }
             if malicious_signers.is_empty() {

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -1159,13 +1159,14 @@ impl<Aggregator: AggregatorTrait> CoordinatorTrait for Coordinator<Aggregator> {
 pub mod test {
     use crate::{
         curve::{point::Point, scalar::Scalar},
-        net::Message,
+        net::{DkgPrivateShares, Message, Packet},
         state_machine::{
             coordinator::{
                 fire::Coordinator as FireCoordinator,
                 test::{
-                    coordinator_state_machine, feedback_messages, new_coordinator,
-                    process_inbound_messages, setup, setup_with_timeouts, start_dkg_round,
+                    coordinator_state_machine, feedback_messages, feedback_mutated_messages,
+                    new_coordinator, process_inbound_messages, setup, setup_with_timeouts,
+                    start_dkg_round,
                 },
                 Config, Coordinator as CoordinatorTrait, State,
             },
@@ -1175,6 +1176,7 @@ pub mod test {
         traits::{Aggregator as AggregatorTrait, Signer as SignerTrait},
         v1, v2,
     };
+    use hashbrown::HashMap;
     use rand_core::OsRng;
     use std::{thread, time::Duration};
 
@@ -1630,6 +1632,111 @@ pub mod test {
             },
             _ => panic!("Expected OperationResult::DkgError"),
         }
+    }
+
+    #[test]
+    fn malicious_signers_dkg_v1() {
+        malicious_signers_dkg::<v1::Aggregator, v1::Signer>(5, 2);
+    }
+
+    #[test]
+    fn malicious_signers_dkg_v2() {
+        malicious_signers_dkg::<v2::Aggregator, v2::Signer>(5, 2);
+    }
+
+    fn malicious_signers_dkg<Aggregator: AggregatorTrait, SignerType: SignerTrait>(
+        num_signers: u32,
+        keys_per_signer: u32,
+    ) -> (Vec<FireCoordinator<Aggregator>>, Vec<Signer<SignerType>>) {
+        let (mut coordinators, mut signers) =
+            setup::<FireCoordinator<Aggregator>, SignerType>(num_signers, keys_per_signer);
+
+        // We have started a dkg round
+        let message = coordinators.first_mut().unwrap().start_dkg_round().unwrap();
+        assert!(coordinators.first().unwrap().aggregate_public_key.is_none());
+        assert_eq!(coordinators.first().unwrap().state, State::DkgPublicGather);
+
+        // Send the DKG Begin message to all signers and gather responses by sharing with all other signers and coordinators
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &[message]);
+        assert!(operation_results.is_empty());
+        for coordinator in &coordinators {
+            assert_eq!(coordinator.state, State::DkgPrivateGather);
+        }
+
+        assert_eq!(outbound_messages.len(), 1);
+        match &outbound_messages[0].msg {
+            Message::DkgPrivateBegin(_) => {}
+            _ => {
+                panic!("Expected DkgPrivateBegin message");
+            }
+        }
+        // Send the DKG Private Begin message to all signers and share their responses with the coordinators and signers, but mutate one signer's DkgPrivateShares so it is marked malicious
+        let (outbound_messages, operation_results) = feedback_mutated_messages(
+            &mut coordinators,
+            &mut signers,
+            &outbound_messages,
+            |signer, msgs| {
+                if signer.signer_id == 0 {
+                    msgs.iter()
+                        .map(|packet| {
+                            if let Message::DkgPrivateShares(shares) = &packet.msg {
+                                // mutate one of the shares
+                                let sshares: Vec<(u32, HashMap<u32, Vec<u8>>)> = shares
+                                    .shares
+                                    .iter()
+                                    .map(|(src_party_id, share_map)| {
+                                        (
+                                            *src_party_id,
+                                            share_map
+                                                .iter()
+                                                .map(|(dst_key_id, bytes)| {
+                                                    let mut bytes = bytes.clone();
+                                                    bytes.insert(0, 234);
+                                                    (*dst_key_id, bytes)
+                                                })
+                                                .collect(),
+                                        )
+                                    })
+                                    .collect();
+
+                                Packet {
+                                    msg: Message::DkgPrivateShares(DkgPrivateShares {
+                                        dkg_id: shares.dkg_id,
+                                        signer_id: shares.signer_id,
+                                        shares: sshares.clone(),
+                                    }),
+                                    sig: vec![],
+                                }
+                            } else {
+                                packet.clone()
+                            }
+                        })
+                        .collect()
+                } else {
+                    msgs
+                }
+            },
+        );
+        assert_eq!(operation_results.len(), 0);
+        assert_eq!(outbound_messages.len(), 1);
+        match &outbound_messages[0].msg {
+            Message::DkgEndBegin(_) => {}
+            _ => {
+                panic!("Expected DkgEndBegin message");
+            }
+        }
+
+        // Send the DkgEndBegin message to all signers and share their responses with the coordinators and signers
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
+        assert_eq!(outbound_messages.len(), 0);
+        assert_eq!(operation_results.len(), 1);
+        match &operation_results[0] {
+            OperationResult::DkgError(_dkg_error) => {}
+            _ => panic!("Expected OperationResult::DkgError"),
+        }
+        (coordinators, signers)
     }
 
     #[test]

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -67,6 +67,7 @@ pub struct Coordinator<Aggregator: AggregatorTrait> {
     dkg_end_start: Option<Instant>,
     sign_start: Option<Instant>,
     malicious_signer_ids: HashSet<u32>,
+    malicious_dkg_signer_ids: HashSet<u32>,
 }
 
 impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
@@ -226,14 +227,14 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                     if let Message::DkgBegin(dkg_begin) = &packet.msg {
                         // Set the current sign id to one before the current message to ensure
                         // that we start the next round at the correct id. (Do this rather
-                        // then overwriting afterwards to ensure logging is accurate)
+                        // than overwriting afterwards to ensure logging is accurate)
                         self.current_dkg_id = dkg_begin.dkg_id.wrapping_sub(1);
                         let packet = self.start_dkg_round()?;
                         return Ok((Some(packet), None));
                     } else if let Message::NonceRequest(nonce_request) = &packet.msg {
                         // Set the current sign id to one before the current message to ensure
                         // that we start the next round at the correct id. (Do this rather
-                        // then overwriting afterwards to ensure logging is accurate)
+                        // than overwriting afterwards to ensure logging is accurate)
                         self.current_sign_id = nonce_request.sign_id.wrapping_sub(1);
                         self.current_sign_iter_id = nonce_request.sign_iter_id.wrapping_sub(1);
                         let packet = self.start_signing_round(
@@ -953,6 +954,7 @@ impl<Aggregator: AggregatorTrait> CoordinatorTrait for Coordinator<Aggregator> {
             nonce_start: None,
             sign_start: None,
             malicious_signer_ids: Default::default(),
+            malicious_dkg_signer_ids: Default::default(),
         }
     }
 

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -599,9 +599,8 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                                             let bytes = &key_shares[key_id];
                                             match decrypt(&shared_secret, bytes) {
                                                 Ok(plain) => match Scalar::try_from(&plain[..]) {
-                                                    Ok(private_share) => {
-                                                        // TODO: verify share is good by comparing to poly evaluated at key_id
-                                                        let f_key_id = match compute::poly(
+                                                    Ok(private_eval) => {
+                                                        let poly_eval = match compute::poly(
                                                             &compute::id(*key_id),
                                                             &poly.poly,
                                                         ) {
@@ -613,7 +612,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                                                             }
                                                         };
 
-                                                        if private_share * G != f_key_id {
+                                                        if private_eval * G != poly_eval {
                                                             warn!("Invalid dkg private share from signer_id {} to key_id {}", bad_signer_id, key_id);
 
                                                             is_bad = true;

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -273,7 +273,21 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                     return Ok((Some(packet), None));
                 }
                 State::DkgEndGather => {
-                    self.gather_dkg_end(packet)?;
+                    if let Err(error) = self.gather_dkg_end(packet) {
+                        match error {
+                            Error::DkgFailure(dkg_failures) => {
+                                return Ok((
+                                    None,
+                                    Some(OperationResult::DkgError(DkgError::DkgEndFailure(
+                                        dkg_failures,
+                                    ))),
+                                ));
+                            }
+                            _ => {
+                                return Err(error);
+                            }
+                        }
+                    }
                     if self.state == State::DkgEndGather {
                         // We need more data
                         return Ok((None, None));

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -532,6 +532,8 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
             }
         }
 
+        let mut dkg_failures = HashMap::new();
+
         if self.dkg_wait_signer_ids.is_empty() {
             // if there are any errors, mark signers malicious and retry
             for (signer_id, dkg_end) in &self.dkg_end_messages {
@@ -557,15 +559,16 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                             }
                             _ => (),
                         }
+                        dkg_failures.insert(*signer_id, dkg_failure.clone());
                     }
                     DkgStatus::Success => (),
                 }
             }
-            if self.malicious_dkg_signer_ids.is_empty() {
+            if dkg_failures.is_empty() {
                 self.dkg_end_gathered()?;
             } else {
-                // see if we have sufficient non-malicious signers to continue
-                todo!();
+                // TODO: see if we have sufficient non-malicious signers to continue
+                return Err(Error::DkgFailure(dkg_failures));
             }
         }
         Ok(())

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -274,18 +274,15 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                 }
                 State::DkgEndGather => {
                     if let Err(error) = self.gather_dkg_end(packet) {
-                        match error {
-                            Error::DkgFailure(dkg_failures) => {
-                                return Ok((
-                                    None,
-                                    Some(OperationResult::DkgError(DkgError::DkgEndFailure(
-                                        dkg_failures,
-                                    ))),
-                                ));
-                            }
-                            _ => {
-                                return Err(error);
-                            }
+                        if let Error::DkgFailure(dkg_failures) = error {
+                            return Ok((
+                                None,
+                                Some(OperationResult::DkgError(DkgError::DkgEndFailure(
+                                    dkg_failures,
+                                ))),
+                            ));
+                        } else {
+                            return Err(error);
                         }
                     }
                     if self.state == State::DkgEndGather {

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -594,7 +594,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                                         let _poly = &dkg_public_shares[src_party_id];
                                         for key_id in signer_key_ids {
                                             let bytes = &key_shares[key_id];
-                                            match decrypt(&shared_secret, &bytes) {
+                                            match decrypt(&shared_secret, bytes) {
                                                 Ok(plain) => match Scalar::try_from(&plain[..]) {
                                                     Ok(_s) => {
                                                         // TODO: verify share is good by comparing to poly evaluated at key_id

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -520,26 +520,25 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
 
         if self.dkg_wait_signer_ids.is_empty() {
             // if there are any errors, mark signers malicious and retry
-            let mut malicious_signers = HashSet::new();
             for (signer_id, dkg_end) in &self.dkg_end_messages {
                 match &dkg_end.status {
                     DkgStatus::Failure(dkg_failure) => {
                         match dkg_failure {
                             DkgFailure::BadState => {
-                                malicious_signers.insert(*signer_id);
+                                self.malicious_dkg_signer_ids.insert(*signer_id);
                             }
                             DkgFailure::BadPublicShares(bad_shares) => {
                                 // bad_shares is a set of signer_ids
                                 for bad_signer_id in bad_shares {
                                     // TODO: verify public shares are bad
-                                    malicious_signers.insert(*bad_signer_id);
+                                    self.malicious_dkg_signer_ids.insert(*bad_signer_id);
                                 }
                             }
                             DkgFailure::BadPrivateShares(bad_shares) => {
                                 // bad_shares is a map of signer_id to shared secret
-                                for (bad_signer_id, _shared_secret) in bad_shares {
+                                for (bad_signer_id, _bad_private_share) in bad_shares {
                                     // TODO: verify private shares are bad
-                                    malicious_signers.insert(*bad_signer_id);
+                                    self.malicious_dkg_signer_ids.insert(*bad_signer_id);
                                 }
                             }
                             _ => (),
@@ -548,7 +547,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                     DkgStatus::Success => (),
                 }
             }
-            if malicious_signers.is_empty() {
+            if self.malicious_dkg_signer_ids.is_empty() {
                 self.dkg_end_gathered()?;
             } else {
                 // see if we have sufficient non-malicious signers to continue

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     curve::{point::Point, scalar::Scalar},
     errors::AggregatorError,
     net::Packet,
-    state_machine::OperationResult,
+    state_machine::{DkgFailure, OperationResult},
 };
 use hashbrown::{HashMap, HashSet};
 use std::time::Duration;
@@ -71,6 +71,9 @@ pub enum Error {
     /// Missing message response information for a signing round
     #[error("Missing message nonce information")]
     MissingMessageNonceInfo,
+    /// DKG failure from signers
+    #[error("DKG failure from signers")]
+    DkgFailure(HashMap<u32, DkgFailure>),
 }
 
 impl From<AggregatorError> for Error {

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -107,6 +107,8 @@ pub struct Config {
     pub sign_timeout: Option<Duration>,
     /// map of signer_id to controlled key_ids
     pub signer_key_ids: HashMap<u32, HashSet<u32>>,
+    /// ECDSA public keys as Point objects indexed by signer_id
+    pub signer_public_keys: HashMap<u32, Point>,
 }
 
 impl Config {
@@ -129,6 +131,7 @@ impl Config {
             nonce_timeout: None,
             sign_timeout: None,
             signer_key_ids: Default::default(),
+            signer_public_keys: Default::default(),
         }
     }
 
@@ -146,6 +149,7 @@ impl Config {
         nonce_timeout: Option<Duration>,
         sign_timeout: Option<Duration>,
         signer_key_ids: HashMap<u32, HashSet<u32>>,
+        signer_public_keys: HashMap<u32, Point>,
     ) -> Self {
         Config {
             num_signers,
@@ -159,6 +163,7 @@ impl Config {
             nonce_timeout,
             sign_timeout,
             signer_key_ids,
+            signer_public_keys,
         }
     }
 }
@@ -386,8 +391,9 @@ pub mod test {
         let mut signer_ids_map = HashMap::new();
         let mut signer_key_ids = HashMap::new();
         let mut signer_key_ids_set = HashMap::new();
+        let mut signer_public_keys = HashMap::new();
         let mut key_ids_map = HashMap::new();
-        for (i, (_private_key, public_key)) in key_pairs.iter().enumerate() {
+        for (i, (private_key, public_key)) in key_pairs.iter().enumerate() {
             let mut key_ids = Vec::new();
             let mut key_ids_set = HashSet::new();
             for _ in 0..keys_per_signer {
@@ -399,6 +405,7 @@ pub mod test {
             signer_ids_map.insert(i as u32, *public_key);
             signer_key_ids.insert(i as u32, key_ids);
             signer_key_ids_set.insert(i as u32, key_ids_set);
+            signer_public_keys.insert(i as u32, Point::from(private_key));
         }
         let public_keys = PublicKeys {
             signers: signer_ids_map,
@@ -435,6 +442,7 @@ pub mod test {
                     nonce_timeout,
                     sign_timeout,
                     signer_key_ids_set.clone(),
+                    signer_public_keys.clone(),
                 );
                 Coordinator::new(config)
             })

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -456,6 +456,19 @@ pub mod test {
         signers: &mut [Signer<SignerType>],
         messages: &[Packet],
     ) -> (Vec<Packet>, Vec<OperationResult>) {
+        mutate_messages(coordinators, signers, messages, |_signer, msgs| msgs)
+    }
+    /// Helper function for feeding mutated messages back from the processor into the signing rounds and coordinators
+    pub fn mutate_messages<
+        Coordinator: CoordinatorTrait,
+        SignerType: SignerTrait,
+        F: FnOnce(&Signer<SignerType>, Vec<Message>) -> Vec<Message>,
+    >(
+        coordinators: &mut [Coordinator],
+        signers: &mut [Signer<SignerType>],
+        messages: &[Packet],
+        signer_mutator: F,
+    ) -> (Vec<Packet>, Vec<OperationResult>) {
         let mut inbound_messages = vec![];
         let mut feedback_messages = vec![];
         for signer in signers.iter_mut() {

--- a/src/state_machine/mod.rs
+++ b/src/state_machine/mod.rs
@@ -4,7 +4,8 @@ use thiserror::Error;
 use crate::{
     common::Signature,
     curve::{ecdsa, point::Point},
-    errors::{AggregatorError, DkgError as DkgCryptoError},
+    errors::AggregatorError,
+    net::DkgFailure,
     taproot::SchnorrProof,
 };
 
@@ -28,9 +29,9 @@ pub enum DkgError {
     /// DKG end timeout
     #[error("DKG end timeout, waiting for {0:?}")]
     DkgEndTimeout(Vec<u32>),
-    /// DKG crypto error
-    #[error("DKG crypto error")]
-    Crypto(#[from] DkgCryptoError),
+    /// DKG end failure
+    #[error("DKG end failure")]
+    DkgEndFailure(HashMap<u32, DkgFailure>),
 }
 
 /// Sign errors

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -338,22 +338,21 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                     // we've handled everything except BadShares and Point both of which should map to DkgFailure::BadPrivateShares
                     let mut bad_private_shares = HashMap::new();
                     for (_my_party_id, dkg_error) in dkg_error_map {
-                        match dkg_error {
-                            DkgError::BadShares(party_ids) => {
-                                for party_id in party_ids {
-                                    if let Some((party_signer_id, _shared_key)) =
-                                        &self.decryption_keys.get(&party_id)
-                                    {
-                                        bad_private_shares.insert(
-                                            *party_signer_id,
-                                            self.make_bad_private_share(*party_signer_id),
-                                        );
-                                    } else {
-                                        warn!("DkgError::BadShares from party_id {} but no (signer_id, shared_secret) cached", party_id);
-                                    }
+                        if let DkgError::BadShares(party_ids) = dkg_error {
+                            for party_id in party_ids {
+                                if let Some((party_signer_id, _shared_key)) =
+                                    &self.decryption_keys.get(&party_id)
+                                {
+                                    bad_private_shares.insert(
+                                        *party_signer_id,
+                                        self.make_bad_private_share(*party_signer_id),
+                                    );
+                                } else {
+                                    warn!("DkgError::BadShares from party_id {} but no (signer_id, shared_secret) cached", party_id);
                                 }
                             }
-                            _ => todo!(),
+                        } else {
+                            todo!();
                         }
                     }
                     DkgEnd {

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -344,7 +344,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                                         &self.decryption_keys.get(&party_id)
                                     {
                                         bad_private_shares
-                                            .insert(*party_signer_id, shared_secret.clone());
+                                            .insert(*party_signer_id, *shared_secret);
                                     } else {
                                         warn!("DkgError::BadShares from party_id {} but no (signer_id, shared_secret) cached", party_id);
                                     }

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -343,8 +343,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                                     if let Some((party_signer_id, shared_secret)) =
                                         &self.decryption_keys.get(&party_id)
                                     {
-                                        bad_private_shares
-                                            .insert(*party_signer_id, *shared_secret);
+                                        bad_private_shares.insert(*party_signer_id, *shared_secret);
                                     } else {
                                         warn!("DkgError::BadShares from party_id {} but no (signer_id, shared_secret) cached", party_id);
                                     }

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -341,7 +341,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                         match dkg_error {
                             DkgError::BadShares(party_ids) => {
                                 for party_id in party_ids {
-                                    if let Some((party_signer_id, shared_key)) =
+                                    if let Some((party_signer_id, _shared_key)) =
                                         &self.decryption_keys.get(&party_id)
                                     {
                                         bad_private_shares.insert(
@@ -721,6 +721,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
         Ok(vec![])
     }
 
+    #[allow(non_snake_case)]
     fn make_bad_private_share(&self, signer_id: u32) -> BadPrivateShare {
         let mut rng = OsRng;
         let a = self.network_private_key;

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -9,10 +9,11 @@ use crate::{
         point::{Compressed, Point},
         scalar::Scalar,
     },
+    errors::DkgError,
     net::{
-        DkgBegin, DkgEnd, DkgEndBegin, DkgPrivateBegin, DkgPrivateShares, DkgPublicShares,
-        DkgStatus, Message, NonceRequest, NonceResponse, Packet, Signable, SignatureShareRequest,
-        SignatureShareResponse,
+        DkgBegin, DkgEnd, DkgEndBegin, DkgFailure, DkgPrivateBegin, DkgPrivateShares,
+        DkgPublicShares, DkgStatus, Message, NonceRequest, NonceResponse, Packet, Signable,
+        SignatureShareRequest, SignatureShareResponse,
     },
     state_machine::{PublicKeys, StateMachine},
     traits::Signer as SignerTrait,
@@ -80,12 +81,17 @@ pub struct Signer<SignerType: SignerTrait> {
     pub signer_id: u32,
     /// the current state
     pub state: State,
-    /// map of party_id to the polynomial commitment for that party
+    /// map of polynomial commitments for each party
+    /// party_id => PolyCommitment
     pub commitments: HashMap<u32, PolyCommitment>,
     /// map of decrypted DKG private shares
+    /// src_party_id => (dst_key_id => private_share)
     pub decrypted_shares: HashMap<u32, HashMap<u32, Scalar>>,
+    /// shared secrets used to decrypt private shares
+    /// src_party_id => (signer_id, decryption key)
+    pub decryption_keys: HashMap<u32, (u32, [u8; 32])>,
     /// invalid private shares
-    pub invalid_private_shares: Vec<u32>,
+    pub invalid_private_shares: HashMap<u32, [u8; 32]>,
     /// public nonces for this signing round
     pub public_nonces: Vec<PublicNonce>,
     /// the private key used to sign messages sent over the network
@@ -138,8 +144,9 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             signer_id,
             state: State::Idle,
             commitments: Default::default(),
-            decrypted_shares: HashMap::new(),
-            invalid_private_shares: Vec::new(),
+            decrypted_shares: Default::default(),
+            decryption_keys: Default::default(),
+            invalid_private_shares: Default::default(),
             public_nonces: vec![],
             network_private_key,
             public_keys,
@@ -155,6 +162,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
         self.dkg_id = dkg_id;
         self.commitments.clear();
         self.decrypted_shares.clear();
+        self.decryption_keys.clear();
         self.invalid_private_shares.clear();
         self.public_nonces.clear();
         self.signer.reset_polys(rng);
@@ -260,18 +268,59 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             return Ok(Message::DkgEnd(DkgEnd {
                 dkg_id: self.dkg_id,
                 signer_id: self.signer_id,
-                status: DkgStatus::Failure("Bad state".to_string()),
+                status: DkgStatus::Failure(DkgFailure::BadState),
             }));
         }
 
         // only use the public shares from the DkgEndBegin signers
+        let mut missing_public_shares = HashSet::new();
+        let mut missing_private_shares = HashSet::new();
+        let mut bad_public_shares = HashSet::new();
         if let Some(dkg_end_begin) = &self.dkg_end_begin_msg {
             for signer_id in &dkg_end_begin.signer_ids {
-                let shares = &self.dkg_public_shares[signer_id];
-                for (party_id, comm) in shares.comms.iter() {
-                    self.commitments.insert(*party_id, comm.clone());
+                if let Some(shares) = self.dkg_public_shares.get(signer_id) {
+                    for (party_id, comm) in shares.comms.iter() {
+                        if !comm.verify() {
+                            bad_public_shares.insert(*signer_id);
+                        } else {
+                            self.commitments.insert(*party_id, comm.clone());
+                        }
+                    }
+                } else {
+                    missing_public_shares.insert(*signer_id);
+                }
+                if let Some(shares) = self.dkg_private_shares.get(signer_id) {
+                    // TODO: consider move private shares checks here
+                } else {
+                    missing_private_shares.insert(*signer_id);
                 }
             }
+        }
+
+        if !missing_public_shares.is_empty() {
+            return Ok(Message::DkgEnd(DkgEnd {
+                dkg_id: self.dkg_id,
+                signer_id: self.signer_id,
+                status: DkgStatus::Failure(DkgFailure::MissingPublicShares(missing_public_shares)),
+            }));
+        }
+
+        if !bad_public_shares.is_empty() {
+            return Ok(Message::DkgEnd(DkgEnd {
+                dkg_id: self.dkg_id,
+                signer_id: self.signer_id,
+                status: DkgStatus::Failure(DkgFailure::BadPublicShares(bad_public_shares)),
+            }));
+        }
+
+        if !missing_private_shares.is_empty() {
+            return Ok(Message::DkgEnd(DkgEnd {
+                dkg_id: self.dkg_id,
+                signer_id: self.signer_id,
+                status: DkgStatus::Failure(DkgFailure::MissingPrivateShares(
+                    missing_private_shares,
+                )),
+            }));
         }
 
         let dkg_end = if self.invalid_private_shares.is_empty() {
@@ -284,17 +333,25 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                     signer_id: self.signer_id,
                     status: DkgStatus::Success,
                 },
-                Err(dkg_error_map) => DkgEnd {
-                    dkg_id: self.dkg_id,
-                    signer_id: self.signer_id,
-                    status: DkgStatus::Failure(format!("{:?}", dkg_error_map)),
-                },
+                Err(dkg_error_map) => {
+                    // we've handled everything except BadShares and Point both of which should map to DkgFailure::BadPrivateShares
+                    let mut bad_private_shares = HashMap::new();
+                    DkgEnd {
+                        dkg_id: self.dkg_id,
+                        signer_id: self.signer_id,
+                        status: DkgStatus::Failure(DkgFailure::BadPrivateShares(
+                            bad_private_shares,
+                        )),
+                    }
+                }
             }
         } else {
             DkgEnd {
                 dkg_id: self.dkg_id,
                 signer_id: self.signer_id,
-                status: DkgStatus::Failure(format!("{:?}", self.invalid_private_shares)),
+                status: DkgStatus::Failure(DkgFailure::BadPrivateShares(
+                    self.invalid_private_shares.clone(),
+                )),
             }
         };
 
@@ -598,13 +655,13 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
         dkg_private_shares: &DkgPrivateShares,
     ) -> Result<Vec<Message>, Error> {
         // go ahead and decrypt here, since we know the signer_id and hence the pubkey of the sender
+        let src_signer_id = dkg_private_shares.signer_id;
         self.dkg_private_shares
-            .insert(dkg_private_shares.signer_id, dkg_private_shares.clone());
+            .insert(src_signer_id, dkg_private_shares.clone());
 
         // make a HashSet of our key_ids so we can quickly query them
         let key_ids: HashSet<u32> = self.signer.get_key_ids().into_iter().collect();
-        let compressed =
-            Compressed::from(self.public_keys.signers[&dkg_private_shares.signer_id].to_bytes());
+        let compressed = Compressed::from(self.public_keys.signers[&src_signer_id].to_bytes());
         let public_key = Point::try_from(&compressed).unwrap();
         let shared_secret = make_dkg_shared_secret(
             &self.network_private_key,
@@ -623,17 +680,21 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                             }
                             Err(e) => {
                                 warn!("Failed to parse Scalar for dkg private share from src_id {} to dst_id {}: {:?}", src_id, dst_key_id, e);
-                                self.invalid_private_shares.push(*src_id);
+                                self.invalid_private_shares
+                                    .insert(src_signer_id, shared_secret);
                             }
                         },
                         Err(e) => {
                             warn!("Failed to decrypt dkg private share from src_id {} to dst_id {}: {:?}", src_id, dst_key_id, e);
-                            self.invalid_private_shares.push(*src_id);
+                            self.invalid_private_shares
+                                .insert(src_signer_id, shared_secret);
                         }
                     }
                 }
             }
             self.decrypted_shares.insert(*src_id, decrypted_shares);
+            self.decryption_keys
+                .insert(*src_id, (dkg_private_shares.signer_id, shared_secret));
         }
         debug!(
             "received DkgPrivateShares from signer {} {}/{}",

--- a/src/util.rs
+++ b/src/util.rs
@@ -38,8 +38,23 @@ pub fn make_dkg_shared_secret(private_key: &Scalar, public_key: &Point, dkg_id: 
     let mut hasher = Sha256::new();
     let shared_key = private_key * public_key;
 
-    hasher.update("DH_SHARED_SECRET_KEY/".as_bytes());
+    hasher.update("DH_DKG_SHARED_SECRET_KEY/".as_bytes());
     hasher.update(shared_key.compress().as_bytes());
+    hasher.update(dkg_id.to_be_bytes());
+
+    let hash = hasher.finalize();
+    let mut bytes = [0u8; 32];
+
+    bytes.clone_from_slice(hash.as_slice());
+    bytes
+}
+
+/// Create a shared secret from the Diffie-Hellman shared key and DKG round ID
+pub fn make_dkg_shared_secret_from_key(dh_shared_key: &Point, dkg_id: u64) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+
+    hasher.update("DH_DKG_SHARED_SECRET_KEY/".as_bytes());
+    hasher.update(dh_shared_key.compress().as_bytes());
     hasher.update(dkg_id.to_be_bytes());
 
     let hash = hasher.finalize();

--- a/src/util.rs
+++ b/src/util.rs
@@ -18,13 +18,29 @@ pub fn hash_to_scalar(hasher: &mut Sha256) -> Scalar {
     Scalar::from(hash_bytes)
 }
 
-/// Do a Diffie-Hellman key exchange to create a shared secret from the passed private and public keys
+/// Do a Diffie-Hellman key exchange to create a shared secret from the passed private/public keys
 pub fn make_shared_secret(private_key: &Scalar, public_key: &Point) -> [u8; 32] {
     let mut hasher = Sha256::new();
     let shared_key = private_key * public_key;
 
     hasher.update("DH_SHARED_SECRET_KEY/".as_bytes());
     hasher.update(shared_key.compress().as_bytes());
+
+    let hash = hasher.finalize();
+    let mut bytes = [0u8; 32];
+
+    bytes.clone_from_slice(hash.as_slice());
+    bytes
+}
+
+/// Do a Diffie-Hellman key exchange to create a shared secret from the passed private/public keys and DKG round ID
+pub fn make_dkg_shared_secret(private_key: &Scalar, public_key: &Point, dkg_id: u64) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    let shared_key = private_key * public_key;
+
+    hasher.update("DH_SHARED_SECRET_KEY/".as_bytes());
+    hasher.update(shared_key.compress().as_bytes());
+    hasher.update(dkg_id.to_be_bytes());
 
     let hash = hasher.finalize();
     let mut bytes = [0u8; 32];
@@ -85,6 +101,24 @@ mod test {
 
         let xy = make_shared_secret(&x, &Y);
         let yx = make_shared_secret(&y, &X);
+
+        assert_eq!(xy, yx);
+    }
+
+    #[test]
+    #[allow(non_snake_case)]
+    fn test_dkg_shared_secret() {
+        let mut rng = OsRng;
+
+        let id = 12345u64;
+        let x = Scalar::random(&mut rng);
+        let y = Scalar::random(&mut rng);
+
+        let X = Point::from(x);
+        let Y = Point::from(y);
+
+        let xy = make_dkg_shared_secret(&x, &Y, id);
+        let yx = make_dkg_shared_secret(&y, &X, id);
 
         assert_eq!(xy, yx);
     }


### PR DESCRIPTION
In order to be able to automatically iterate on DKG rounds, we must be able to identify malicious signers who send bad DKG private shares.  This is non-trivial because the private shares are encrypted.  

This PR makes a number of changes to how signers return DKG error back to the coordinator, including sending the shared key with a validity proof for any bad DkgPublicShares.  This allows the coordinator to verify that the shares were bad without compromising any of the ECDSA signing keys themselves.
