### PR TITLE
Optimistically aggregate the group signature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsts"
-version = "8.0.0"
+version = "8.1.0"
 edition = "2021"
 authors = ["Joey Yandle <xoloki@gmail.com>"]
 license = "Apache-2.0"

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -118,6 +118,7 @@ pub fn id(i: u32) -> Scalar {
 }
 
 /// Evaluate the public polynomial `f` at scalar `x` using multi-exponentiation
+#[allow(clippy::ptr_arg)]
 pub fn poly(x: &Scalar, f: &Vec<Point>) -> Result<Point, PointError> {
     let mut s = Vec::with_capacity(f.len());
     let mut pow = Scalar::one();

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -516,7 +516,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
 
                 info!(
                     "Signer {} sending SignatureShareResponse for DKG round {} sign round {} sign iteration {}",
-                    signer_id, self.dkg_id, self.sign_id, self.sign_iter_id,
+                    signer_id, sign_request.dkg_id, sign_request.sign_id, sign_request.sign_iter_id,
                 );
 
                 let response = Message::SignatureShareResponse(response);

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -290,10 +290,8 @@ impl Aggregator {
         let tweaked_public_key = aggregate_public_key + tweak * G;
         let c = compute::challenge(&tweaked_public_key, &R, msg);
         let mut cx_sign = Scalar::one();
-        if tweak != &Scalar::zero() {
-            if !tweaked_public_key.has_even_y() {
-                cx_sign = -Scalar::one();
-            }
+        if tweak != &Scalar::zero() && !tweaked_public_key.has_even_y() {
+            cx_sign = -Scalar::one();
         }
 
         // optimistically try to create the aggregate signature without checking for bad keys or sig shares

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -322,7 +322,6 @@ impl Aggregator {
 
         let party_ids: Vec<u32> = sig_shares.iter().map(|ss| ss.id).collect();
         let (Rs, R) = compute::intermediate(msg, &party_ids, nonces);
-        let mut z = Scalar::zero();
         let mut bad_party_keys = Vec::new();
         let mut bad_party_sigs = Vec::new();
         let aggregate_public_key = self.poly[0];

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -284,17 +284,13 @@ impl Aggregator {
         }
 
         let party_ids: Vec<u32> = sig_shares.iter().map(|ss| ss.id).collect();
-        let (Rs, R) = compute::intermediate(msg, &party_ids, nonces);
+        let (_Rs, R) = compute::intermediate(msg, &party_ids, nonces);
         let mut z = Scalar::zero();
         let aggregate_public_key = self.poly[0];
         let tweaked_public_key = aggregate_public_key + tweak * G;
         let c = compute::challenge(&tweaked_public_key, &R, msg);
-        let mut r_sign = Scalar::one();
         let mut cx_sign = Scalar::one();
         if tweak != &Scalar::zero() {
-            if !R.has_even_y() {
-                r_sign = -Scalar::one();
-            }
             if !tweaked_public_key.has_even_y() {
                 cx_sign = -Scalar::one();
             }

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -341,13 +341,6 @@ impl Aggregator {
             }
         }
 
-        // optimistically try to create the aggregate signature without checking for bad keys or sig shares
-        for i in 0..sig_shares.len() {
-            z += sig_shares[i].z_i;
-        }
-
-        z += cx_sign * c * tweak;
-
         for i in 0..sig_shares.len() {
             let z_i = sig_shares[i].z_i;
             let mut cx = Point::zero();

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -269,7 +269,7 @@ pub struct Aggregator {
 }
 
 impl Aggregator {
-    /// Aggregate the party signatures
+    /// Aggregate the party signatures using a tweak
     #[allow(non_snake_case)]
     pub fn sign_with_tweak(
         &mut self,


### PR DESCRIPTION
One of the design principles of `FROST` is to optimize the performance of the protocol for the optimistic case where all participants are honest.  This is a good design choice for a cryptocurrency context, because dishonest participants can be readily identified, and sanctioned in ways to severely disincentivize such behavior.

Recently we have focused on performance of the signing part of the protocol, to allow for a large group signature (hundreds of parties controlling thousands of keys) in a matter of seconds.  This is necessary, for example, to enable 5 second block times in `PoS` style cryptocurrency systems, where all staked actors participate in a threshold signature over the block.

Prior to this PR, during the signature aggregation phase of signing we checked all signature shares before aggregation.  However, doing so involved many large multiexponentiations, with the number of such on the order of the number of parties, and the magnitude on the order of the threshold.   

If we think of the security properties of a `FROST`, or any `Schnorr` signature, we know that these include `soundness`, where a signature will fail validation with some computationally high probability if the parties making it do not have valid witnesses.  So to determine that a signature is valid, it is not necessary to check the individual signature shares; simply checking that the aggregate signature itself is valid will demonstrate this quite adequately.  

If the aggregate signature fails validation, it will still be necessary to check the signatures shares individually, in order to determine which actors are malicious.  But since aggregating and checking the group signature is computationally trivial, we lose nothing in the failure case, and improve our performance by multiple orders of magnitude in the optimistic case.  

Fixes #51 