### PR TITLE
feat: Implement net::Signable for net::Message

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -103,6 +103,23 @@ pub enum Message {
     SignatureShareResponse(SignatureShareResponse),
 }
 
+impl Signable for Message {
+    fn hash(&self, hasher: &mut Sha256) {
+        match self {
+            Message::DkgBegin(msg) => msg.hash(hasher),
+            Message::DkgPublicShares(msg) => msg.hash(hasher),
+            Message::DkgPrivateBegin(msg) => msg.hash(hasher),
+            Message::DkgPrivateShares(msg) => msg.hash(hasher),
+            Message::DkgEndBegin(msg) => msg.hash(hasher),
+            Message::DkgEnd(msg) => msg.hash(hasher),
+            Message::NonceRequest(msg) => msg.hash(hasher),
+            Message::NonceResponse(msg) => msg.hash(hasher),
+            Message::SignatureShareRequest(msg) => msg.hash(hasher),
+            Message::SignatureShareResponse(msg) => msg.hash(hasher),
+        }
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 /// DKG begin message from coordinator to signers
 pub struct DkgBegin {
@@ -903,5 +920,23 @@ mod test {
             &test_config.public_keys,
             &test_config.coordinator_public_key
         ));
+    }
+
+    #[test]
+    fn signature_share_response_wrapped_verify_msg() {
+        let test_config = TestConfig::default();
+
+        let signature_share_response = SignatureShareResponse {
+            dkg_id: 0,
+            sign_id: 0,
+            sign_iter_id: 0,
+            signer_id: 0,
+            signature_shares: vec![],
+        };
+        let msg = Message::SignatureShareResponse(signature_share_response.clone());
+        let sig = msg
+            .sign(&test_config.coordinator_private_key)
+            .expect("Failed to sign");
+        assert!(msg.verify(&sig, &test_config.coordinator_public_key));
     }
 }

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -282,48 +282,9 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             let outbounds = self.process(&message.msg)?;
             for out in outbounds {
                 let msg = Packet {
-                    sig: match &out {
-                        Message::DkgBegin(msg) => msg
-                            .sign(&self.network_private_key)
-                            .expect("failed to sign DkgBegin")
-                            .to_vec(),
-                        Message::DkgPrivateBegin(msg) => msg
-                            .sign(&self.network_private_key)
-                            .expect("failed to sign DkgPrivateBegin")
-                            .to_vec(),
-                        Message::DkgEndBegin(msg) => msg
-                            .sign(&self.network_private_key)
-                            .expect("failed to sign DkgEndBegin")
-                            .to_vec(),
-                        Message::DkgEnd(msg) => msg
-                            .sign(&self.network_private_key)
-                            .expect("failed to sign DkgEnd")
-                            .to_vec(),
-                        Message::DkgPublicShares(msg) => msg
-                            .sign(&self.network_private_key)
-                            .expect("failed to sign DkgPublicShares")
-                            .to_vec(),
-                        Message::DkgPrivateShares(msg) => msg
-                            .sign(&self.network_private_key)
-                            .expect("failed to sign DkgPrivateShare")
-                            .to_vec(),
-                        Message::NonceRequest(msg) => msg
-                            .sign(&self.network_private_key)
-                            .expect("failed to sign NonceRequest")
-                            .to_vec(),
-                        Message::NonceResponse(msg) => msg
-                            .sign(&self.network_private_key)
-                            .expect("failed to sign NonceResponse")
-                            .to_vec(),
-                        Message::SignatureShareRequest(msg) => msg
-                            .sign(&self.network_private_key)
-                            .expect("failed to sign SignShareRequest")
-                            .to_vec(),
-                        Message::SignatureShareResponse(msg) => msg
-                            .sign(&self.network_private_key)
-                            .expect("failed to sign SignShareResponse")
-                            .to_vec(),
-                    },
+                    sig: out
+                        .sign(&self.network_private_key)
+                        .expect("Failed to sign message"),
                     msg: out,
                 };
                 responses.push(msg);


### PR DESCRIPTION
Closes #64 

This PR does two things:

1. It implements `net::Signable` for `net::Message` as advertised.
2. It simplifies the signing logic in `state_machine/signer/mod.rs` given the new `net::Signable` implementation

We could potentially do some simplification for the verification logic as well, but it's not as trivial since we verify different packet types against different public keys.