### PR TITLE
Check length of polynomials

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsts"
-version = "9.1.0"
+version = "9.1.1"
 edition = "2021"
 authors = ["Joey Yandle <xoloki@gmail.com>"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsts"
-version = "9.1.1"
+version = "9.2.0"
 edition = "2021"
 authors = ["Joey Yandle <xoloki@gmail.com>"]
 license = "Apache-2.0"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -13,7 +13,7 @@ pub enum DkgError {
     /// The private shares which were missing
     MissingPrivateShares(Vec<u32>),
     #[error("bad public shares {0:?}")]
-    /// The bad public shares that failed to verify
+    /// The public shares that failed to verify or were the wrong size
     BadPublicShares(Vec<u32>),
     #[error("not enough shares {0:?}")]
     /// Not enough shares to complete DKG
@@ -36,10 +36,10 @@ impl From<PointError> for DkgError {
 /// Errors which can happen during signature aggregation
 pub enum AggregatorError {
     #[error("bad poly commitment length (expected {0} got {1})")]
-    /// The polynomial commitment was the wrong size
+    /// The polynomial commitment was the wrong size (unused)
     BadPolyCommitmentLen(usize, usize),
     #[error("bad poly commitments {0:?}")]
-    /// The polynomial commitments which failed verification
+    /// The polynomial commitments which failed verification or was the wrong size
     BadPolyCommitments(Vec<Scalar>),
     #[error("bad nonce length (expected {0} got {1}")]
     /// The nonce length was the wrong size

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -36,10 +36,10 @@ impl From<PointError> for DkgError {
 /// Errors which can happen during signature aggregation
 pub enum AggregatorError {
     #[error("bad poly commitment length (expected {0} got {1})")]
-    /// The polynomial commitment was the wrong size (unused)
+    /// The number of polynomial commitments was wrong (no longer used)
     BadPolyCommitmentLen(usize, usize),
     #[error("bad poly commitments {0:?}")]
-    /// The polynomial commitments which failed verification or was the wrong size
+    /// The polynomial commitments which failed verification or were the wrong size
     BadPolyCommitments(Vec<Scalar>),
     #[error("bad nonce length (expected {0} got {1}")]
     /// The nonce length was the wrong size

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -2025,7 +2025,7 @@ pub mod test {
         assert_eq!(operation_results.len(), 1);
         match &operation_results[0] {
             OperationResult::DkgError(dkg_error) => {
-                // we mutated the private shares themselves, so we should see a BadPrivateShares from signer_id 0
+                // we mutated the public shares themselves, so we should see a BadPublicShares from signer_ids 0 and 1
                 match dkg_error {
                     DkgError::DkgEndFailure(failure_map) => {
                         for (_signer_id, dkg_failure) in failure_map {

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -1958,7 +1958,7 @@ pub mod test {
             &mut signers,
             &[message],
             |signer, msgs| {
-                if signer.signer_id == 0 {
+                if signer.signer_id == 0 || signer.signer_id == 1 {
                     msgs.iter()
                         .map(|packet| {
                             if let Message::DkgPublicShares(shares) = &packet.msg {
@@ -1967,7 +1967,11 @@ pub mod test {
                                     .iter()
                                     .map(|(id, comm)| {
                                         let mut c = comm.clone();
-                                        c.poly.push(Point::new());
+					if signer.signer_id == 0 {
+                                            c.poly.push(Point::new());
+					} else {
+					    c.poly.pop();
+					}
                                         (*id, c)
                                     })
                                     .collect();
@@ -2028,7 +2032,7 @@ pub mod test {
                             match dkg_failure {
                                 DkgFailure::BadPublicShares(bad_shares) => {
                                     for bad_signer_id in bad_shares {
-                                        assert_eq!(*bad_signer_id, 0u32);
+                                        assert!(*bad_signer_id == 0u32 || *bad_signer_id == 1u32);
                                     }
                                 }
                                 _ => panic!("Expected DkgFailure::BadPublicShares"),

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -1952,7 +1952,7 @@ pub mod test {
         assert!(coordinators.first().unwrap().aggregate_public_key.is_none());
         assert_eq!(coordinators.first().unwrap().state, State::DkgPublicGather);
 
-        // Send the DkgBegin message to all signers and share their responses with the coordinators and signers, but mutate two signer's DkgPublicShares: make one polynomial larger than the threshold, and the other smaller
+        // Send the DkgBegin message to all signers and share their responses with the coordinators and signers, but mutate two signers' DkgPublicShares: make one polynomial larger than the threshold, and the other smaller
         let (outbound_messages, operation_results) = feedback_mutated_messages(
             &mut coordinators,
             &mut signers,

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -1240,7 +1240,9 @@ impl<Aggregator: AggregatorTrait> CoordinatorTrait for Coordinator<Aggregator> {
 pub mod test {
     use crate::{
         curve::{point::Point, scalar::Scalar},
-        net::{DkgBegin, DkgFailure, DkgPrivateShares, Message, NonceRequest, Packet},
+        net::{
+            DkgBegin, DkgFailure, DkgPrivateShares, DkgPublicShares, Message, NonceRequest, Packet,
+        },
         state_machine::{
             coordinator::{
                 fire::Coordinator as FireCoordinator,
@@ -1917,6 +1919,119 @@ pub mod test {
                                     }
                                 }
                                 _ => panic!("Expected DkgFailure::BadPrivateShares"),
+                            }
+                        }
+                    }
+                    _ => panic!("Expected DkgError::DkgEndFailure"),
+                }
+            }
+            _ => panic!("Expected OperationResult::DkgError"),
+        }
+        (coordinators, signers)
+    }
+
+    #[test]
+    fn bad_poly_length_dkg_v1() {
+        bad_poly_length_dkg::<v1::Aggregator, v1::Signer>(5, 2);
+    }
+
+    #[test]
+    fn bad_poly_length_dkg_v2() {
+        bad_poly_length_dkg::<v2::Aggregator, v2::Signer>(5, 2);
+    }
+
+    fn bad_poly_length_dkg<Aggregator: AggregatorTrait, SignerType: SignerTrait>(
+        num_signers: u32,
+        keys_per_signer: u32,
+    ) -> (Vec<FireCoordinator<Aggregator>>, Vec<Signer<SignerType>>) {
+        let (mut coordinators, mut signers) =
+            setup::<FireCoordinator<Aggregator>, SignerType>(num_signers, keys_per_signer);
+
+        // We have started a dkg round
+        let message = coordinators.first_mut().unwrap().start_dkg_round().unwrap();
+        assert!(coordinators.first().unwrap().aggregate_public_key.is_none());
+        assert_eq!(coordinators.first().unwrap().state, State::DkgPublicGather);
+
+        // Send the DkgBegin message to all signers and share their responses with the coordinators and signers, but mutate one signer's DkgPublicShares so it is marked malicious
+        let (outbound_messages, operation_results) = feedback_mutated_messages(
+            &mut coordinators,
+            &mut signers,
+            &[message],
+            |signer, msgs| {
+                if signer.signer_id == 0 {
+                    msgs.iter()
+                        .map(|packet| {
+                            if let Message::DkgPublicShares(shares) = &packet.msg {
+                                let comms = shares
+                                    .comms
+                                    .iter()
+                                    .map(|(id, comm)| {
+                                        let mut c = comm.clone();
+                                        c.poly.push(Point::new());
+                                        (*id, c)
+                                    })
+                                    .collect();
+                                Packet {
+                                    msg: Message::DkgPublicShares(DkgPublicShares {
+                                        dkg_id: shares.dkg_id,
+                                        signer_id: shares.signer_id,
+                                        comms,
+                                    }),
+                                    sig: vec![],
+                                }
+                            } else {
+                                packet.clone()
+                            }
+                        })
+                        .collect()
+                } else {
+                    msgs
+                }
+            },
+        );
+
+        assert!(operation_results.is_empty());
+        for coordinator in &coordinators {
+            assert_eq!(coordinator.state, State::DkgPrivateGather);
+        }
+
+        assert_eq!(outbound_messages.len(), 1);
+        match &outbound_messages[0].msg {
+            Message::DkgPrivateBegin(_) => {}
+            _ => {
+                panic!("Expected DkgPrivateBegin message");
+            }
+        }
+
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
+        assert_eq!(operation_results.len(), 0);
+        assert_eq!(outbound_messages.len(), 1);
+        match &outbound_messages[0].msg {
+            Message::DkgEndBegin(_) => {}
+            _ => {
+                panic!("Expected DkgEndBegin message");
+            }
+        }
+
+        // Send the DkgEndBegin message to all signers and share their responses with the coordinators and signers
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
+        assert_eq!(outbound_messages.len(), 0);
+        assert_eq!(operation_results.len(), 1);
+        match &operation_results[0] {
+            OperationResult::DkgError(dkg_error) => {
+                // we mutated the private shares themselves, so we should see a BadPrivateShares from signer_id 0
+                match dkg_error {
+                    DkgError::DkgEndFailure(failure_map) => {
+                        for (_signer_id, dkg_failure) in failure_map {
+                            match dkg_failure {
+                                DkgFailure::BadPublicShares(bad_shares) => {
+                                    for bad_signer_id in bad_shares {
+                                        assert_eq!(*bad_signer_id, 0u32);
+                                    }
+                                }
+                                _ => panic!("Expected DkgFailure::BadPublicShares"),
                             }
                         }
                     }

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -1952,7 +1952,7 @@ pub mod test {
         assert!(coordinators.first().unwrap().aggregate_public_key.is_none());
         assert_eq!(coordinators.first().unwrap().state, State::DkgPublicGather);
 
-        // Send the DkgBegin message to all signers and share their responses with the coordinators and signers, but mutate one signer's DkgPublicShares so it is marked malicious
+        // Send the DkgBegin message to all signers and share their responses with the coordinators and signers, but mutate two signer's DkgPublicShares: make one polynomial larger than the threshold, and the other smaller
         let (outbound_messages, operation_results) = feedback_mutated_messages(
             &mut coordinators,
             &mut signers,

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -1967,11 +1967,11 @@ pub mod test {
                                     .iter()
                                     .map(|(id, comm)| {
                                         let mut c = comm.clone();
-					if signer.signer_id == 0 {
+                                        if signer.signer_id == 0 {
                                             c.poly.push(Point::new());
-					} else {
-					    c.poly.pop();
-					}
+                                        } else {
+                                            c.poly.pop();
+                                        }
                                         (*id, c)
                                     })
                                     .collect();

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -343,7 +343,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             for signer_id in &dkg_end_begin.signer_ids {
                 if let Some(shares) = self.dkg_public_shares.get(signer_id) {
                     for (party_id, comm) in shares.comms.iter() {
-                        if !comm.verify() {
+                        if comm.poly.len() != self.threshold.try_into().unwrap() || !comm.verify() {
                             bad_public_shares.insert(*signer_id);
                         } else {
                             self.commitments.insert(*party_id, comm.clone());

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -154,7 +154,7 @@ pub mod test_helpers {
     use crate::{common::PolyCommitment, errors::DkgError};
 
     #[allow(non_snake_case)]
-    /// Remove the provided key ids from the list of private shares and execute compute secrets
+    /// Run DKG on the passed signers
     pub fn dkg<RNG: RngCore + CryptoRng, Signer: super::Signer>(
         signers: &mut [Signer],
         rng: &mut RNG,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -276,9 +276,8 @@ pub mod test_helpers {
             })
             .collect();
 
-        match dkg(&mut signers, &mut rng) {
-            Ok(_) => panic!("DKG should have failed"),
-            _ => (),
+        if let Ok(_) = dkg(&mut signers, &mut rng) {
+            panic!("DKG should have failed")
         }
 
         let polys: HashMap<u32, PolyCommitment> = signers

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -257,7 +257,7 @@ pub mod test_helpers {
     }
 
     #[allow(non_snake_case)]
-    /// Run compute secrets test to trigger NotEnoughShares code path
+    /// Check that bad polynomial lengths are properly caught as errors
     pub fn bad_polynomial_length<Signer: super::Signer, Aggregator: super::Aggregator>() {
         let Nk: u32 = 10;
         let Np: u32 = 4;
@@ -290,7 +290,7 @@ pub mod test_helpers {
         match aggregator.init(&polys) {
             Ok(_) => panic!("Aggregator::init should not have succeeded"),
             Err(e) => match e {
-                crate::traits::AggregatorError::BadPolyCommitments(_) => (),
+                super::AggregatorError::BadPolyCommitments(_) => (),
                 _ => panic!("Should have failed with BadPolyCommitments"),
             },
         }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -276,7 +276,7 @@ pub mod test_helpers {
             })
             .collect();
 
-        if let Ok(_) = dkg(&mut signers, &mut rng) {
+        if dkg(&mut signers, &mut rng).is_ok() {
             panic!("DKG should have failed")
         }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -153,7 +153,6 @@ pub mod test_helpers {
 
     use crate::{common::PolyCommitment, errors::DkgError};
 
-    #[allow(non_snake_case)]
     /// Run DKG on the passed signers
     pub fn dkg<RNG: RngCore + CryptoRng, Signer: super::Signer>(
         signers: &mut [Signer],
@@ -188,7 +187,6 @@ pub mod test_helpers {
         }
     }
 
-    #[allow(non_snake_case)]
     /// Remove the provided key ids from the list of private shares and execute compute secrets
     fn compute_secrets_not_enough_shares<RNG: RngCore + CryptoRng, Signer: super::Signer>(
         signers: &mut [Signer],

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -256,18 +256,24 @@ pub mod test_helpers {
 
     #[allow(non_snake_case)]
     /// Check that bad polynomial lengths are properly caught as errors
-    pub fn bad_polynomial_length<Signer: super::Signer, Aggregator: super::Aggregator>() {
+    pub fn bad_polynomial_length<
+        Signer: super::Signer,
+        Aggregator: super::Aggregator,
+        F: Fn(u32) -> u32,
+    >(
+        func: F,
+    ) {
         let Nk: u32 = 10;
         let Np: u32 = 4;
         let T: u32 = 7;
-        let signer_ids: Vec<Vec<u32>> = vec![vec![1, 2, 3], vec![4, 5], vec![6, 7, 8, 9], vec![10]];
+        let signer_ids: Vec<Vec<u32>> = vec![vec![1, 2, 3, 4], vec![5, 6, 7], vec![8, 9], vec![10]];
         let mut rng = OsRng;
         let mut signers: Vec<Signer> = signer_ids
             .iter()
             .enumerate()
             .map(|(id, ids)| {
                 if *ids == vec![10] {
-                    Signer::new(id.try_into().unwrap(), ids, Nk, Np, T - 1, &mut rng)
+                    Signer::new(id.try_into().unwrap(), ids, Nk, Np, func(T), &mut rng)
                 } else {
                     Signer::new(id.try_into().unwrap(), ids, Nk, Np, T, &mut rng)
                 }

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -698,6 +698,7 @@ pub mod test_helpers {
 
 #[cfg(test)]
 mod tests {
+    use crate::traits;
     use crate::traits::test_helpers::run_compute_secrets_not_enough_shares;
     use crate::traits::{Aggregator, Signer};
     use crate::v1;
@@ -802,7 +803,7 @@ mod tests {
             .map(|(id, ids)| v1::Signer::new(id.try_into().unwrap(), ids, N, T, &mut rng))
             .collect();
 
-        let comms = match v1::test_helpers::dkg(&mut signers, &mut rng) {
+        let comms = match traits::test_helpers::dkg(&mut signers, &mut rng) {
             Ok(comms) => comms,
             Err(secret_errors) => {
                 panic!("Got secret errors from DKG: {:?}", secret_errors);
@@ -827,5 +828,12 @@ mod tests {
     /// Run a distributed key generation round with not enough shares
     pub fn run_compute_secrets_missing_shares() {
         run_compute_secrets_not_enough_shares::<v1::Signer>()
+    }
+
+    #[allow(non_snake_case)]
+    #[test]
+    /// Run DKG and aggregator init with a bad polynomial
+    pub fn bad_polynomial_length() {
+        traits::test_helpers::bad_polynomial_length::<v1::Signer, v1::Aggregator>()
     }
 }

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -834,6 +834,9 @@ mod tests {
     #[test]
     /// Run DKG and aggregator init with a bad polynomial
     pub fn bad_polynomial_length() {
-        traits::test_helpers::bad_polynomial_length::<v1::Signer, v1::Aggregator>()
+        let gt = |t| t + 1;
+        let lt = |t| t + 1;
+        traits::test_helpers::bad_polynomial_length::<v1::Signer, v1::Aggregator, _>(gt);
+        traits::test_helpers::bad_polynomial_length::<v1::Signer, v1::Aggregator, _>(lt);
     }
 }

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -835,7 +835,7 @@ mod tests {
     /// Run DKG and aggregator init with a bad polynomial
     pub fn bad_polynomial_length() {
         let gt = |t| t + 1;
-        let lt = |t| t + 1;
+        let lt = |t| t - 1;
         traits::test_helpers::bad_polynomial_length::<v1::Signer, v1::Aggregator, _>(gt);
         traits::test_helpers::bad_polynomial_length::<v1::Signer, v1::Aggregator, _>(lt);
     }

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -636,7 +636,7 @@ pub mod test_helpers {
 #[cfg(test)]
 mod tests {
     use crate::{
-        traits::{test_helpers::run_compute_secrets_not_enough_shares, Aggregator, Signer},
+        traits::{self, test_helpers::run_compute_secrets_not_enough_shares, Aggregator, Signer},
         v2,
     };
 
@@ -696,7 +696,7 @@ mod tests {
             .map(|(pid, pkids)| v2::Party::new(pid.try_into().unwrap(), pkids, Np, Nk, T, &mut rng))
             .collect();
 
-        let comms = match v2::test_helpers::dkg(&mut signers, &mut rng) {
+        let comms = match traits::test_helpers::dkg(&mut signers, &mut rng) {
             Ok(comms) => comms,
             Err(secret_errors) => {
                 panic!("Got secret errors from DKG: {:?}", secret_errors);
@@ -722,5 +722,12 @@ mod tests {
     /// Run a distributed key generation round with not enough shares
     pub fn run_compute_secrets_missing_shares() {
         run_compute_secrets_not_enough_shares::<v2::Signer>()
+    }
+
+    #[allow(non_snake_case)]
+    #[test]
+    /// Run DKG and aggregator init with a bad polynomial
+    pub fn bad_polynomial_length() {
+        traits::test_helpers::bad_polynomial_length::<v2::Signer, v2::Aggregator>()
     }
 }

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -728,7 +728,7 @@ mod tests {
     /// Run DKG and aggregator init with a bad polynomial
     pub fn bad_polynomial_length() {
         let gt = |t| t + 1;
-        let lt = |t| t + 1;
+        let lt = |t| t - 1;
         traits::test_helpers::bad_polynomial_length::<v2::Signer, v2::Aggregator, _>(gt);
         traits::test_helpers::bad_polynomial_length::<v2::Signer, v2::Aggregator, _>(lt);
     }


### PR DESCRIPTION
This change fixes a DoS that results from incorrectly sized polynomials.  A polynomial that is too large will result in signatures that fail to verify, and one that is too small will lead to a `panic` when initializing the signature aggregator.

Fixes #87 