### PR TITLE
Add copyright/license section to README.md with a disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,19 @@ This crate uses the Bitcoin ```secp256k1``` curve.  But since the C ```libsecp25
 
 - [wsts crate docs in GitHub](https://trust-machines.github.io/wsts/wsts)
 - [WSTS Paper](https://trust-machines.github.io/wsts/wsts.pdf)
+
+## Copyright and License
+
+Copyright 2022-2024, Nassau Machines Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0)
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
As an interim step until we get a full bug bounty supported security policy, this change adds a copyright/license section to README.md, with an appropriate disclaimer.