### PR TITLE
Keep polynomial constant parameters during DKG

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsts"
-version = "9.2.0"
+version = "10.0.0"
 edition = "2021"
 authors = ["Joey Yandle <xoloki@gmail.com>"]
 license = "Apache-2.0"

--- a/src/common.rs
+++ b/src/common.rs
@@ -22,6 +22,28 @@ use crate::{
 /// A merkle root is a 256 bit hash
 pub type MerkleRoot = [u8; 32];
 
+/// A Polynomial where the parameters are not necessarily the same type as the args
+pub struct Polynomial<Param, Arg> {
+    /// parameters for the polynomial
+    pub data: Vec<Param>,
+    _x: std::marker::PhantomData<Arg>,
+}
+
+impl<
+        Param: Clone + Zero + Add + std::ops::AddAssign<<Arg as std::ops::Mul<Param>>::Output>,
+        Arg: Clone + std::ops::Mul<Param>,
+    > Polynomial<Param, Arg>
+{
+    /// evaluate the polynomial with the passed arg
+    pub fn eval(&self, x: Arg) -> Param {
+        let mut ret = Param::zero();
+        for i in 0..self.data.len() {
+            ret += x.clone() * self.data[i].clone();
+        }
+        ret
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 /// A commitment to a polynonial, with a Schnorr proof of ownership bound to the ID
 pub struct PolyCommitment {

--- a/src/common.rs
+++ b/src/common.rs
@@ -456,43 +456,43 @@ pub mod test {
         let n = 16u32;
 
         let poly = super::Polynomial::<Scalar, Scalar>::random(n - 1, &mut rng);
-        let params = poly.params.clone();
-        let y = poly.eval(Scalar::from(1));
+        let x = Scalar::from(8);
+        let y = poly.eval(x);
         let mut z = Scalar::zero();
+        let mut pow = Scalar::from(1);
         for i in 0..poly.params.len() {
-            z += poly.params[i];
+            z += pow * poly.params[i];
+            pow *= x;
         }
         assert_eq!(y, z);
 
-        let a = poly.eval(Scalar::from(8));
-        let b = compute::private_poly(Scalar::from(8), &params);
-        assert_eq!(a, b);
-
-        let public_params = params.iter().map(|p| p * G).collect::<Vec<Point>>();
+        let public_params = poly.params.iter().map(|p| p * G).collect::<Vec<Point>>();
         let public_poly: super::Polynomial<Point, Scalar> =
             super::Polynomial::new(public_params.clone());
-        let a = poly.eval(Scalar::from(8));
-        let b = public_poly.eval(Scalar::from(8));
+        let a = poly.eval(x);
+        let b = public_poly.eval(x);
         assert_eq!(a * G, b);
 
         let mul_poly = poly * G;
-        let m = mul_poly.eval(Scalar::from(8));
-        assert_eq!(a * G, m);
+        let b = mul_poly.eval(x);
+        assert_eq!(a * G, b);
 
-        let b = compute::poly(&Scalar::from(8), &public_params);
+        let b = compute::poly(&x, &public_params);
         assert_eq!(a * G, b.unwrap());
 
         let poly = super::Polynomial::random(n - 1, &mut rng);
         let params = poly.params.clone();
-        let y = poly.eval(Scalar::from(1));
+        let y = poly.eval(x);
         let mut z = Point::zero();
+        let mut pow = Scalar::from(1);
         for i in 0..poly.params.len() {
-            z += poly.params[i];
+            z += pow * poly.params[i];
+            pow *= x;
         }
         assert_eq!(y, z);
 
-        let a = poly.eval(Scalar::from(8));
-        let b = compute::poly(&Scalar::from(8), &params);
+        let a = poly.eval(x);
+        let b = compute::poly(&x, &params);
         assert_eq!(a, b.unwrap());
     }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -84,11 +84,16 @@ impl<
     pub fn len(&self) -> usize {
         self.params.len()
     }
+
+    /// is the length of the polynomial zero
+    pub fn is_empty(&self) -> bool {
+        self.params.is_empty()
+    }
 }
 
 impl<Param, Arg> Index<usize> for Polynomial<Param, Arg> {
     type Output = Param;
-    fn index<'a>(&'a self, i: usize) -> &'a Param {
+    fn index(&self, i: usize) -> &Param {
         &self.params[i]
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -35,14 +35,14 @@ impl<
     > Polynomial<Param, Arg>
 {
     /*
-       /// evaluate the polynomial with the passed arg
-       pub fn new<RNG: RngCore + CryptoRng>(n: usize, rng: &RNG) -> Self {
+    /// construct new random polynomial of the specified size
+    pub fn random<RNG: RngCore + CryptoRng>(n: usize, rng: &RNG) -> Self {
        let data = (0..n).map(|_| Param::random(rng)).collect::<Vec<Param>>();
        Self {
            data,
            _x: std::marker::PhantomData,
        }
-       }
+    }
     */
     /// construct new polynomial from passed params
     pub fn new(params: Vec<Param>) -> Self {

--- a/src/common.rs
+++ b/src/common.rs
@@ -284,7 +284,7 @@ pub struct TupleProof {
     pub R: Point,
     /// rB = r*B = b*R
     pub rB: Point,
-    /// z = r + a*c where c = H(G,A,B,K,R) as per Fiat-Shamir
+    /// z = r + c*a where c = H(G,A,B,K,R) as per Fiat-Shamir
     pub z: Scalar,
 }
 
@@ -305,7 +305,7 @@ impl TupleProof {
         Self {
             R,
             rB: r * B,
-            z: r + a * c,
+            z: r + c * a,
         }
     }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -52,9 +52,9 @@ impl<
         Arg: Clone + One + Mul<Param> + MulAssign,
     > Polynomial<Param, Arg>
 {
-    /// construct new random polynomial of the specified size
+    /// construct new random polynomial of the specified degree
     pub fn random<RNG: RngCore + CryptoRng>(n: usize, rng: &mut RNG) -> Self {
-        let params = (0..n).map(|_| Param::fill(rng)).collect::<Vec<Param>>();
+        let params = (0..n + 1).map(|_| Param::fill(rng)).collect::<Vec<Param>>();
         Self {
             params,
             _x: std::marker::PhantomData,

--- a/src/common.rs
+++ b/src/common.rs
@@ -98,6 +98,26 @@ impl<Param, Arg> Index<usize> for Polynomial<Param, Arg> {
     }
 }
 
+impl<Param, Arg, Operand, OpResult> Mul<Operand> for &Polynomial<Param, Arg>
+where
+    Param: Clone
+        + Zero
+        + Random
+        + Add
+        + AddAssign<<Arg as Mul<Param>>::Output>
+        + Mul<Operand, Output = OpResult>,
+    Arg: Clone + One + Mul<OpResult> + Mul<Param> + MulAssign,
+    Operand: Clone,
+    OpResult: Clone + Zero + Random + Add + AddAssign<<Arg as Mul<OpResult>>::Output>,
+    Vec<OpResult>: FromIterator<<Param as Mul<Operand>>::Output>,
+{
+    type Output = Polynomial<OpResult, Arg>;
+    fn mul(self, x: Operand) -> Self::Output {
+        let params: Vec<OpResult> = self.params.iter().map(|p| p.clone() * x.clone()).collect();
+        Polynomial::new(params)
+    }
+}
+
 impl<Param, Arg, Operand, OpResult> Mul<Operand> for Polynomial<Param, Arg>
 where
     Param: Clone

--- a/src/common.rs
+++ b/src/common.rs
@@ -98,16 +98,22 @@ impl<Param, Arg> Index<usize> for Polynomial<Param, Arg> {
     }
 }
 
-impl<Param, Arg, T> Mul<T> for Polynomial<Param, Arg>
+impl<Param, Arg, Operand, OpResult> Mul<Operand> for Polynomial<Param, Arg>
 where
-    Param: Clone + Zero + Random + Add + AddAssign<<Arg as Mul<Param>>::Output> + Mul<T>,
-    Arg: Clone + One + Mul<T> + Mul<Param> + MulAssign,
-    T: Clone + Zero + Random + Add + AddAssign<<Arg as Mul<T>>::Output>,
-    Vec<T>: FromIterator<<Param as Mul<T>>::Output>,
+    Param: Clone
+        + Zero
+        + Random
+        + Add
+        + AddAssign<<Arg as Mul<Param>>::Output>
+        + Mul<Operand, Output = OpResult>,
+    Arg: Clone + One + Mul<OpResult> + Mul<Param> + MulAssign,
+    Operand: Clone,
+    OpResult: Clone + Zero + Random + Add + AddAssign<<Arg as Mul<OpResult>>::Output>,
+    Vec<OpResult>: FromIterator<<Param as Mul<Operand>>::Output>,
 {
-    type Output = Polynomial<T, Arg>;
-    fn mul(self, x: T) -> Self::Output {
-        let params: Vec<T> = self.params.iter().map(|p| p.clone() * x.clone()).collect();
+    type Output = Polynomial<OpResult, Arg>;
+    fn mul(self, x: Operand) -> Self::Output {
+        let params: Vec<OpResult> = self.params.iter().map(|p| p.clone() * x.clone()).collect();
         Polynomial::new(params)
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -48,10 +48,10 @@ pub struct Polynomial<Param, Arg> {
     _x: std::marker::PhantomData<Arg>,
 }
 
-impl<
-        Param: Clone + Zero + Random + Add + AddAssign<<Arg as Mul<Param>>::Output>,
-        Arg: Clone + One + Mul<Param> + MulAssign,
-    > Polynomial<Param, Arg>
+impl<Param, Arg> Polynomial<Param, Arg>
+where
+    Param: Clone + Zero + Random + Add + AddAssign<<Arg as Mul<Param>>::Output>,
+    Arg: Clone + One + Mul<Param> + MulAssign,
 {
     /// construct new random polynomial of the specified degree
     pub fn random<RNG: RngCore + CryptoRng>(n: u32, rng: &mut RNG) -> Self {

--- a/src/common.rs
+++ b/src/common.rs
@@ -397,10 +397,8 @@ pub mod test {
         let mut rng = OsRng;
         let n = 16usize;
 
-        let params = (0..n)
-            .map(|_| Scalar::random(&mut rng))
-            .collect::<Vec<Scalar>>();
-        let poly = super::Polynomial::new(params.clone());
+        let poly = super::Polynomial::<Scalar, Scalar>::random(n - 1, &mut rng);
+        let params = poly.params.clone();
         let y = poly.eval(Scalar::from(1));
         let mut z = Scalar::zero();
         for i in 0..poly.params.len() {
@@ -422,10 +420,8 @@ pub mod test {
         let b = compute::poly(&Scalar::from(8), &public_params);
         assert_eq!(a * G, b.unwrap());
 
-        let params = (0..n)
-            .map(|_| Point::from(Scalar::random(&mut rng)))
-            .collect::<Vec<Point>>();
-        let poly = super::Polynomial::new(params.clone());
+        let poly = super::Polynomial::random(n - 1, &mut rng);
+        let params = poly.params.clone();
         let y = poly.eval(Scalar::from(1));
         let mut z = Point::zero();
         for i in 0..poly.params.len() {

--- a/src/common.rs
+++ b/src/common.rs
@@ -22,6 +22,24 @@ use crate::{
 /// A merkle root is a 256 bit hash
 pub type MerkleRoot = [u8; 32];
 
+/// A trait that allows us to create random instances of implementors
+pub trait Random {
+    /// Create a new instance with random data
+    fn fill<RNG: RngCore + CryptoRng>(rng: &mut RNG) -> Self;
+}
+
+impl Random for Point {
+    fn fill<RNG: RngCore + CryptoRng>(rng: &mut RNG) -> Self {
+        Point::from(Scalar::random(rng))
+    }
+}
+
+impl Random for Scalar {
+    fn fill<RNG: RngCore + CryptoRng>(rng: &mut RNG) -> Self {
+        Scalar::random(rng)
+    }
+}
+
 /// A Polynomial where the parameters are not necessarily the same type as the args
 pub struct Polynomial<Param, Arg> {
     /// parameters for the polynomial
@@ -30,20 +48,19 @@ pub struct Polynomial<Param, Arg> {
 }
 
 impl<
-        Param: Clone + Zero + Add + AddAssign<<Arg as Mul<Param>>::Output>,
+        Param: Clone + Zero + Random + Add + AddAssign<<Arg as Mul<Param>>::Output>,
         Arg: Clone + One + Mul<Param> + MulAssign,
     > Polynomial<Param, Arg>
 {
-    /*
     /// construct new random polynomial of the specified size
-    pub fn random<RNG: RngCore + CryptoRng>(n: usize, rng: &RNG) -> Self {
-       let data = (0..n).map(|_| Param::random(rng)).collect::<Vec<Param>>();
-       Self {
-           data,
-           _x: std::marker::PhantomData,
-       }
+    pub fn random<RNG: RngCore + CryptoRng>(n: usize, rng: &mut RNG) -> Self {
+        let params = (0..n).map(|_| Param::fill(rng)).collect::<Vec<Param>>();
+        Self {
+            params,
+            _x: std::marker::PhantomData,
+        }
     }
-    */
+
     /// construct new polynomial from passed params
     pub fn new(params: Vec<Param>) -> Self {
         Self {

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,6 @@
 use core::{
     fmt::{Debug, Display, Formatter, Result as FmtResult},
-    ops::Add,
+    ops::{Add, AddAssign, Mul},
 };
 use hashbrown::HashMap;
 use num_traits::{One, Zero};
@@ -30,25 +30,34 @@ pub struct Polynomial<Param, Arg> {
 }
 
 impl<
-        Param: Clone + Zero + Add + std::ops::AddAssign<<Arg as std::ops::Mul<Param>>::Output>,
-        Arg: Clone + std::ops::Mul<Param>,
+        Param: Clone + Zero + Add + AddAssign<<Arg as Mul<Param>>::Output>,
+        Arg: Clone + Mul<Param>,
     > Polynomial<Param, Arg>
 {
     /*
-        /// evaluate the polynomial with the passed arg
-        pub fn new<RNG: RngCore + CryptoRng>(n: usize, rng: &RNG) -> Self {
-        let data = (0..n).map(|_| Param::random(rng)).collect::<Vec<Param>>();
+       /// evaluate the polynomial with the passed arg
+       pub fn new<RNG: RngCore + CryptoRng>(n: usize, rng: &RNG) -> Self {
+       let data = (0..n).map(|_| Param::random(rng)).collect::<Vec<Param>>();
+       Self {
+           data,
+           _x: std::marker::PhantomData,
+       }
+       }
+    */
+    /// construct new polynomial from passed params
+    pub fn new(params: Vec<Param>) -> Self {
         Self {
-            data,
+            params,
             _x: std::marker::PhantomData,
         }
-        }
-    */
+    }
     /// evaluate the polynomial with the passed arg
     pub fn eval(&self, x: Arg) -> Param {
+        //let mut pow = Scalar::one();
         let mut ret = Param::zero();
         for i in 0..self.params.len() {
             ret += x.clone() * self.params[i].clone();
+            //pow *= x.clone();
         }
         ret
     }
@@ -353,49 +362,56 @@ pub mod test_helpers {
 
 #[cfg(test)]
 pub mod test {
-    use num_traits::Zero;
+    //use num_traits::Zero;
     use rand_core::OsRng;
 
     use crate::{
         common::TupleProof,
+        //compute,
         curve::{point::Point, scalar::Scalar},
     };
 
     #[test]
     #[allow(non_snake_case)]
     fn polynomial() {
-        let mut rng = OsRng;
-        let n = 16usize;
+        /*
+            let mut rng = OsRng;
+            let n = 16usize;
 
-        let params = (0..n)
-            .map(|_| Scalar::random(&mut rng))
-            .collect::<Vec<Scalar>>();
-        let poly = super::Polynomial {
-            params,
-            _x: std::marker::PhantomData,
-        };
+            let params = (0..n)
+                .map(|_| Scalar::random(&mut rng))
+                .collect::<Vec<Scalar>>();
+            let poly = super::Polynomial::new(params.clone());
+            let y = poly.eval(Scalar::from(1));
+            let mut z = Scalar::zero();
+            for i in 0..poly.params.len() {
+                z += poly.params[i];
+            }
+            assert_eq!(y, z);
 
-        let y = poly.eval(Scalar::from(1));
-        let mut z = Scalar::zero();
-        for i in 0..poly.params.len() {
-            z += poly.params[i];
-        }
-        assert_eq!(y, z);
+        let b = compute::private_poly(Scalar::from(8), &params);
+        assert_eq!(y, b);
 
-        let params = (0..n)
-            .map(|_| Point::from(Scalar::random(&mut rng)))
-            .collect::<Vec<Point>>();
-        let poly = super::Polynomial {
-            params,
-            _x: std::marker::PhantomData,
-        };
+            let public_params = params.iter().map(|p| p * G).collect::<Vec<Point>>();
+            let public_poly: super::Polynomial<Point, Scalar> = super::Polynomial::new(public_params.clone());
+        let a = poly.eval(Scalar::from(8));
+        let b = public_poly.eval(Scalar::from(8));
+        assert_eq!(a * G, b);
 
-        let y = poly.eval(Scalar::from(1));
-        let mut z = Point::zero();
-        for i in 0..poly.params.len() {
-            z += poly.params[i];
-        }
-        assert_eq!(y, z);
+        let b = compute::poly(&Scalar::from(8), &public_params);
+        assert_eq!(a * G, b.unwrap());
+
+            let params = (0..n)
+                .map(|_| Point::from(Scalar::random(&mut rng)))
+                .collect::<Vec<Point>>();
+            let poly = super::Polynomial::new(params);
+            let y = poly.eval(Scalar::from(1));
+            let mut z = Point::zero();
+            for i in 0..poly.params.len() {
+                z += poly.params[i];
+            }
+            assert_eq!(y, z);
+        */
     }
 
     #[test]

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -184,7 +184,6 @@ pub fn merkle_root(data: &[u8]) -> [u8; 32] {
 
 #[cfg(test)]
 pub mod test {
-    //use num_traits::Zero;
     use rand_core::OsRng;
 
     use crate::{

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -130,6 +130,16 @@ pub fn poly(x: &Scalar, f: &Vec<Point>) -> Result<Point, PointError> {
     Point::multimult(s, f.clone())
 }
 
+/// Evaluate the public polynomial `f` at scalar `x` using multi-exponentiation
+#[allow(clippy::ptr_arg)]
+pub fn private_poly(x: Scalar, f: &Vec<Scalar>) -> Scalar {
+    let mut sum = Scalar::zero();
+    for i in 0..f.len() {
+        sum += x * f[i];
+    }
+    sum
+}
+
 /// Create a BIP340 compliant tagged hash by double hashing the tag
 pub fn tagged_hash(tag: &str) -> Sha256 {
     let mut hasher = Sha256::new();

--- a/src/net.rs
+++ b/src/net.rs
@@ -125,6 +125,8 @@ impl Signable for Message {
 pub struct DkgBegin {
     /// DKG round ID
     pub dkg_id: u64,
+    /// Keep the constant factor so DKG will produce the same key
+    pub keep_constant: bool,
 }
 
 impl Signable for DkgBegin {

--- a/src/net.rs
+++ b/src/net.rs
@@ -134,7 +134,7 @@ impl Signable for DkgBegin {
         let keep_constant = if self.keep_constant { [1u8] } else { [0u8] };
         hasher.update("DKG_BEGIN".as_bytes());
         hasher.update(self.dkg_id.to_be_bytes());
-        hasher.update(&keep_constant);
+        hasher.update(keep_constant);
     }
 }
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -131,8 +131,10 @@ pub struct DkgBegin {
 
 impl Signable for DkgBegin {
     fn hash(&self, hasher: &mut Sha256) {
+        let keep_constant = if self.keep_constant { [1u8] } else { [0u8] };
         hasher.update("DKG_BEGIN".as_bytes());
         hasher.update(self.dkg_id.to_be_bytes());
+        hasher.update(&keep_constant);
     }
 }
 
@@ -631,7 +633,10 @@ mod test {
     #[test]
     fn dkg_begin_verify_msg() {
         let test_config = TestConfig::default();
-        let dkg_begin = DkgBegin { dkg_id: 0 };
+        let dkg_begin = DkgBegin {
+            dkg_id: 0,
+            keep_constant: false,
+        };
         let dkg_private_begin = DkgPrivateBegin {
             dkg_id: 0,
             key_ids: Default::default(),

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -2697,7 +2697,10 @@ pub mod test {
             let (packets, results) = coordinator
                 .process_inbound_messages(&[Packet {
                     sig: vec![],
-                    msg: Message::DkgBegin(DkgBegin { dkg_id: old_id }),
+                    msg: Message::DkgBegin(DkgBegin {
+                        dkg_id: old_id,
+                        keep_constant: false,
+                    }),
                 }])
                 .unwrap();
             assert!(packets.is_empty());
@@ -2709,7 +2712,10 @@ pub mod test {
             let (packets, results) = coordinator
                 .process_inbound_messages(&[Packet {
                     sig: vec![],
-                    msg: Message::DkgBegin(DkgBegin { dkg_id: id }),
+                    msg: Message::DkgBegin(DkgBegin {
+                        dkg_id: id,
+                        keep_constant: false,
+                    }),
                 }])
                 .unwrap();
             assert!(packets.is_empty());

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -363,6 +363,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
         );
         let dkg_begin = DkgBegin {
             dkg_id: self.current_dkg_id,
+            keep_constant: false,
         };
         let dkg_begin_packet = Packet {
             sig: dkg_begin

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -249,10 +249,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                     return Ok((None, None));
                 }
                 State::DkgPublicDistribute => {
-                    // XXX does this ever happen? start_dkg_round should call start_public_shares
-                    //panic!("Got message in DkgPublicDistribute");
-                    let packet = self.start_public_shares(false)?;
-                    return Ok((Some(packet), None));
+                    return Err(Error::BadStateChange("should never be in ephemeral DkgPublicDistribute during process_message loop".to_string()));
                 }
                 State::DkgPublicGather => {
                     self.gather_public_shares(packet)?;

--- a/src/state_machine/coordinator/frost.rs
+++ b/src/state_machine/coordinator/frost.rs
@@ -889,7 +889,10 @@ pub mod test {
         let (packets, results) = coordinator
             .process_inbound_messages(&[Packet {
                 sig: vec![],
-                msg: Message::DkgBegin(DkgBegin { dkg_id: old_id }),
+                msg: Message::DkgBegin(DkgBegin {
+                    dkg_id: old_id,
+                    keep_constant: false,
+                }),
             }])
             .unwrap();
         assert!(packets.is_empty());
@@ -901,7 +904,10 @@ pub mod test {
         let (packets, results) = coordinator
             .process_inbound_messages(&[Packet {
                 sig: vec![],
-                msg: Message::DkgBegin(DkgBegin { dkg_id: id }),
+                msg: Message::DkgBegin(DkgBegin {
+                    dkg_id: id,
+                    keep_constant: false,
+                }),
             }])
             .unwrap();
         assert!(packets.is_empty());

--- a/src/state_machine/coordinator/frost.rs
+++ b/src/state_machine/coordinator/frost.rs
@@ -69,7 +69,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                         // that we start the next round at the correct id. (Do this rather
                         // then overwriting afterwards to ensure logging is accurate)
                         self.current_dkg_id = dkg_begin.dkg_id.wrapping_sub(1);
-                        let packet = self.start_dkg_round()?;
+                        let packet = self.start_dkg_round(dkg_begin.keep_constant)?;
                         return Ok((Some(packet), None));
                     } else if let Message::NonceRequest(nonce_request) = &packet.msg {
                         if self.current_sign_id >= nonce_request.sign_id {
@@ -91,7 +91,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                     return Ok((None, None));
                 }
                 State::DkgPublicDistribute => {
-                    let packet = self.start_public_shares()?;
+                    let packet = self.start_public_shares(false)?;
                     return Ok((Some(packet), None));
                 }
                 State::DkgPublicGather => {
@@ -184,7 +184,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
     }
 
     /// Ask signers to send DKG public shares
-    pub fn start_public_shares(&mut self) -> Result<Packet, Error> {
+    pub fn start_public_shares(&mut self, keep_constant: bool) -> Result<Packet, Error> {
         self.dkg_public_shares.clear();
         self.party_polynomials.clear();
         self.ids_to_await = (0..self.config.num_signers).collect();
@@ -194,7 +194,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
         );
         let dkg_begin = DkgBegin {
             dkg_id: self.current_dkg_id,
-            keep_constant: false,
+            keep_constant,
         };
 
         let dkg_begin_packet = Packet {
@@ -716,11 +716,11 @@ impl<Aggregator: AggregatorTrait> CoordinatorTrait for Coordinator<Aggregator> {
     }
 
     /// Start a DKG round
-    fn start_dkg_round(&mut self) -> Result<Packet, Error> {
+    fn start_dkg_round(&mut self, keep_constant: bool) -> Result<Packet, Error> {
         self.current_dkg_id = self.current_dkg_id.wrapping_add(1);
         info!("Starting DKG round {}", self.current_dkg_id);
         self.move_to(State::DkgPublicDistribute)?;
-        self.start_public_shares()
+        self.start_public_shares(keep_constant)
     }
 
     /// Start a signing round
@@ -827,7 +827,7 @@ pub mod test {
 
         coordinator.state = State::DkgPublicDistribute; // Must be in this state before calling start public shares
 
-        let result = coordinator.start_public_shares().unwrap();
+        let result = coordinator.start_public_shares(false).unwrap();
 
         assert!(matches!(result.msg, Message::DkgBegin(_)));
         assert_eq!(coordinator.get_state(), State::DkgPublicGather);

--- a/src/state_machine/coordinator/frost.rs
+++ b/src/state_machine/coordinator/frost.rs
@@ -194,6 +194,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
         );
         let dkg_begin = DkgBegin {
             dkg_id: self.current_dkg_id,
+            keep_constant: false,
         };
 
         let dkg_begin_packet = Packet {

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -280,7 +280,7 @@ pub trait Coordinator: Clone + Debug + PartialEq {
     fn get_state(&self) -> State;
 
     /// Trigger a DKG round
-    fn start_dkg_round(&mut self) -> Result<Packet, Error>;
+    fn start_dkg_round(&mut self, keep_constant: bool) -> Result<Packet, Error>;
 
     /// Trigger a signing round
     fn start_signing_round(
@@ -415,7 +415,7 @@ pub mod test {
         let mut rng = OsRng;
         let config = Config::new(10, 40, 28, Scalar::random(&mut rng));
         let mut coordinator = Coordinator::new(config);
-        let result = coordinator.start_dkg_round();
+        let result = coordinator.start_dkg_round(false);
 
         assert!(result.is_ok());
         if let Message::DkgBegin(dkg_begin) = result.unwrap().msg {
@@ -593,7 +593,11 @@ pub mod test {
             setup::<Coordinator, SignerType>(num_signers, keys_per_signer);
 
         // We have started a dkg round
-        let message = coordinators.first_mut().unwrap().start_dkg_round().unwrap();
+        let message = coordinators
+            .first_mut()
+            .unwrap()
+            .start_dkg_round(false)
+            .unwrap();
         assert!(coordinators
             .first_mut()
             .unwrap()

--- a/src/state_machine/mod.rs
+++ b/src/state_machine/mod.rs
@@ -51,6 +51,7 @@ pub enum SignError {
 }
 
 /// Result of a DKG or sign operation
+#[derive(Debug, Clone)]
 pub enum OperationResult {
     /// DKG succeeded with the wrapped public key
     Dkg(Point),

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -260,14 +260,14 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
     }
 
     /// Reset internal state
-    pub fn reset<T: RngCore + CryptoRng>(&mut self, dkg_id: u64, rng: &mut T) {
+    pub fn reset<T: RngCore + CryptoRng>(&mut self, dkg_id: u64, keep_constant: bool, rng: &mut T) {
         self.dkg_id = dkg_id;
         self.commitments.clear();
         self.decrypted_shares.clear();
         self.decryption_keys.clear();
         self.invalid_private_shares.clear();
         self.public_nonces.clear();
-        self.signer.reset_polys(rng);
+        self.signer.reset_polys(keep_constant, rng);
         self.dkg_public_shares.clear();
         self.dkg_private_shares.clear();
         self.dkg_private_begin_msg = None;
@@ -594,7 +594,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
     fn dkg_begin(&mut self, dkg_begin: &DkgBegin) -> Result<Vec<Message>, Error> {
         let mut rng = OsRng;
 
-        self.reset(dkg_begin.dkg_id, &mut rng);
+        self.reset(dkg_begin.dkg_id, dkg_begin.keep_constant, &mut rng);
         self.move_to(State::DkgPublicDistribute)?;
 
         //let _party_state = self.signer.save();

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -935,7 +935,10 @@ pub mod test {
         assert!(!signer.can_dkg_end());
 
         // meet the conditions for DKG_END
-        let dkg_begin = Message::DkgBegin(DkgBegin { dkg_id: 1 });
+        let dkg_begin = Message::DkgBegin(DkgBegin {
+            dkg_id: 1,
+            keep_constant: false,
+        });
         let dkg_public_shares = signer
             .process(&dkg_begin)
             .expect("failed to process DkgBegin");

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,6 +1,5 @@
 use core::{cmp::PartialEq, fmt::Debug};
 use hashbrown::HashMap;
-use polynomial::Polynomial;
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
@@ -15,7 +14,7 @@ use crate::{
 /// The saved state required to reconstruct a party
 pub struct PartyState {
     /// The party's private polynomial
-    pub polynomial: Option<Polynomial<Scalar>>,
+    pub polynomial: Option<Vec<Scalar>>,
     /// The key IDS and associate private keys for this party
     pub private_keys: Vec<(u32, Scalar)>,
     /// The nonce being used by this party
@@ -72,7 +71,7 @@ pub trait Signer: Clone + Debug + PartialEq {
     fn get_poly_commitments<RNG: RngCore + CryptoRng>(&self, rng: &mut RNG) -> Vec<PolyCommitment>;
 
     /// Reset all polynomials for this signer
-    fn reset_polys<RNG: RngCore + CryptoRng>(&mut self, rng: &mut RNG);
+    fn reset_polys<RNG: RngCore + CryptoRng>(&mut self, keep_constant: bool, rng: &mut RNG);
 
     /// Clear all polynomials for this signer
     fn clear_polys(&mut self);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -298,4 +298,33 @@ pub mod test_helpers {
             },
         }
     }
+
+    /// Check that the keep_constant param of reset_polys works
+    pub fn reset_polys<Signer: super::Signer>() {
+        let mut rng = OsRng;
+        let id = 1;
+        let key_ids = [1, 2, 3];
+        let n: u32 = 10;
+        let n_p = 4;
+        let t: u32 = 7;
+
+        let mut signer = Signer::new(id, &key_ids, n, n_p, t, &mut rng);
+        let comms0 = signer.get_poly_commitments(&mut rng);
+
+        signer.reset_polys(false, &mut rng);
+
+        let comms1 = signer.get_poly_commitments(&mut rng);
+
+        for (comm0, comm1) in comms0.into_iter().zip(comms1.clone()) {
+            assert!(comm0.poly[0] != comm1.poly[0]);
+        }
+
+        signer.reset_polys(true, &mut rng);
+
+        let comms2 = signer.get_poly_commitments(&mut rng);
+
+        for (comm1, comm2) in comms1.into_iter().zip(comms2) {
+            assert!(comm1.poly[0] == comm2.poly[0]);
+        }
+    }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -4,7 +4,9 @@ use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    common::{MerkleRoot, Nonce, PolyCommitment, PublicNonce, Signature, SignatureShare},
+    common::{
+        MerkleRoot, Nonce, PolyCommitment, Polynomial, PublicNonce, Signature, SignatureShare,
+    },
     curve::{point::Point, scalar::Scalar},
     errors::{AggregatorError, DkgError},
     taproot::SchnorrProof,
@@ -14,7 +16,7 @@ use crate::{
 /// The saved state required to reconstruct a party
 pub struct PartyState {
     /// The party's private polynomial
-    pub polynomial: Option<Vec<Scalar>>,
+    pub polynomial: Option<Polynomial<Scalar, Scalar>>,
     /// The key IDS and associate private keys for this party
     pub private_keys: Vec<(u32, Scalar)>,
     /// The nonce being used by this party

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -95,7 +95,7 @@ impl Party {
         if let Some(poly) = &self.f {
             Some(PolyCommitment {
                 id: ID::new(&self.id(), &poly[0], rng),
-                poly: (poly.clone() * G).params,
+                poly: (poly * G).params,
             })
         } else {
             warn!("get_poly_commitment called with no polynomial");

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -104,7 +104,7 @@ impl Party {
     pub fn reset_poly<RNG: RngCore + CryptoRng>(&mut self, keep_constant: bool, rng: &mut RNG) {
         let constant = if let Some(poly) = &self.f {
             if keep_constant {
-                Some(poly[0].clone())
+                Some(poly[0])
             } else {
                 None
             }

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -794,6 +794,11 @@ mod tests {
         }
     }
 
+    #[test]
+    fn reset_polys() {
+        traits::test_helpers::reset_polys::<v1::Signer>();
+    }
+
     #[allow(non_snake_case)]
     #[test]
     fn aggregator_sign() {

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -743,4 +743,9 @@ mod tests {
         traits::test_helpers::bad_polynomial_length::<v2::Signer, v2::Aggregator, _>(gt);
         traits::test_helpers::bad_polynomial_length::<v2::Signer, v2::Aggregator, _>(lt);
     }
+
+    #[test]
+    fn reset_polys() {
+        traits::test_helpers::reset_polys::<v2::Signer>();
+    }
 }

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -478,7 +478,7 @@ impl traits::Signer for Party {
     fn reset_polys<RNG: RngCore + CryptoRng>(&mut self, keep_constant: bool, rng: &mut RNG) {
         let constant = if let Some(poly) = &self.f {
             if keep_constant {
-                Some(poly[0].clone())
+                Some(poly[0])
             } else {
                 None
             }

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -72,7 +72,7 @@ impl Party {
         if let Some(poly) = &self.f {
             Some(PolyCommitment {
                 id: ID::new(&self.id(), &poly[0], rng),
-                poly: (poly.clone() * G).params,
+                poly: (poly * G).params,
             })
         } else {
             warn!("get_poly_commitment called with no polynomial");

--- a/src/vss.rs
+++ b/src/vss.rs
@@ -1,5 +1,6 @@
 use rand_core::{CryptoRng, RngCore};
 
+use crate::common::Polynomial;
 use crate::curve::scalar::Scalar;
 
 /// A verifiable secret share algorithm
@@ -7,8 +8,11 @@ pub struct VSS {}
 
 impl VSS {
     /// Construct a random polynomial of the passed degree `n`
-    pub fn random_poly<RNG: RngCore + CryptoRng>(n: u32, rng: &mut RNG) -> Vec<Scalar> {
-        (0..n + 1).map(|_| Scalar::random(rng)).collect()
+    pub fn random_poly<RNG: RngCore + CryptoRng>(
+        n: u32,
+        rng: &mut RNG,
+    ) -> Polynomial<Scalar, Scalar> {
+        Polynomial::random(n, rng)
     }
 
     /// Construct a random polynomial of the passed degree `n` using the passed constant term
@@ -16,10 +20,10 @@ impl VSS {
         n: u32,
         constant: Scalar,
         rng: &mut RNG,
-    ) -> Vec<Scalar> {
-        let mut params: Vec<Scalar> = (0..n + 1).map(|_| Scalar::random(rng)).collect();
-        params[0] = constant;
+    ) -> Polynomial<Scalar, Scalar> {
+        let mut poly = Polynomial::random(n, rng);
+        poly.params[0] = constant;
 
-        params
+        poly
     }
 }

--- a/src/vss.rs
+++ b/src/vss.rs
@@ -1,4 +1,3 @@
-use polynomial::Polynomial;
 use rand_core::{CryptoRng, RngCore};
 
 use crate::curve::scalar::Scalar;
@@ -8,8 +7,19 @@ pub struct VSS {}
 
 impl VSS {
     /// Construct a random polynomial of the passed degree `n`
-    pub fn random_poly<RNG: RngCore + CryptoRng>(n: u32, rng: &mut RNG) -> Polynomial<Scalar> {
-        let params: Vec<Scalar> = (0..n + 1).map(|_| Scalar::random(rng)).collect();
-        Polynomial::new(params)
+    pub fn random_poly<RNG: RngCore + CryptoRng>(n: u32, rng: &mut RNG) -> Vec<Scalar> {
+        (0..n + 1).map(|_| Scalar::random(rng)).collect()
+    }
+
+    /// Construct a random polynomial of the passed degree `n` using the passed constant term
+    pub fn random_poly_with_constant<RNG: RngCore + CryptoRng>(
+        n: u32,
+        constant: Scalar,
+        rng: &mut RNG,
+    ) -> Vec<Scalar> {
+        let mut params: Vec<Scalar> = (0..n + 1).map(|_| Scalar::random(rng)).collect();
+        params[0] = constant;
+
+        params
     }
 }


### PR DESCRIPTION
The group key created during dkg is the sum of the constant parameters of the party polynomials. This change adds the ability to keep these constant parameters when rerunning dkg, so the group key stays the same.  Tests show that it works on both the low level `Signer` interface and the high level state machines.

This change also adds `common::Polynomial`, in an attempt to fix the disparity between how we handle private and public polynomials.  Private polynomials, which use `Scalar` for both parameters and args, have been using `polynomial::Polynomial` from an external crate.  But we weren't using any of the advanced features from that crate, just calling `eval` to generate private shares.  Public polynomials couldn't use the crate, because they have `Point` parameters but `Scalar` args, which the crate did not support. Also, we couldn't support the `keep_constant` feature with the crate, since it did not allow specifying or editing any of the polynomial parameters.

This change is now using `common::Polynomial` for private polynomials, but `Vec<Point>` for public polynomials (with some help from Polynomial to convert between the two).  This is similar to how the code worked before this change, so should require few downstream changes.