### PR TITLE
Properly handle `BIP-340` Schnorr signatures with or without `BIP-341` taproot tweaked keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsts"
-version = "9.2.0"
+version = "10.0.0"
 edition = "2021"
 authors = ["Joey Yandle <xoloki@gmail.com>"]
 license = "Apache-2.0"

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -174,8 +174,3 @@ pub fn merkle_root(data: &[u8]) -> [u8; 32] {
 
     hasher.finalize().into()
 }
-
-/// logical xor
-pub fn xor(a: bool, b: bool) -> bool {
-    (a && !b) || (b && !a)
-}

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -158,7 +158,12 @@ pub fn tweak(public_key: &Point, merkle_root: Option<[u8; 32]>) -> Scalar {
 
 /// Create a BIP341 compliant taproot tweak from a public key and merkle root
 pub fn tweaked_public_key(public_key: &Point, merkle_root: Option<[u8; 32]>) -> Point {
-    public_key + tweak(public_key, merkle_root) * G
+    tweaked_public_key_from_tweak(public_key, tweak(public_key, merkle_root))
+}
+
+/// Create a BIP341 compliant taproot tweak from a public key and a pre-calculated tweak
+pub fn tweaked_public_key_from_tweak(public_key: &Point, tweak: Scalar) -> Point {
+    Point::lift_x(&public_key.x()).unwrap() + tweak * G
 }
 
 /// Create a taproot style merkle root from the serialized script data
@@ -168,4 +173,9 @@ pub fn merkle_root(data: &[u8]) -> [u8; 32] {
     hasher.update(data);
 
     hasher.finalize().into()
+}
+
+/// logical xor
+pub fn xor(a: bool, b: bool) -> bool {
+    (a && !b) || (b && !a)
 }

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -162,6 +162,10 @@ pub fn tweaked_public_key(public_key: &Point, merkle_root: Option<[u8; 32]>) -> 
 }
 
 /// Create a BIP341 compliant taproot tweak from a public key and a pre-calculated tweak
+///
+/// We should never trigger the unwrap here, because Point::lift_x only returns an error
+/// when the x-coordinate is not on the secp256k1 curve, but we know that public_key.x()
+/// is on the curve because it is a Point.
 pub fn tweaked_public_key_from_tweak(public_key: &Point, tweak: Scalar) -> Point {
     Point::lift_x(&public_key.x()).unwrap() + tweak * G
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -297,12 +297,6 @@ impl Signable for NonceRequest {
         hasher.update(self.sign_iter_id.to_be_bytes());
         hasher.update(self.message.as_slice());
         hasher.update(format!("{:?}", self.signature_type));
-        /*
-            hasher.update((self.is_taproot as u16).to_be_bytes());
-            if let Some(merkle_root) = self.merkle_root {
-                hasher.update(merkle_root);
-            }
-        */
     }
 }
 
@@ -420,12 +414,6 @@ impl Signable for SignatureShareRequest {
 
         hasher.update(self.message.as_slice());
         hasher.update(format!("{:?}", self.signature_type));
-        /*
-            hasher.update((self.is_taproot as u16).to_be_bytes());
-            if let Some(merkle_root) = self.merkle_root {
-                hasher.update(merkle_root);
-            }
-        */
     }
 }
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -273,10 +273,8 @@ pub struct NonceRequest {
     pub sign_iter_id: u64,
     /// The message to sign
     pub message: Vec<u8>,
-    /// Whether to make a taproot signature
-    pub is_taproot: bool,
-    /// Taproot merkle root
-    pub merkle_root: Option<MerkleRoot>,
+    /// What type of signature to create
+    pub signature_type: SignatureType,
 }
 
 impl Debug for NonceRequest {
@@ -286,8 +284,7 @@ impl Debug for NonceRequest {
             .field("sign_id", &self.sign_id)
             .field("sign_iter_id", &self.sign_iter_id)
             .field("message", &hex::encode(&self.message))
-            .field("is_taproot", &self.is_taproot)
-            .field("merkle_root", &self.merkle_root.as_ref().map(hex::encode))
+            .field("signature_type", &self.signature_type)
             .finish()
     }
 }
@@ -299,10 +296,13 @@ impl Signable for NonceRequest {
         hasher.update(self.sign_id.to_be_bytes());
         hasher.update(self.sign_iter_id.to_be_bytes());
         hasher.update(self.message.as_slice());
+	hasher.update(format!("{:?}", self.signature_type));
+	/*
         hasher.update((self.is_taproot as u16).to_be_bytes());
         if let Some(merkle_root) = self.merkle_root {
             hasher.update(merkle_root);
         }
+	*/
     }
 }
 
@@ -367,6 +367,17 @@ impl Signable for NonceResponse {
     }
 }
 
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+/// Signature type
+pub enum SignatureType {
+    /// FROST signature
+    Frost,
+    /// BIP-340 Schnorr proof
+    Schnorr,
+    /// BIP-341 Taproot style schnorr proof with a merkle root
+    Taproot(Option<MerkleRoot>),
+}
+
 #[derive(Clone, Serialize, Deserialize, PartialEq)]
 /// Signature share request message from coordinator to signers
 pub struct SignatureShareRequest {
@@ -380,11 +391,9 @@ pub struct SignatureShareRequest {
     pub nonce_responses: Vec<NonceResponse>,
     /// Bytes to sign
     pub message: Vec<u8>,
-    /// Whether to make a taproot signature
-    pub is_taproot: bool,
-    /// Taproot merkle root
-    pub merkle_root: Option<MerkleRoot>,
-}
+    /// What type of signature to create
+    pub signature_type: SignatureType,
+ }
 
 impl Debug for SignatureShareRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -394,8 +403,7 @@ impl Debug for SignatureShareRequest {
             .field("sign_iter_id", &self.sign_iter_id)
             .field("nonce_responses", &self.nonce_responses)
             .field("message", &hex::encode(&self.message))
-            .field("is_taproot", &self.is_taproot)
-            .field("merkle_root", &self.merkle_root.as_ref().map(hex::encode))
+            .field("signature_type", &self.signature_type)
             .finish()
     }
 }
@@ -411,11 +419,13 @@ impl Signable for SignatureShareRequest {
         }
 
         hasher.update(self.message.as_slice());
-
+	hasher.update(format!("{:?}", self.signature_type));
+	/*
         hasher.update((self.is_taproot as u16).to_be_bytes());
         if let Some(merkle_root) = self.merkle_root {
             hasher.update(merkle_root);
         }
+	*/
     }
 }
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -370,7 +370,7 @@ impl Signable for NonceResponse {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Clone, Copy, Serialize, Deserialize, Debug, PartialEq)]
 /// Signature type
 pub enum SignatureType {
     /// FROST signature

--- a/src/net.rs
+++ b/src/net.rs
@@ -296,7 +296,16 @@ impl Signable for NonceRequest {
         hasher.update(self.sign_id.to_be_bytes());
         hasher.update(self.sign_iter_id.to_be_bytes());
         hasher.update(self.message.as_slice());
-        hasher.update(format!("{:?}", self.signature_type));
+        match self.signature_type {
+            SignatureType::Frost => hasher.update("SIGNATURE_TYPE_FROST".as_bytes()),
+            SignatureType::Schnorr => hasher.update("SIGNATURE_TYPE_SCHNORR".as_bytes()),
+            SignatureType::Taproot(merkle_root) => {
+                hasher.update("SIGNATURE_TYPE_TAPROOT".as_bytes());
+                if let Some(merkle_root) = merkle_root {
+                    hasher.update(&merkle_root);
+                }
+            }
+        }
     }
 }
 
@@ -413,7 +422,16 @@ impl Signable for SignatureShareRequest {
         }
 
         hasher.update(self.message.as_slice());
-        hasher.update(format!("{:?}", self.signature_type));
+        match self.signature_type {
+            SignatureType::Frost => hasher.update("SIGNATURE_TYPE_FROST".as_bytes()),
+            SignatureType::Schnorr => hasher.update("SIGNATURE_TYPE_SCHNORR".as_bytes()),
+            SignatureType::Taproot(merkle_root) => {
+                hasher.update("SIGNATURE_TYPE_TAPROOT".as_bytes());
+                if let Some(merkle_root) = merkle_root {
+                    hasher.update(&merkle_root);
+                }
+            }
+        }
     }
 }
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -296,13 +296,13 @@ impl Signable for NonceRequest {
         hasher.update(self.sign_id.to_be_bytes());
         hasher.update(self.sign_iter_id.to_be_bytes());
         hasher.update(self.message.as_slice());
-	hasher.update(format!("{:?}", self.signature_type));
-	/*
-        hasher.update((self.is_taproot as u16).to_be_bytes());
-        if let Some(merkle_root) = self.merkle_root {
-            hasher.update(merkle_root);
-        }
-	*/
+        hasher.update(format!("{:?}", self.signature_type));
+        /*
+            hasher.update((self.is_taproot as u16).to_be_bytes());
+            if let Some(merkle_root) = self.merkle_root {
+                hasher.update(merkle_root);
+            }
+        */
     }
 }
 
@@ -393,7 +393,7 @@ pub struct SignatureShareRequest {
     pub message: Vec<u8>,
     /// What type of signature to create
     pub signature_type: SignatureType,
- }
+}
 
 impl Debug for SignatureShareRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -419,13 +419,13 @@ impl Signable for SignatureShareRequest {
         }
 
         hasher.update(self.message.as_slice());
-	hasher.update(format!("{:?}", self.signature_type));
-	/*
-        hasher.update((self.is_taproot as u16).to_be_bytes());
-        if let Some(merkle_root) = self.merkle_root {
-            hasher.update(merkle_root);
-        }
-	*/
+        hasher.update(format!("{:?}", self.signature_type));
+        /*
+            hasher.update((self.is_taproot as u16).to_be_bytes());
+            if let Some(merkle_root) = self.merkle_root {
+                hasher.update(merkle_root);
+            }
+        */
     }
 }
 
@@ -802,8 +802,7 @@ mod test {
             sign_id: 0,
             sign_iter_id: 0,
             message: vec![],
-            is_taproot: false,
-            merkle_root: None,
+            signature_type: SignatureType::Frost,
         };
         let msg = Message::NonceRequest(nonce_request.clone());
         let coordinator_packet_nonce_request = Packet {
@@ -872,8 +871,7 @@ mod test {
             sign_iter_id: 0,
             nonce_responses: vec![],
             message: vec![],
-            is_taproot: false,
-            merkle_root: None,
+            signature_type: SignatureType::Frost,
         };
         let msg = Message::SignatureShareRequest(signature_share_request.clone());
         let coordinator_packet_signature_share_request = Packet {

--- a/src/net.rs
+++ b/src/net.rs
@@ -302,7 +302,7 @@ impl Signable for NonceRequest {
             SignatureType::Taproot(merkle_root) => {
                 hasher.update("SIGNATURE_TYPE_TAPROOT".as_bytes());
                 if let Some(merkle_root) = merkle_root {
-                    hasher.update(&merkle_root);
+                    hasher.update(merkle_root);
                 }
             }
         }
@@ -428,7 +428,7 @@ impl Signable for SignatureShareRequest {
             SignatureType::Taproot(merkle_root) => {
                 hasher.update("SIGNATURE_TYPE_TAPROOT".as_bytes());
                 if let Some(merkle_root) = merkle_root {
-                    hasher.update(&merkle_root);
+                    hasher.update(merkle_root);
                 }
             }
         }

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -524,12 +524,6 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                 "DKG round {} DkgPrivateShares from signer {}",
                 dkg_private_shares.dkg_id, dkg_private_shares.signer_id
             );
-            for share in &dkg_private_shares.shares {
-                info!("src_party_id {}", share.0);
-                for (dst_key_id, enc_share) in &share.1 {
-                    info!("dst_key_id {} {} bytes", dst_key_id, enc_share.len());
-                }
-            }
         }
 
         if self.dkg_wait_signer_ids.is_empty() {

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -949,19 +949,19 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                     &key_ids,
                     merkle_root,
                 )?;
-                info!("SchnorrProof ({}, {})", schnorr_proof.r, schnorr_proof.s);
+                debug!("SchnorrProof ({}, {})", schnorr_proof.r, schnorr_proof.s);
                 self.schnorr_proof = Some(schnorr_proof);
             } else if let SignatureType::Schnorr = signature_type {
                 let schnorr_proof =
                     self.aggregator
                         .sign_schnorr(&self.message, &nonces, &shares, &key_ids)?;
-                info!("SchnorrProof ({}, {})", schnorr_proof.r, schnorr_proof.s);
+                debug!("SchnorrProof ({}, {})", schnorr_proof.r, schnorr_proof.s);
                 self.schnorr_proof = Some(schnorr_proof);
             } else {
                 let signature = self
                     .aggregator
                     .sign(&self.message, &nonces, &shares, &key_ids)?;
-                info!("Signature ({}, {})", signature.R, signature.z);
+                debug!("Signature ({}, {})", signature.R, signature.z);
                 self.signature = Some(signature);
             }
 
@@ -1357,12 +1357,16 @@ pub mod test {
 
     #[test]
     fn run_dkg_sign_v1() {
-        run_dkg_sign::<FireCoordinator<v1::Aggregator>, v1::Signer>(5, 2);
+        for _ in 0..4 {
+            run_dkg_sign::<FireCoordinator<v1::Aggregator>, v1::Signer>(5, 2);
+        }
     }
 
     #[test]
     fn run_dkg_sign_v2() {
-        run_dkg_sign::<FireCoordinator<v2::Aggregator>, v2::Signer>(5, 2);
+        for _ in 0..4 {
+            run_dkg_sign::<FireCoordinator<v2::Aggregator>, v2::Signer>(5, 2);
+        }
     }
 
     #[test]

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -816,7 +816,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                         nonce_info.nonce_recv_key_ids.insert(*key_id);
                     } else {
                         //TODO: should we mark this signer as malicious?
-                        debug!("Key id {} not in signer key ids {:?}", key_id, key_ids);
+                        warn!("Key id {} not in signer key ids {:?}", key_id, key_ids);
                     }
                 }
             }

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -361,23 +361,21 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                                     ))),
                                 ));
                             }
+                        } else if let Some(signature) = &self.signature {
+                            return Ok((
+                                None,
+                                Some(OperationResult::Sign(Signature {
+                                    R: signature.R,
+                                    z: signature.z,
+                                })),
+                            ));
                         } else {
-                            if let Some(signature) = &self.signature {
-                                return Ok((
-                                    None,
-                                    Some(OperationResult::Sign(Signature {
-                                        R: signature.R,
-                                        z: signature.z,
-                                    })),
-                                ));
-                            } else {
-                                return Ok((
-                                    None,
-                                    Some(OperationResult::SignError(SignError::Coordinator(
-                                        Error::MissingSignature,
-                                    ))),
-                                ));
-                            }
+                            return Ok((
+                                None,
+                                Some(OperationResult::SignError(SignError::Coordinator(
+                                    Error::MissingSignature,
+                                ))),
+                            ));
                         }
                     }
                 }

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -328,39 +328,56 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                     } else if self.state == State::Idle {
                         // We are done with the DKG round! Return the operation result
                         if let SignatureType::Taproot(_) = signature_type {
-                            let schnorr_proof = self
-                                .schnorr_proof
-                                .as_ref()
-                                .ok_or(Error::MissingSchnorrProof)?;
-                            return Ok((
-                                None,
-                                Some(OperationResult::SignTaproot(SchnorrProof {
-                                    r: schnorr_proof.r,
-                                    s: schnorr_proof.s,
-                                })),
-                            ));
+                            if let Some(schnorr_proof) = &self.schnorr_proof {
+                                return Ok((
+                                    None,
+                                    Some(OperationResult::SignTaproot(SchnorrProof {
+                                        r: schnorr_proof.r,
+                                        s: schnorr_proof.s,
+                                    })),
+                                ));
+                            } else {
+                                return Ok((
+                                    None,
+                                    Some(OperationResult::SignError(SignError::Coordinator(
+                                        Error::MissingSchnorrProof,
+                                    ))),
+                                ));
+                            }
                         } else if let SignatureType::Schnorr = signature_type {
-                            let schnorr_proof = self
-                                .schnorr_proof
-                                .as_ref()
-                                .ok_or(Error::MissingSchnorrProof)?;
-                            return Ok((
-                                None,
-                                Some(OperationResult::SignSchnorr(SchnorrProof {
-                                    r: schnorr_proof.r,
-                                    s: schnorr_proof.s,
-                                })),
-                            ));
+                            if let Some(schnorr_proof) = &self.schnorr_proof {
+                                return Ok((
+                                    None,
+                                    Some(OperationResult::SignSchnorr(SchnorrProof {
+                                        r: schnorr_proof.r,
+                                        s: schnorr_proof.s,
+                                    })),
+                                ));
+                            } else {
+                                return Ok((
+                                    None,
+                                    Some(OperationResult::SignError(SignError::Coordinator(
+                                        Error::MissingSchnorrProof,
+                                    ))),
+                                ));
+                            }
                         } else {
-                            let signature =
-                                self.signature.as_ref().ok_or(Error::MissingSignature)?;
-                            return Ok((
-                                None,
-                                Some(OperationResult::Sign(Signature {
-                                    R: signature.R,
-                                    z: signature.z,
-                                })),
-                            ));
+                            if let Some(signature) = &self.signature {
+                                return Ok((
+                                    None,
+                                    Some(OperationResult::Sign(Signature {
+                                        R: signature.R,
+                                        z: signature.z,
+                                    })),
+                                ));
+                            } else {
+                                return Ok((
+                                    None,
+                                    Some(OperationResult::SignError(SignError::Coordinator(
+                                        Error::MissingSignature,
+                                    ))),
+                                ));
+                            }
                         }
                     }
                 }

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -704,10 +704,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
         self.move_to(State::Idle)
     }
 
-    fn request_nonces(
-        &mut self,
-	signature_type: SignatureType,
-    ) -> Result<Packet, Error> {
+    fn request_nonces(&mut self, signature_type: SignatureType) -> Result<Packet, Error> {
         self.message_nonces.clear();
         self.current_sign_iter_id = self.current_sign_iter_id.wrapping_add(1);
         info!(
@@ -719,7 +716,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
             sign_id: self.current_sign_id,
             sign_iter_id: self.current_sign_iter_id,
             message: self.message.clone(),
-	    signature_type: signature_type.clone(),
+            signature_type: signature_type.clone(),
         };
         let nonce_request_msg = Packet {
             sig: nonce_request
@@ -736,7 +733,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
     fn gather_nonces(
         &mut self,
         packet: &Packet,
-	signature_type: SignatureType,
+        signature_type: SignatureType,
     ) -> Result<(), Error> {
         if let Message::NonceResponse(nonce_response) = &packet.msg {
             if nonce_response.dkg_id != self.current_dkg_id {
@@ -809,10 +806,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
         Ok(())
     }
 
-    fn request_sig_shares(
-        &mut self,
-	signature_type: SignatureType,
-    ) -> Result<Packet, Error> {
+    fn request_sig_shares(&mut self, signature_type: SignatureType) -> Result<Packet, Error> {
         self.signature_shares.clear();
         info!(
             "Sign Round {} Requesting Signature Shares",
@@ -832,7 +826,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
             sign_iter_id: self.current_sign_iter_id,
             nonce_responses,
             message: self.message.clone(),
-	    signature_type: signature_type.clone(),
+            signature_type: signature_type.clone(),
         };
         let sig_share_request_msg = Packet {
             sig: sig_share_request
@@ -849,7 +843,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
     fn gather_sig_shares(
         &mut self,
         packet: &Packet,
-	signature_type: SignatureType,
+        signature_type: SignatureType,
     ) -> Result<(), Error> {
         if let Message::SignatureShareResponse(sig_share_response) = &packet.msg {
             if sig_share_response.dkg_id != self.current_dkg_id {
@@ -1200,7 +1194,7 @@ impl<Aggregator: AggregatorTrait> CoordinatorTrait for Coordinator<Aggregator> {
     fn start_signing_round(
         &mut self,
         message: &[u8],
-	signature_type: SignatureType,
+        signature_type: SignatureType,
     ) -> Result<Packet, Error> {
         // We cannot sign if we haven't first set DKG (either manually or via DKG round).
         if self.aggregate_public_key.is_none() {
@@ -1234,6 +1228,7 @@ pub mod test {
         curve::{point::Point, scalar::Scalar},
         net::{
             DkgBegin, DkgFailure, DkgPrivateShares, DkgPublicShares, Message, NonceRequest, Packet,
+            SignatureType,
         },
         state_machine::{
             coordinator::{
@@ -2056,16 +2051,15 @@ pub mod test {
         let msg = "It was many and many a year ago, in a kingdom by the sea"
             .as_bytes()
             .to_vec();
-        let is_taproot = false;
-        let merkle_root = None;
+        let signature_type = SignatureType::Frost;
         let message = coordinators
             .first_mut()
             .unwrap()
-            .start_signing_round(&msg, signature_type)
+            .start_signing_round(&msg, signature_type.clone())
             .unwrap();
         assert_eq!(
             coordinators.first().unwrap().state,
-            State::NonceGather(signature_type)
+            State::NonceGather(signature_type.clone())
         );
 
         // Send the message to all signers and gather responses by sharing with all other signers and coordinator
@@ -2075,7 +2069,7 @@ pub mod test {
         for coordinator in &coordinators {
             assert_eq!(
                 coordinator.state,
-                State::SigShareGather(signature_type)
+                State::SigShareGather(signature_type.clone())
             );
         }
 
@@ -2143,16 +2137,15 @@ pub mod test {
         let msg = "It was many and many a year ago, in a kingdom by the sea"
             .as_bytes()
             .to_vec();
-        let is_taproot = false;
-        let merkle_root = None;
+        let signature_type = SignatureType::Frost;
         let message = coordinators
             .first_mut()
             .unwrap()
-            .start_signing_round(&msg, signature_type)
+            .start_signing_round(&msg, signature_type.clone())
             .unwrap();
         assert_eq!(
             coordinators.first().unwrap().state,
-            State::NonceGather(signature_type)
+            State::NonceGather(signature_type.clone())
         );
 
         // Send the message to all signers and gather responses by sharing with all other signers and coordinator
@@ -2162,7 +2155,7 @@ pub mod test {
         for coordinator in &coordinators {
             assert_eq!(
                 coordinator.state,
-                State::SigShareGather(signature_type)
+                State::SigShareGather(signature_type.clone())
             );
         }
 
@@ -2234,16 +2227,15 @@ pub mod test {
         let msg = "It was many and many a year ago, in a kingdom by the sea"
             .as_bytes()
             .to_vec();
-        let is_taproot = false;
-        let merkle_root = None;
+        let signature_type = SignatureType::Frost;
         let message = coordinators
             .first_mut()
             .unwrap()
-            .start_signing_round(&msg, signature_type)
+            .start_signing_round(&msg, signature_type.clone())
             .unwrap();
         assert_eq!(
             coordinators.first().unwrap().state,
-            State::NonceGather(signature_type)
+            State::NonceGather(signature_type.clone())
         );
 
         // Send the message to all signers and gather responses by sharing with all other signers and coordinator
@@ -2253,7 +2245,7 @@ pub mod test {
         for coordinator in &coordinators {
             assert_eq!(
                 coordinator.state,
-                State::SigShareGather(signature_type)
+                State::SigShareGather(signature_type.clone())
             );
         }
 
@@ -2378,16 +2370,15 @@ pub mod test {
         let msg = "It was many and many a year ago, in a kingdom by the sea"
             .as_bytes()
             .to_vec();
-        let is_taproot = false;
-        let merkle_root = None;
+        let signature_type = SignatureType::Frost;
         let message = insufficient_coordinators
             .first_mut()
             .unwrap()
-            .start_signing_round(&msg, signature_type)
+            .start_signing_round(&msg, signature_type.clone())
             .unwrap();
         assert_eq!(
             insufficient_coordinators.first().unwrap().state,
-            State::NonceGather(signature_type)
+            State::NonceGather(signature_type.clone())
         );
 
         // Send the message to all signers and gather responses by sharing with all other signers and coordinator
@@ -2400,7 +2391,7 @@ pub mod test {
         for coordinator in &insufficient_coordinators {
             assert_eq!(
                 coordinator.state,
-                State::NonceGather(signature_type)
+                State::NonceGather(signature_type.clone())
             );
         }
 
@@ -2420,7 +2411,7 @@ pub mod test {
         for coordinator in &insufficient_coordinators {
             assert_eq!(
                 coordinator.state,
-                State::NonceGather(signature_type)
+                State::NonceGather(signature_type.clone())
             );
         }
         match &operation_results[0] {
@@ -2438,11 +2429,11 @@ pub mod test {
         let message = insufficient_coordinators
             .first_mut()
             .unwrap()
-            .start_signing_round(&msg, signature_type)
+            .start_signing_round(&msg, signature_type.clone())
             .unwrap();
         assert_eq!(
             insufficient_coordinators.first().unwrap().state,
-            State::NonceGather(signature_type)
+            State::NonceGather(signature_type.clone())
         );
 
         // Send the message to all signers and gather responses by sharing with all other signers and insufficient_coordinator
@@ -2455,7 +2446,7 @@ pub mod test {
         for coordinator in &insufficient_coordinators {
             assert_eq!(
                 coordinator.state,
-                State::SigShareGather(signature_type)
+                State::SigShareGather(signature_type.clone())
             );
         }
 
@@ -2479,7 +2470,7 @@ pub mod test {
         for coordinator in &insufficient_coordinators {
             assert_eq!(
                 coordinator.state,
-                State::SigShareGather(signature_type)
+                State::SigShareGather(signature_type.clone())
             );
         }
 
@@ -2496,7 +2487,7 @@ pub mod test {
         assert_eq!(operation_results.len(), 0);
         assert_eq!(
             insufficient_coordinators.first().unwrap().state,
-            State::NonceGather(signature_type)
+            State::NonceGather(signature_type.clone())
         );
 
         // put the malicious signers back in
@@ -2516,7 +2507,7 @@ pub mod test {
         for coordinator in &insufficient_coordinators {
             assert_eq!(
                 coordinator.state,
-                State::SigShareGather(signature_type)
+                State::SigShareGather(signature_type.clone())
             );
         }
 
@@ -2537,7 +2528,7 @@ pub mod test {
         for coordinator in &insufficient_coordinators {
             assert_eq!(
                 coordinator.state,
-                State::SigShareGather(signature_type)
+                State::SigShareGather(signature_type.clone())
             );
         }
 
@@ -2554,7 +2545,7 @@ pub mod test {
         assert_eq!(operation_results.len(), 1);
         assert_eq!(
             insufficient_coordinators.first_mut().unwrap().state,
-            State::SigShareGather(signature_type)
+            State::SigShareGather(signature_type.clone())
         );
         match &operation_results[0] {
             OperationResult::SignError(sign_error) => match sign_error {
@@ -2585,18 +2576,17 @@ pub mod test {
         let orig_msg = "It was many and many a year ago, in a kingdom by the sea"
             .as_bytes()
             .to_vec();
-        let is_taproot = false;
-        let merkle_root = None;
+        let signature_type = SignatureType::Frost;
         let message = coordinators
             .first_mut()
             .unwrap()
-            .start_signing_round(&orig_msg, signature_type)
+            .start_signing_round(&orig_msg, signature_type.clone())
             .unwrap();
 
         let mut alt_packet = message.clone();
         assert_eq!(
             coordinators.first().unwrap().state,
-            State::NonceGather(signature_type)
+            State::NonceGather(signature_type.clone())
         );
 
         // Send the original message to the first 1/4 of the signers and gather responses by sharing with the rest of the signers and the coordinators
@@ -2629,7 +2619,7 @@ pub mod test {
         for coordinator in &coordinators {
             assert_eq!(
                 coordinator.state,
-                State::SigShareGather(signature_type)
+                State::SigShareGather(signature_type.clone())
             );
         }
         // Assert that the first 1/4 signers did not receive a result
@@ -2717,8 +2707,7 @@ pub mod test {
                         sign_id: old_id,
                         message: vec![],
                         sign_iter_id: id,
-                        is_taproot: false,
-                        merkle_root: None,
+                        signature_type: SignatureType::Frost,
                     }),
                 }])
                 .unwrap();
@@ -2736,8 +2725,7 @@ pub mod test {
                         sign_id: id,
                         message: vec![],
                         sign_iter_id: id,
-                        is_taproot: false,
-                        merkle_root: None,
+                        signature_type: SignatureType::Frost,
                     }),
                 }])
                 .unwrap();

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -524,6 +524,12 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                 "DKG round {} DkgPrivateShares from signer {}",
                 dkg_private_shares.dkg_id, dkg_private_shares.signer_id
             );
+            for share in &dkg_private_shares.shares {
+                info!("src_party_id {}", share.0);
+                for (dst_key_id, enc_share) in &share.1 {
+                    info!("dst_key_id {} {} bytes", dst_key_id, enc_share.len());
+                }
+            }
         }
 
         if self.dkg_wait_signer_ids.is_empty() {

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -748,7 +748,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
             sign_id: self.current_sign_id,
             sign_iter_id: self.current_sign_iter_id,
             message: self.message.clone(),
-            signature_type: signature_type,
+            signature_type,
         };
         let nonce_request_msg = Packet {
             sig: nonce_request
@@ -858,7 +858,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
             sign_iter_id: self.current_sign_iter_id,
             nonce_responses,
             message: self.message.clone(),
-            signature_type: signature_type,
+            signature_type,
         };
         let sig_share_request_msg = Packet {
             sig: sig_share_request

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -334,6 +334,18 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                                     s: schnorr_proof.s,
                                 })),
                             ));
+                        } else if let SignatureType::Schnorr = signature_type {
+                            let schnorr_proof = self
+                                .schnorr_proof
+                                .as_ref()
+                                .ok_or(Error::MissingSchnorrProof)?;
+                            return Ok((
+                                None,
+                                Some(OperationResult::SignSchnorr(SchnorrProof {
+                                    r: schnorr_proof.r,
+                                    s: schnorr_proof.s,
+                                })),
+                            ));
                         } else {
                             let signature =
                                 self.signature.as_ref().ok_or(Error::MissingSignature)?;
@@ -937,6 +949,12 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                     &key_ids,
                     merkle_root,
                 )?;
+                info!("SchnorrProof ({}, {})", schnorr_proof.r, schnorr_proof.s);
+                self.schnorr_proof = Some(schnorr_proof);
+            } else if let SignatureType::Schnorr = signature_type {
+                let schnorr_proof =
+                    self.aggregator
+                        .sign_schnorr(&self.message, &nonces, &shares, &key_ids)?;
                 info!("SchnorrProof ({}, {})", schnorr_proof.r, schnorr_proof.s);
                 self.schnorr_proof = Some(schnorr_proof);
             } else {

--- a/src/state_machine/coordinator/frost.rs
+++ b/src/state_machine/coordinator/frost.rs
@@ -505,19 +505,19 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                     &key_ids,
                     merkle_root,
                 )?;
-                info!("SchnorrProof ({}, {})", schnorr_proof.r, schnorr_proof.s);
+                debug!("SchnorrProof ({}, {})", schnorr_proof.r, schnorr_proof.s);
                 self.schnorr_proof = Some(schnorr_proof);
             } else if let SignatureType::Schnorr = signature_type {
                 let schnorr_proof =
                     self.aggregator
                         .sign_schnorr(&self.message, &nonces, shares, &key_ids)?;
-                info!("SchnorrProof ({}, {})", schnorr_proof.r, schnorr_proof.s);
+                debug!("SchnorrProof ({}, {})", schnorr_proof.r, schnorr_proof.s);
                 self.schnorr_proof = Some(schnorr_proof);
             } else {
                 let signature = self
                     .aggregator
                     .sign(&self.message, &nonces, shares, &key_ids)?;
-                info!("Signature ({}, {})", signature.R, signature.z);
+                debug!("Signature ({}, {})", signature.R, signature.z);
                 self.signature = Some(signature);
             }
 
@@ -862,7 +862,16 @@ pub mod test {
 
     #[test]
     fn run_dkg_sign_v1() {
-        run_dkg_sign::<FrostCoordinator<v1::Aggregator>, v1::Signer>(5, 2);
+        for _ in 0..4 {
+            run_dkg_sign::<FrostCoordinator<v1::Aggregator>, v1::Signer>(5, 2);
+        }
+    }
+
+    #[test]
+    fn run_dkg_sign_v2() {
+        for _ in 0..4 {
+            run_dkg_sign::<FrostCoordinator<v2::Aggregator>, v2::Signer>(5, 2);
+        }
     }
 
     #[test]

--- a/src/state_machine/coordinator/frost.rs
+++ b/src/state_machine/coordinator/frost.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use tracing::{debug, info};
 
 use crate::{
-    common::{MerkleRoot, PolyCommitment, PublicNonce, Signature, SignatureShare},
+    common::{PolyCommitment, PublicNonce, Signature, SignatureShare},
     compute,
     curve::point::Point,
     net::{
@@ -136,7 +136,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                     return Ok((Some(packet), None));
                 }
                 State::NonceGather(signature_type) => {
-                    self.gather_nonces(packet, signature_type.clone())?;q
+                    self.gather_nonces(packet, signature_type.clone())?;
                     if self.state == State::NonceGather(signature_type) {
                         // We need more data
                         return Ok((None, None));
@@ -148,7 +148,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                 }
                 State::SigShareGather(signature_type) => {
                     self.gather_sig_shares(packet, signature_type.clone())?;
-                    if self.state == State::SigShareGather(signature_type) {
+                    if self.state == State::SigShareGather(signature_type.clone()) {
                         // We need more data
                         return Ok((None, None));
                     } else if self.state == State::Idle {

--- a/src/state_machine/coordinator/frost.rs
+++ b/src/state_machine/coordinator/frost.rs
@@ -359,7 +359,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
             sign_id: self.current_sign_id,
             sign_iter_id: self.current_sign_iter_id,
             message: self.message.clone(),
-            signature_type: signature_type,
+            signature_type,
         };
         let nonce_request_msg = Packet {
             sig: nonce_request
@@ -429,7 +429,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
             sign_iter_id: self.current_sign_iter_id,
             nonce_responses,
             message: self.message.clone(),
-            signature_type: signature_type,
+            signature_type,
         };
         let sig_share_request_msg = Packet {
             sig: sig_share_request

--- a/src/state_machine/coordinator/frost.rs
+++ b/src/state_machine/coordinator/frost.rs
@@ -165,6 +165,18 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                                     s: schnorr_proof.s,
                                 })),
                             ));
+                        } else if let SignatureType::Schnorr = signature_type {
+                            let schnorr_proof = self
+                                .schnorr_proof
+                                .as_ref()
+                                .ok_or(Error::MissingSchnorrProof)?;
+                            return Ok((
+                                None,
+                                Some(OperationResult::SignSchnorr(SchnorrProof {
+                                    r: schnorr_proof.r,
+                                    s: schnorr_proof.s,
+                                })),
+                            ));
                         } else {
                             let signature =
                                 self.signature.as_ref().ok_or(Error::MissingSignature)?;
@@ -493,6 +505,12 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                     &key_ids,
                     merkle_root,
                 )?;
+                info!("SchnorrProof ({}, {})", schnorr_proof.r, schnorr_proof.s);
+                self.schnorr_proof = Some(schnorr_proof);
+            } else if let SignatureType::Schnorr = signature_type {
+                let schnorr_proof =
+                    self.aggregator
+                        .sign_schnorr(&self.message, &nonces, shares, &key_ids)?;
                 info!("SchnorrProof ({}, {})", schnorr_proof.r, schnorr_proof.s);
                 self.schnorr_proof = Some(schnorr_proof);
             } else {

--- a/src/state_machine/coordinator/frost.rs
+++ b/src/state_machine/coordinator/frost.rs
@@ -331,10 +331,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
         Ok(())
     }
 
-    fn request_nonces(
-        &mut self,
-	signature_type: SignatureType,
-    ) -> Result<Packet, Error> {
+    fn request_nonces(&mut self, signature_type: SignatureType) -> Result<Packet, Error> {
         self.public_nonces.clear();
         info!(
             "Sign Round {} Nonce round {} Requesting Nonces",
@@ -345,7 +342,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
             sign_id: self.current_sign_id,
             sign_iter_id: self.current_sign_iter_id,
             message: self.message.clone(),
-	    signature_type: signature_type.clone(),
+            signature_type: signature_type.clone(),
         };
         let nonce_request_msg = Packet {
             sig: nonce_request
@@ -361,7 +358,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
     fn gather_nonces(
         &mut self,
         packet: &Packet,
-	signature_type: SignatureType,
+        signature_type: SignatureType,
     ) -> Result<(), Error> {
         if let Message::NonceResponse(nonce_response) = &packet.msg {
             if nonce_response.dkg_id != self.current_dkg_id {
@@ -400,10 +397,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
         Ok(())
     }
 
-    fn request_sig_shares(
-        &mut self,
-	signature_type: SignatureType,
-    ) -> Result<Packet, Error> {
+    fn request_sig_shares(&mut self, signature_type: SignatureType) -> Result<Packet, Error> {
         self.signature_shares.clear();
         info!(
             "Sign Round {} Requesting Signature Shares",
@@ -418,7 +412,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
             sign_iter_id: self.current_sign_iter_id,
             nonce_responses,
             message: self.message.clone(),
-	    signature_type: signature_type.clone(),
+            signature_type: signature_type.clone(),
         };
         let sig_share_request_msg = Packet {
             sig: sig_share_request
@@ -435,7 +429,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
     fn gather_sig_shares(
         &mut self,
         packet: &Packet,
-	signature_type: SignatureType,
+        signature_type: SignatureType,
     ) -> Result<(), Error> {
         if let Message::SignatureShareResponse(sig_share_response) = &packet.msg {
             if sig_share_response.dkg_id != self.current_dkg_id {
@@ -719,7 +713,7 @@ impl<Aggregator: AggregatorTrait> CoordinatorTrait for Coordinator<Aggregator> {
     fn start_signing_round(
         &mut self,
         message: &[u8],
-	signature_type: SignatureType,
+        signature_type: SignatureType,
     ) -> Result<Packet, Error> {
         // We cannot sign if we haven't first set DKG (either manually or via DKG round).
         if self.aggregate_public_key.is_none() {
@@ -747,7 +741,7 @@ impl<Aggregator: AggregatorTrait> CoordinatorTrait for Coordinator<Aggregator> {
 pub mod test {
     use crate::{
         curve::scalar::Scalar,
-        net::{DkgBegin, Message, NonceRequest, Packet},
+        net::{DkgBegin, Message, NonceRequest, Packet, SignatureType},
         state_machine::coordinator::{
             frost::Coordinator as FrostCoordinator,
             test::{
@@ -909,8 +903,7 @@ pub mod test {
                     sign_id: old_id,
                     message: vec![],
                     sign_iter_id: id,
-                    is_taproot: false,
-                    merkle_root: None,
+                    signature_type: SignatureType::Frost,
                 }),
             }])
             .unwrap();
@@ -928,8 +921,7 @@ pub mod test {
                     sign_id: id,
                     message: vec![],
                     sign_iter_id: id,
-                    is_taproot: false,
-                    merkle_root: None,
+                    signature_type: SignatureType::Frost,
                 }),
             }])
             .unwrap();

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -714,7 +714,7 @@ pub mod test {
     }
 
     pub fn run_sign<Coordinator: CoordinatorTrait, SignerType: SignerTrait>(
-        coordinators: &mut Vec<Coordinator>,
+        coordinators: &mut [Coordinator],
         signers: &mut Vec<Signer<SignerType>>,
         msg: &Vec<u8>,
         signature_type: SignatureType,
@@ -723,7 +723,7 @@ pub mod test {
         let message = coordinators
             .first_mut()
             .unwrap()
-            .start_signing_round(&msg, signature_type.clone())
+            .start_signing_round(msg, signature_type.clone())
             .unwrap();
         assert_eq!(
             coordinators.first_mut().unwrap().get_state(),
@@ -775,7 +775,7 @@ pub mod test {
                             &coordinator
                                 .get_aggregate_public_key()
                                 .expect("No aggregate public key set!"),
-                            &msg
+                            msg
                         ));
                         assert_eq!(coordinator.get_state(), State::Idle);
                     }
@@ -791,7 +791,7 @@ pub mod test {
                                 .get_aggregate_public_key()
                                 .expect("No aggregate public key set!")
                                 .x(),
-                            &msg
+                            msg
                         ));
                         assert_eq!(coordinator.get_state(), State::Idle);
                     }
@@ -809,7 +809,7 @@ pub mod test {
                             merkle_root,
                         );
 
-                        assert!(sig.verify(&tweaked_public_key.x(), &msg));
+                        assert!(sig.verify(&tweaked_public_key.x(), msg));
                         assert_eq!(coordinator.get_state(), State::Idle);
                     }
                 } else {

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -299,7 +299,7 @@ pub mod frost;
 /// The coordinator for the FIRE algorithm
 pub mod fire;
 
-#[cfg(test)]
+#[allow(missing_docs)]
 pub mod test {
     use hashbrown::{HashMap, HashSet};
     use rand_core::OsRng;

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -755,8 +755,6 @@ pub mod test {
             .map(|c| Coordinator::load(&c.save()))
             .collect::<Vec<Coordinator>>();
 
-        //assert_eq!(coordinators, &new_coordinators);
-
         let new_signers = signers
             .iter()
             .map(|s| Signer::<SignerType>::load(&s.save()))

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    common::{MerkleRoot, PolyCommitment, Signature, SignatureShare},
+    common::{PolyCommitment, Signature, SignatureShare},
     curve::{point::Point, scalar::Scalar},
     errors::AggregatorError,
     net::{DkgEnd, DkgPrivateShares, DkgPublicShares, NonceResponse, Packet, SignatureType},

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -725,11 +725,11 @@ pub mod test {
         let message = coordinators
             .first_mut()
             .unwrap()
-            .start_signing_round(msg, signature_type.clone())
+            .start_signing_round(msg, signature_type)
             .unwrap();
         assert_eq!(
             coordinators.first_mut().unwrap().get_state(),
-            State::NonceGather(signature_type.clone())
+            State::NonceGather(signature_type)
         );
 
         // Send the message to all signers and gather responses by sharing with all other signers and coordinator
@@ -738,7 +738,7 @@ pub mod test {
         assert!(operation_results.is_empty());
         assert_eq!(
             coordinators.first_mut().unwrap().get_state(),
-            State::SigShareGather(signature_type.clone())
+            State::SigShareGather(signature_type)
         );
 
         assert_eq!(outbound_messages.len(), 1);
@@ -877,11 +877,11 @@ pub mod test {
         let message = coordinators
             .first_mut()
             .unwrap()
-            .start_signing_round(&msg, signature_type.clone())
+            .start_signing_round(&msg, signature_type)
             .unwrap();
         assert_eq!(
             coordinators.first_mut().unwrap().get_state(),
-            State::NonceGather(signature_type.clone())
+            State::NonceGather(signature_type)
         );
 
         // Send the message to all signers and gather responses by sharing with all other signers and coordinator
@@ -890,7 +890,7 @@ pub mod test {
         assert!(operation_results.is_empty());
         assert_eq!(
             coordinators.first_mut().unwrap().get_state(),
-            State::SigShareGather(signature_type.clone())
+            State::SigShareGather(signature_type)
         );
 
         assert_eq!(outbound_messages.len(), 1);

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -716,7 +716,7 @@ pub mod test {
     pub fn run_sign<Coordinator: CoordinatorTrait, SignerType: SignerTrait>(
         coordinators: &mut [Coordinator],
         signers: &mut Vec<Signer<SignerType>>,
-        msg: &Vec<u8>,
+        msg: &[u8],
         signature_type: SignatureType,
     ) -> OperationResult {
         // Start a signing round

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -845,20 +845,18 @@ pub mod test {
             &msg,
             SignatureType::Schnorr,
         );
-        /*
-            run_sign::<Coordinator, SignerType>(
-                &mut coordinators,
-                &mut signers,
-                &msg,
-                SignatureType::Taproot(None),
-            );
-            run_sign::<Coordinator, SignerType>(
-                &mut coordinators,
-                &mut signers,
-                &msg,
-                SignatureType::Taproot(Some([128u8; 32])),
+        run_sign::<Coordinator, SignerType>(
+            &mut coordinators,
+            &mut signers,
+            &msg,
+            SignatureType::Taproot(None),
         );
-        */
+        run_sign::<Coordinator, SignerType>(
+            &mut coordinators,
+            &mut signers,
+            &msg,
+            SignatureType::Taproot(Some([128u8; 32])),
+        );
     }
 
     pub fn equal_after_save_load<Coordinator: CoordinatorTrait, SignerType: SignerTrait>(

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -859,6 +859,8 @@ pub mod test {
         );
     }
 
+    /// Run DKG then sign a message, but alter the signature shares for signer 0.  This should trigger the aggregator internal check_signature_shares function to run and determine which parties signatures were bad.
+    /// Because of the differences between how parties are represented in v1 and v2, we need to pass in a vector of the expected bad parties.
     pub fn check_signature_shares<Coordinator: CoordinatorTrait, SignerType: SignerTrait>(
         num_signers: u32,
         keys_per_signer: u32,

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -718,7 +718,7 @@ pub mod test {
         signers: &mut Vec<Signer<SignerType>>,
         msg: &Vec<u8>,
         signature_type: SignatureType,
-    ) {
+    ) -> OperationResult {
         // Start a signing round
         let message = coordinators
             .first_mut()
@@ -818,6 +818,8 @@ pub mod test {
             }
             _ => panic!("Expected OperationResult"),
         }
+
+        operation_results[0].clone()
     }
 
     pub fn run_dkg_sign<Coordinator: CoordinatorTrait, SignerType: SignerTrait>(

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -845,18 +845,20 @@ pub mod test {
             &msg,
             SignatureType::Schnorr,
         );
-        run_sign::<Coordinator, SignerType>(
-            &mut coordinators,
-            &mut signers,
-            &msg,
-            SignatureType::Taproot(None),
+        /*
+            run_sign::<Coordinator, SignerType>(
+                &mut coordinators,
+                &mut signers,
+                &msg,
+                SignatureType::Taproot(None),
+            );
+            run_sign::<Coordinator, SignerType>(
+                &mut coordinators,
+                &mut signers,
+                &msg,
+                SignatureType::Taproot(Some([128u8; 32])),
         );
-        run_sign::<Coordinator, SignerType>(
-            &mut coordinators,
-            &mut signers,
-            &msg,
-            SignatureType::Taproot(Some([128u8; 32])),
-        );
+        */
     }
 
     pub fn equal_after_save_load<Coordinator: CoordinatorTrait, SignerType: SignerTrait>(

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -286,7 +286,7 @@ pub trait Coordinator: Clone + Debug + PartialEq {
     fn start_signing_round(
         &mut self,
         message: &[u8],
-	signature_type: SignatureType,
+        signature_type: SignatureType,
     ) -> Result<Packet, Error>;
 
     /// Reset internal state
@@ -713,15 +713,15 @@ pub mod test {
         let msg = "It was many and many a year ago, in a kingdom by the sea"
             .as_bytes()
             .to_vec();
-	let signature_type = SignatureType::Frost;
+        let signature_type = SignatureType::Frost;
         let message = coordinators
             .first_mut()
             .unwrap()
-            .start_signing_round(&msg, signature_type)
+            .start_signing_round(&msg, signature_type.clone())
             .unwrap();
         assert_eq!(
             coordinators.first_mut().unwrap().get_state(),
-            State::NonceGather(is_taproot, merkle_root)
+            State::NonceGather(signature_type.clone())
         );
 
         // Send the message to all signers and gather responses by sharing with all other signers and coordinator
@@ -730,7 +730,7 @@ pub mod test {
         assert!(operation_results.is_empty());
         assert_eq!(
             coordinators.first_mut().unwrap().get_state(),
-            State::SigShareGather(is_taproot, merkle_root)
+            State::SigShareGather(signature_type.clone())
         );
 
         assert_eq!(outbound_messages.len(), 1);

--- a/src/state_machine/mod.rs
+++ b/src/state_machine/mod.rs
@@ -51,6 +51,7 @@ pub enum SignError {
 }
 
 /// Result of a DKG or sign operation
+#[derive(Debug, Clone)]
 pub enum OperationResult {
     /// DKG succeeded with the wrapped public key
     Dkg(Point),

--- a/src/state_machine/mod.rs
+++ b/src/state_machine/mod.rs
@@ -39,6 +39,7 @@ pub enum DkgError {
 
 /// Sign errors
 #[derive(Error, Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum SignError {
     /// Nonce timeout
     #[error("Nonce timeout, valid responses from {0:?}, signers {1:?} are malicious")]

--- a/src/state_machine/mod.rs
+++ b/src/state_machine/mod.rs
@@ -8,6 +8,7 @@ use crate::{
     curve::{ecdsa, point::Point},
     errors::AggregatorError,
     net::DkgFailure,
+    state_machine::coordinator::Error as CoordinatorError,
     taproot::SchnorrProof,
 };
 
@@ -48,6 +49,9 @@ pub enum SignError {
     /// Signature aggregator error
     #[error("Signature aggregator error")]
     Aggregator(#[from] AggregatorError),
+    /// Coordinator error
+    #[error("Coordinator error")]
+    Coordinator(#[from] CoordinatorError),
 }
 
 /// Result of a DKG or sign operation

--- a/src/state_machine/mod.rs
+++ b/src/state_machine/mod.rs
@@ -56,6 +56,8 @@ pub enum OperationResult {
     Dkg(Point),
     /// Sign succeeded with the wrapped Signature
     Sign(Signature),
+    /// Sign schnorr succeeded with the wrapped SchnorrProof
+    SignSchnorr(SchnorrProof),
     /// Sign taproot succeeded with the wrapped SchnorrProof
     SignTaproot(SchnorrProof),
     /// DKG error

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -555,7 +555,9 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                     .iter()
                     .flat_map(|nr| nr.nonces.clone())
                     .collect::<Vec<PublicNonce>>();
-                let signature_shares = if let SignatureType::Taproot(m) = sign_request.signature_type {
+                let signature_shares = if let SignatureType::Taproot(m) =
+                    sign_request.signature_type
+                {
                     self.signer.sign_taproot(
                         &sign_request.message,
                         &signer_ids,
@@ -564,12 +566,8 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                         m,
                     )
                 } else if let SignatureType::Schnorr = sign_request.signature_type {
-                    self.signer.sign_schnorr(
-                        &sign_request.message,
-                        &signer_ids,
-                        &key_ids,
-                        &nonces,
-                    )
+                    self.signer
+                        .sign_schnorr(&sign_request.message, &signer_ids, &key_ids, &nonces)
                 } else {
                     self.signer
                         .sign(&sign_request.message, &signer_ids, &key_ids, &nonces)

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -339,11 +339,12 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
         let mut missing_public_shares = HashSet::new();
         let mut missing_private_shares = HashSet::new();
         let mut bad_public_shares = HashSet::new();
+        let threshold: usize = self.threshold.try_into().unwrap();
         if let Some(dkg_end_begin) = &self.dkg_end_begin_msg {
             for signer_id in &dkg_end_begin.signer_ids {
                 if let Some(shares) = self.dkg_public_shares.get(signer_id) {
                     for (party_id, comm) in shares.comms.iter() {
-                        if comm.poly.len() != self.threshold.try_into().unwrap() || !comm.verify() {
+                        if comm.poly.len() != threshold || !comm.verify() {
                             bad_public_shares.insert(*signer_id);
                         } else {
                             self.commitments.insert(*party_id, comm.clone());

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -425,7 +425,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                                 }
                             }
                         } else {
-                            todo!();
+                            warn!("Got unexpected dkg_error {:?}", dkg_error);
                         }
                     }
                     DkgEnd {

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -556,22 +556,24 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                     .iter()
                     .flat_map(|nr| nr.nonces.clone())
                     .collect::<Vec<PublicNonce>>();
-                let signature_shares = if let SignatureType::Taproot(m) =
-                    sign_request.signature_type
-                {
-                    self.signer.sign_taproot(
+                let signature_shares = match sign_request.signature_type {
+                    SignatureType::Taproot(m) => self.signer.sign_taproot(
                         &sign_request.message,
                         &signer_ids,
                         &key_ids,
                         &nonces,
                         m,
-                    )
-                } else if let SignatureType::Schnorr = sign_request.signature_type {
-                    self.signer
-                        .sign_schnorr(&sign_request.message, &signer_ids, &key_ids, &nonces)
-                } else {
-                    self.signer
-                        .sign(&sign_request.message, &signer_ids, &key_ids, &nonces)
+                    ),
+                    SignatureType::Schnorr => self.signer.sign_schnorr(
+                        &sign_request.message,
+                        &signer_ids,
+                        &key_ids,
+                        &nonces,
+                    ),
+                    SignatureType::Frost => {
+                        self.signer
+                            .sign(&sign_request.message, &signer_ids, &key_ids, &nonces)
+                    }
                 };
 
                 let response = SignatureShareResponse {

--- a/src/taproot.rs
+++ b/src/taproot.rs
@@ -30,6 +30,7 @@ impl SchnorrProof {
     /// Verify a BIP-340 schnorr proof
     #[allow(non_snake_case)]
     pub fn verify(&self, public_key: &field::Element, msg: &[u8]) -> bool {
+        println!("taproot verify: public_key  {}", &public_key);
         let Y = match Point::lift_x(public_key) {
             Ok(Y) => Y,
             Err(_) => return false,
@@ -39,6 +40,7 @@ impl SchnorrProof {
             Err(_) => return false,
         };
         let c = compute::challenge(&Y, &R, msg);
+        println!("taproot verify: challenge   {}", c);
         let Rp = self.s * G - c * Y;
 
         Rp.has_even_y() && Rp.x() == self.r
@@ -146,10 +148,144 @@ pub mod test_helpers {
 
 #[cfg(test)]
 mod test {
-    use super::{test_helpers, SchnorrProof};
+    use super::{test_helpers, Point, Scalar, SchnorrProof, G};
 
     use crate::{compute, traits::Aggregator, traits::Signer, v1, v2};
     use rand_core::OsRng;
+
+    fn xor(a: bool, b: bool) -> bool {
+        (a && !b) || (b && !a)
+    }
+
+    #[test]
+    #[allow(non_snake_case)]
+    fn key_tweaks() {
+        let mut rng = OsRng;
+        let script = "OP_1".as_bytes();
+        let merkle_root = compute::merkle_root(script);
+        let r = Scalar::random(&mut rng);
+        let R = r * G;
+        let rp = if R.has_even_y() { r } else { -r };
+        let mut d = Scalar::random(&mut rng);
+        let mut P = d * G;
+        let msg = "sign me";
+        let c = compute::challenge(&P, &R, msg.as_bytes());
+
+        println!("P.has_even_y {}", P.has_even_y());
+        println!("R.has_even_y {}", R.has_even_y());
+
+        let s = r - c * d;
+        assert!(R == s * G + c * P);
+
+        while P.has_even_y() {
+            d = Scalar::random(&mut rng);
+            P = d * G;
+        }
+
+        println!("P.has_even_y {}", P.has_even_y());
+        let s = r - c * d;
+        assert!(R == s * G + c * P);
+
+        assert!(!P.has_even_y());
+        assert_eq!(d * G, P);
+
+        let s = rp + c * (-d);
+        assert!(Point::lift_x(&R.x()).unwrap() == s * G - c * Point::lift_x(&P.x()).unwrap());
+
+        let proof = SchnorrProof { r: R.x(), s };
+        {
+            let Pp = Point::lift_x(&P.x()).unwrap();
+            assert!(Pp == (-d) * G);
+            let R = Point::lift_x(&proof.r).unwrap();
+            let e = compute::challenge(&P, &R, msg.as_bytes());
+            //let e = c.clone();
+            let Rp = proof.s * G - e * Pp;
+            //assert!(Rp.has_even_y());
+            //assert_eq!(Rp.x(), proof.r);
+        }
+        //assert!(proof.verify(&P.x(), msg.as_bytes()));
+
+        let mut Q = Point::lift_x(&P.x()).unwrap();
+        let c = compute::challenge(&Q, &R, msg.as_bytes());
+        println!("Q.has_even_y {}", Q.has_even_y());
+
+        assert!(Q != P);
+        assert!(d * G != Q);
+
+        let mut e = -d;
+
+        assert!(e * G == Q);
+
+        let s = r + c * e;
+        assert!(R == s * G - c * Q);
+
+        let s = rp + c * e;
+        let proof = SchnorrProof { r: R.x(), s };
+        assert!(proof.verify(&Q.x(), msg.as_bytes()));
+
+        {
+            let P = Point::lift_x(&Q.x()).unwrap();
+            let R = Point::lift_x(&proof.r).unwrap();
+            let e = compute::challenge(&Q, &R, msg.as_bytes());
+            //let e = c.clone();
+            let Rp = proof.s * G - e * P;
+            assert!(Rp.has_even_y());
+            assert_eq!(Rp.x(), proof.r);
+        }
+
+        /*
+        d = Scalar::random(&mut rng);
+        P = d * G;
+        e = Scalar::random(&mut rng);
+        Q = e * G;
+        */
+        let S = compute::tweaked_public_key(&P, None);
+        println!("S.has_even_y {}", S.has_even_y());
+        let t = compute::tweak(&P, None);
+        //let d = if !P.has_even_y() || !S.has_even_y() {
+        //let d = if !S.has_even_y() {
+        let d = if !P.has_even_y() { (-d + t) } else { (d + t) };
+        assert!((d * G).x() == S.x());
+        assert!((d * G) == S);
+
+        let c = compute::challenge(&S, &R, msg.as_bytes());
+        let s = r - c * d;
+        assert!(R == s * G + c * S);
+
+        let d = if !S.has_even_y() { -d } else { d };
+
+        let s = rp + c * d;
+        let proof = SchnorrProof { r: R.x(), s };
+        {
+            let P = Point::lift_x(&S.x()).unwrap();
+            let R = Point::lift_x(&proof.r).unwrap();
+            let e = compute::challenge(&S, &R, msg.as_bytes());
+            //let e = c.clone();
+            let Rp = proof.s * G - e * P;
+            assert!(Rp.has_even_y());
+            assert_eq!(Rp.x(), proof.r);
+        }
+        assert!(proof.verify(&S.x(), msg.as_bytes()));
+
+        let T = compute::tweaked_public_key(&Q, None);
+        println!("T.has_even_y {}", T.has_even_y());
+        let t = compute::tweak(&Q, None);
+        //let e = if !Q.has_even_y() || !T.has_even_y() {
+        //let e = if !T.has_even_y() {
+        let e = if !Q.has_even_y() { (-e + t) } else { (e + t) };
+        assert!((e * G).x() == T.x());
+        assert!((e * G) == T);
+
+        let c = compute::challenge(&T, &R, msg.as_bytes());
+        let s = r - c * e;
+        assert!(R == s * G + c * T);
+
+        let e = if !T.has_even_y() { -e } else { e };
+
+        let s = rp + c * e;
+        let schnorr_proof = SchnorrProof { r: R.x(), s };
+        assert!(schnorr_proof.verify(&T.x(), msg.as_bytes()));
+    }
 
     #[test]
     #[allow(non_snake_case)]
@@ -197,7 +333,18 @@ mod test {
         let mut S = [signers[0].clone(), signers[1].clone(), signers[3].clone()].to_vec();
         let mut sig_agg = v1::Aggregator::new(N, T);
         sig_agg.init(&polys).expect("aggregator init failed");
-        let tweaked_public_key = compute::tweaked_public_key(&sig_agg.poly[0], merkle_root);
+        let aggregate_public_key = sig_agg.poly[0];
+        println!(
+            "sign_verify:  agg_pubkey    {}",
+            &hex::encode(sig_agg.poly[0].compress().as_bytes())
+        );
+        println!("sign_verify:  agg_pubkey.x  {}", &sig_agg.poly[0].x());
+        let tweaked_public_key = compute::tweaked_public_key(&aggregate_public_key, merkle_root);
+        println!(
+            "sign_verify: tweaked_key    {}",
+            &hex::encode(tweaked_public_key.compress().as_bytes())
+        );
+        println!("sign_verify: tweaked_key.x  {}", &tweaked_public_key.x());
         let (nonces, sig_shares) = test_helpers::sign(msg, &mut S, &mut rng, merkle_root);
         let proof = match sig_agg.sign_taproot(msg, &nonces, &sig_shares, &[], merkle_root) {
             Err(e) => panic!("Aggregator sign failed: {:?}", e),
@@ -260,6 +407,7 @@ mod test {
         let key_ids = S.iter().flat_map(|s| s.get_key_ids()).collect::<Vec<u32>>();
         let mut sig_agg = v2::Aggregator::new(Nk, T);
         sig_agg.init(&polys).expect("aggregator init failed");
+        let public_key = sig_agg.poly[0].clone();
         let tweaked_public_key = compute::tweaked_public_key(&sig_agg.poly[0], merkle_root);
         let (nonces, sig_shares) = test_helpers::sign(msg, &mut S, &mut rng, merkle_root);
         let proof = match sig_agg.sign_taproot(msg, &nonces, &sig_shares, &key_ids, merkle_root) {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -135,7 +135,7 @@ pub trait Aggregator: Clone + Debug + PartialEq {
     /// Initialize an Aggregator with the passed polynomial commitments
     fn init(&mut self, poly_comms: &HashMap<u32, PolyCommitment>) -> Result<(), AggregatorError>;
 
-    /// Check and aggregate the signature shares into a `Signature`
+    /// Check and aggregate the signature shares into a FROST `Signature`
     fn sign(
         &mut self,
         msg: &[u8],
@@ -144,7 +144,8 @@ pub trait Aggregator: Clone + Debug + PartialEq {
         key_ids: &[u32],
     ) -> Result<Signature, AggregatorError>;
 
-    /// Check and aggregate the signature shares into a `SchnorrProof`
+    /// Check and aggregate the signature shares into a BIP-340 `SchnorrProof`.
+    /// https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki
     fn sign_schnorr(
         &mut self,
         msg: &[u8],
@@ -153,7 +154,9 @@ pub trait Aggregator: Clone + Debug + PartialEq {
         key_ids: &[u32],
     ) -> Result<SchnorrProof, AggregatorError>;
 
-    /// Check and aggregate the signature shares into a `SchnorrProof`
+    /// Check and aggregate the signature shares into a BIP-340 `SchnorrProof` with BIP-341 key tweaks
+    /// https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki
+    /// https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki
     fn sign_taproot(
         &mut self,
         msg: &[u8],

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -145,6 +145,15 @@ pub trait Aggregator: Clone + Debug + PartialEq {
     ) -> Result<Signature, AggregatorError>;
 
     /// Check and aggregate the signature shares into a `SchnorrProof`
+    fn sign_schnorr(
+        &mut self,
+        msg: &[u8],
+        nonces: &[PublicNonce],
+        sig_shares: &[SignatureShare],
+        key_ids: &[u32],
+    ) -> Result<SchnorrProof, AggregatorError>;
+
+    /// Check and aggregate the signature shares into a `SchnorrProof`
     fn sign_taproot(
         &mut self,
         msg: &[u8],

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -107,6 +107,15 @@ pub trait Signer: Clone + Debug + PartialEq {
         nonces: &[PublicNonce],
     ) -> Vec<SignatureShare>;
 
+    /// Sign `msg` using all this signer's keys
+    fn sign_schnorr(
+        &self,
+        msg: &[u8],
+        signer_ids: &[u32],
+        key_ids: &[u32],
+        nonces: &[PublicNonce],
+    ) -> Vec<SignatureShare>;
+
     /// Sign `msg` using all this signer's keys and a tweaked public key
     fn sign_taproot(
         &self,

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -425,6 +425,25 @@ impl traits::Aggregator for Aggregator {
         }
     }
 
+    /// Check and aggregate the party signatures
+    fn sign_schnorr(
+        &mut self,
+        msg: &[u8],
+        nonces: &[PublicNonce],
+        sig_shares: &[SignatureShare],
+        _key_ids: &[u32],
+    ) -> Result<SchnorrProof, AggregatorError> {
+        let tweak = Scalar::from(0);
+        let (key, sig) = self.sign_with_tweak(msg, nonces, sig_shares, Some(tweak))?;
+        let proof = SchnorrProof::new(&sig);
+
+        if proof.verify(&key.x(), msg) {
+            Ok(proof)
+        } else {
+            Err(self.check_signature_shares(msg, nonces, sig_shares, &tweak))
+        }
+    }
+
     /// Check and aggregate the party signatures using a merke root to make a tweak
     fn sign_taproot(
         &mut self,

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -234,11 +234,11 @@ impl Party {
         }
 
         let tweaked_public_key = if let Some(t) = tweak {
-	    self.group_key + t * G
-	} else {
-	    self.group_key
-	};
-	    
+            self.group_key + t * G
+        } else {
+            self.group_key
+        };
+
         let mut cx = compute::challenge(&tweaked_public_key, aggregate_nonce, msg)
             * &self.private_key
             * compute::lambda(self.id, signers);
@@ -287,10 +287,10 @@ impl Aggregator {
         let mut z = Scalar::zero();
         let aggregate_public_key = self.poly[0];
         let tweaked_public_key = if let Some(t) = tweak {
-	    aggregate_public_key + t * G
-	} else {
-	    aggregate_public_key
-	};
+            aggregate_public_key + t * G
+        } else {
+            aggregate_public_key
+        };
         let c = compute::challenge(&tweaked_public_key, &R, msg);
         let mut cx_sign = Scalar::one();
         if tweak.is_some() && !tweaked_public_key.has_even_y() {
@@ -301,9 +301,9 @@ impl Aggregator {
             z += sig_share.z_i;
         }
 
-	if let Some(t) = tweak {
+        if let Some(t) = tweak {
             z += cx_sign * c * t;
-	}
+        }
 
         let sig = Signature { R, z };
 
@@ -643,7 +643,9 @@ impl traits::Signer for Signer {
         let tweak = compute::tweak(&self.parties[0].group_key, merkle_root);
         self.parties
             .iter()
-            .map(|p| p.sign_precomputed_with_tweak(msg, key_ids, nonces, &aggregate_nonce, Some(tweak)))
+            .map(|p| {
+                p.sign_precomputed_with_tweak(msg, key_ids, nonces, &aggregate_nonce, Some(tweak))
+            })
             .collect()
     }
 
@@ -657,7 +659,15 @@ impl traits::Signer for Signer {
         let aggregate_nonce = compute::aggregate_nonce(msg, key_ids, nonces).unwrap();
         self.parties
             .iter()
-            .map(|p| p.sign_precomputed_with_tweak(msg, key_ids, nonces, &aggregate_nonce, Some(Scalar::from(0))))
+            .map(|p| {
+                p.sign_precomputed_with_tweak(
+                    msg,
+                    key_ids,
+                    nonces,
+                    &aggregate_nonce,
+                    Some(Scalar::from(0)),
+                )
+            })
             .collect()
     }
 }

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -236,7 +236,10 @@ impl Party {
             r = -r;
         }
 
-        // When using BIP-340 32-byte public keys, we have to invert the private key if the public key is odd.  But if we're also using BIP-341 tweaked keys, we have to do the same thing if the tweaked public key is odd.  In that case, only invert the public key if exactly one of the internal or tweaked public keys is odd
+        // When using BIP-340 32-byte public keys, we have to invert the private key if the
+        // public key is odd.  But if we're also using BIP-341 tweaked keys, we have to do
+        // the same thing if the tweaked public key is odd.  In that case, only invert the
+        // public key if exactly one of the internal or tweaked public keys is odd
         let mut cx_sign = Scalar::one();
         let tweaked_public_key = if let Some(t) = tweak {
             if t != Scalar::zero() {

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -357,10 +357,8 @@ impl Aggregator {
                 if !tweaked_public_key.has_even_y() ^ !aggregate_public_key.has_even_y() {
                     cx_sign = -Scalar::one();
                 }
-            } else {
-                if !aggregate_public_key.has_even_y() {
-                    cx_sign = -Scalar::one();
-                }
+            } else if !aggregate_public_key.has_even_y() {
+                cx_sign = -Scalar::one();
             }
         }
 

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -236,7 +236,7 @@ impl Party {
             r = -r;
         }
 
-	// When using BIP-340 32-byte public keys, we have to invert the private key if the public key is odd.  But if we're also using BIP-341 tweaked keys, we have to do the same thing if the tweaked public key is odd.  In that case, only invert the public key if exactly one of the internal or tweaked public keys is odd
+        // When using BIP-340 32-byte public keys, we have to invert the private key if the public key is odd.  But if we're also using BIP-341 tweaked keys, we have to do the same thing if the tweaked public key is odd.  In that case, only invert the public key if exactly one of the internal or tweaked public keys is odd
         let mut cx_sign = Scalar::one();
         let tweaked_public_key = if let Some(t) = tweak {
             if t != Scalar::zero() {
@@ -320,7 +320,7 @@ impl Aggregator {
             z += sig_share.z_i;
         }
 
-	// The signature shares have already incorporated the private key adjustments, so we just have to add the tweak.  But the tweak itself needs to be adjusted if the tweaked public key is odd
+        // The signature shares have already incorporated the private key adjustments, so we just have to add the tweak.  But the tweak itself needs to be adjusted if the tweaked public key is odd
         if let Some(t) = tweak {
             z += cx_sign * c * t;
         }

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -393,6 +393,25 @@ impl traits::Aggregator for Aggregator {
     }
 
     /// Check and aggregate the party signatures
+    fn sign_schnorr(
+        &mut self,
+        msg: &[u8],
+        nonces: &[PublicNonce],
+        sig_shares: &[SignatureShare],
+        key_ids: &[u32],
+    ) -> Result<SchnorrProof, AggregatorError> {
+        let tweak = Scalar::from(0);
+        let (key, sig) = self.sign_with_tweak(msg, nonces, sig_shares, key_ids, Some(tweak))?;
+        let proof = SchnorrProof::new(&sig);
+
+        if proof.verify(&key.x(), msg) {
+            Ok(proof)
+        } else {
+            Err(self.check_signature_shares(msg, nonces, sig_shares, key_ids, &tweak))
+        }
+    }
+
+    /// Check and aggregate the party signatures
     fn sign_taproot(
         &mut self,
         msg: &[u8],

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -198,7 +198,10 @@ impl Party {
         nonces: &[PublicNonce],
         tweak: Option<Scalar>,
     ) -> SignatureShare {
-        // When using BIP-340 32-byte public keys, we have to invert the private key if the public key is odd.  But if we're also using BIP-341 tweaked keys, we have to do the same thing if the tweaked public key is odd.  In that case, only invert the public key if exactly one of the internal or tweaked public keys is odd
+        // When using BIP-340 32-byte public keys, we have to invert the private key if the
+        // public key is odd.  But if we're also using BIP-341 tweaked keys, we have to do
+        // the same thing if the tweaked public key is odd.  In that case, only invert the
+        // public key if exactly one of the internal or tweaked public keys is odd
         let mut cx_sign = Scalar::one();
         let tweaked_public_key = if let Some(t) = tweak {
             if t != Scalar::zero() {

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -193,7 +193,7 @@ impl Party {
         let tweaked_public_key = if let Some(t) = tweak {
             if t != Scalar::zero() {
                 let key = compute::tweaked_public_key_from_tweak(&self.group_key, t);
-                if compute::xor(key.has_even_y(), self.group_key.has_even_y()) {
+                if key.has_even_y() ^ self.group_key.has_even_y() {
                     cx_sign = -cx_sign;
                 }
 
@@ -209,7 +209,6 @@ impl Party {
         };
         let (_, R) = compute::intermediate(msg, party_ids, nonces);
         let c = compute::challenge(&tweaked_public_key, &R, msg);
-        println!("v2 sign_with_tweak: challenge {}", c);
         let mut r = &self.nonce.d + &self.nonce.e * compute::binding(&self.id(), nonces, msg);
         if tweak.is_some() && !R.has_even_y() {
             r = -r;
@@ -321,7 +320,7 @@ impl Aggregator {
         };
         let c = compute::challenge(&tweaked_public_key, &R, msg);
         let mut r_sign = Scalar::one();
-        let mut cx_sign = Scalar::one();
+        let cx_sign = Scalar::one();
         if tweak.is_some() {
             if !R.has_even_y() {
                 r_sign = -Scalar::one();

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -373,7 +373,7 @@ impl traits::Aggregator for Aggregator {
 
     /// Initialize the Aggregator polynomial
     fn init(&mut self, comms: &HashMap<u32, PolyCommitment>) -> Result<(), AggregatorError> {
-        let threshold = self.threshold.try_into().unwrap();
+        let threshold: usize = self.threshold.try_into().unwrap();
         let mut bad_poly_commitments = Vec::new();
         for (_id, comm) in comms {
             if comm.poly.len() != threshold || !comm.verify() {

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -320,13 +320,19 @@ impl Aggregator {
         };
         let c = compute::challenge(&tweaked_public_key, &R, msg);
         let mut r_sign = Scalar::one();
-        let cx_sign = Scalar::one();
-        if tweak.is_some() {
+        let mut cx_sign = Scalar::one();
+        if let Some(t) = tweak {
             if !R.has_even_y() {
                 r_sign = -Scalar::one();
             }
-            if !tweaked_public_key.has_even_y() {
-                //cx_sign = -Scalar::one();
+            if t != Scalar::zero() {
+                if !tweaked_public_key.has_even_y() ^ !aggregate_public_key.has_even_y() {
+                    cx_sign = -Scalar::one();
+                }
+            } else {
+                if !aggregate_public_key.has_even_y() {
+                    cx_sign = -Scalar::one();
+                }
             }
         }
 

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -192,7 +192,7 @@ impl Party {
         nonces: &[PublicNonce],
         tweak: Option<Scalar>,
     ) -> SignatureShare {
-	// When using BIP-340 32-byte public keys, we have to invert the private key if the public key is odd.  But if we're also using BIP-341 tweaked keys, we have to do the same thing if the tweaked public key is odd.  In that case, only invert the public key if exactly one of the internal or tweaked public keys is odd
+        // When using BIP-340 32-byte public keys, we have to invert the private key if the public key is odd.  But if we're also using BIP-341 tweaked keys, we have to do the same thing if the tweaked public key is odd.  In that case, only invert the public key if exactly one of the internal or tweaked public keys is odd
         let mut cx_sign = Scalar::one();
         let tweaked_public_key = if let Some(t) = tweak {
             if t != Scalar::zero() {
@@ -288,7 +288,7 @@ impl Aggregator {
             z += sig_share.z_i;
         }
 
-	// The signature shares have already incorporated the private key adjustments, so we just have to add the tweak.  But the tweak itself needs to be adjusted if the tweaked public key is odd
+        // The signature shares have already incorporated the private key adjustments, so we just have to add the tweak.  But the tweak itself needs to be adjusted if the tweaked public key is odd
         if let Some(t) = tweak {
             z += cx_sign * c * t;
         }

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -329,10 +329,8 @@ impl Aggregator {
                 if !tweaked_public_key.has_even_y() ^ !aggregate_public_key.has_even_y() {
                     cx_sign = -Scalar::one();
                 }
-            } else {
-                if !aggregate_public_key.has_even_y() {
-                    cx_sign = -Scalar::one();
-                }
+            } else if !aggregate_public_key.has_even_y() {
+                cx_sign = -Scalar::one();
             }
         }
 

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -190,10 +190,10 @@ impl Party {
         tweak: Option<Scalar>,
     ) -> SignatureShare {
         let tweaked_public_key = if let Some(t) = tweak {
-	    self.group_key + t * G
-	} else {
-	    self.group_key
-	};
+            self.group_key + t * G
+        } else {
+            self.group_key
+        };
         let (_, R) = compute::intermediate(msg, party_ids, nonces);
         let c = compute::challenge(&tweaked_public_key, &R, msg);
         let mut r = &self.nonce.d + &self.nonce.e * compute::binding(&self.id(), nonces, msg);
@@ -251,10 +251,10 @@ impl Aggregator {
         let mut z = Scalar::zero();
         let aggregate_public_key = self.poly[0];
         let tweaked_public_key = if let Some(t) = tweak {
-	    aggregate_public_key + t * G
-	} else {
-	    aggregate_public_key
-	};
+            aggregate_public_key + t * G
+        } else {
+            aggregate_public_key
+        };
         let c = compute::challenge(&tweaked_public_key, &R, msg);
         let mut cx_sign = Scalar::one();
         if tweak.is_some() && !tweaked_public_key.has_even_y() {
@@ -266,9 +266,9 @@ impl Aggregator {
             z += sig_share.z_i;
         }
 
-	if let Some(t) = tweak {
+        if let Some(t) = tweak {
             z += cx_sign * c * t;
-	}
+        }
 
         let sig = Signature { R, z };
 

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -131,6 +131,12 @@ impl Party {
         let mut not_enough_shares = Vec::new();
         for key_id in &self.key_ids {
             if shares[key_id].len() != comms.len() {
+                warn!(
+                    "key_id {} has {} private shares not {}",
+                    key_id,
+                    shares[key_id].len(),
+                    comms.len()
+                );
                 not_enough_shares.push(*key_id);
             }
         }


### PR DESCRIPTION
In the early days of `sBTC-Alpha`, we had no idea how `Taproot` worked.  I started by implementing `BIP-340`, only to discover that I really needed to implement `BIP-341` as well to get tweaked public keys.  At that point there was no way to do `BIP-340` alone.

We discovered recently that TapScript public key spends need to use `BIP-340` without `BIP-341`, since the whole point of tweaking the keys is to prevent hidden script spends, and we're already inside the script at that point.  So this change enables that, from the low level `Signer`/`Aggregator` code all the way up to the network packets and state machines.  