### PR TITLE
Clean up error handling in compute_secrets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ num-traits = "0.2"
 polynomial = { version = "0.2.5", features = ["serde"] }
 primitive-types = "0.12"
 rand_core = "0.6"
-p256k1 = { version = "7.1", default-features = false }
+p256k1 = { version = "7.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"
 thiserror = "1.0"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,4 @@
+use core::num::TryFromIntError;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -9,26 +10,32 @@ pub enum DkgError {
     #[error("missing public shares from {0:?}")]
     /// The public shares which were missing
     MissingPublicShares(Vec<u32>),
-    #[error("missing private shares from {0:?}")]
+    #[error("missing private shares for/from {0:?}")]
     /// The private shares which were missing
-    MissingPrivateShares(Vec<u32>),
+    MissingPrivateShares(Vec<(u32, u32)>),
     #[error("bad public shares {0:?}")]
     /// The public shares that failed to verify or were the wrong size
     BadPublicShares(Vec<u32>),
-    #[error("not enough shares {0:?}")]
-    /// Not enough shares to complete DKG
-    NotEnoughShares(Vec<u32>),
     #[error("bad private shares {0:?}")]
     /// The private shares which failed to verify
     BadPrivateShares(Vec<u32>),
     #[error("point error {0:?}")]
     /// An error during point operations
     Point(PointError),
+    #[error("integer conversion error")]
+    /// An error during integer conversion operations
+    TryFromInt,
 }
 
 impl From<PointError> for DkgError {
     fn from(e: PointError) -> Self {
         DkgError::Point(e)
+    }
+}
+
+impl From<TryFromIntError> for DkgError {
+    fn from(_e: TryFromIntError) -> Self {
+        DkgError::TryFromInt
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -42,9 +42,6 @@ impl From<TryFromIntError> for DkgError {
 #[derive(Error, Debug, Clone, Serialize, Deserialize, PartialEq)]
 /// Errors which can happen during signature aggregation
 pub enum AggregatorError {
-    #[error("bad poly commitment length (expected {0} got {1})")]
-    /// The number of polynomial commitments was wrong (no longer used)
-    BadPolyCommitmentLen(usize, usize),
     #[error("bad poly commitments {0:?}")]
     /// The polynomial commitments which failed verification or were the wrong size
     BadPolyCommitments(Vec<Scalar>),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -35,7 +35,7 @@ impl From<PointError> for DkgError {
 
 impl From<TryFromIntError> for DkgError {
     fn from(_e: TryFromIntError) -> Self {
-        DkgError::TryFromInt
+        Self::TryFromInt
     }
 }
 
@@ -60,4 +60,13 @@ pub enum AggregatorError {
     #[error("bad group sig")]
     /// The aggregate group signature failed to verify
     BadGroupSig,
+    #[error("integer conversion error")]
+    /// An error during integer conversion operations
+    TryFromInt,
+}
+
+impl From<TryFromIntError> for AggregatorError {
+    fn from(_e: TryFromIntError) -> Self {
+        Self::TryFromInt
+    }
 }

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -363,8 +363,15 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                 } else {
                     missing_public_shares.insert(*signer_id);
                 }
-                if let Some(_shares) = self.dkg_private_shares.get(signer_id) {
-                    // TODO: consider move private shares checks here
+                if let Some(shares) = self.dkg_private_shares.get(signer_id) {
+                    // signer_id sent shares, but make sure that it sent shares for every one of this signer's key_ids
+                    for dst_key_id in self.signer.get_key_ids() {
+                        for (_src_key_id, shares) in &shares.shares {
+                            if shares.get(&dst_key_id).is_none() {
+                                missing_private_shares.insert(*signer_id);
+                            }
+                        }
+                    }
                 } else {
                     missing_private_shares.insert(*signer_id);
                 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -11,7 +11,7 @@ use crate::{
     taproot::SchnorrProof,
 };
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 /// The saved state required to reconstruct a party
 pub struct PartyState {
     /// The party's private polynomial
@@ -22,7 +22,7 @@ pub struct PartyState {
     pub nonce: Nonce,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 /// The saved state required to reconstruct a signer
 pub struct SignerState {
     /// The signer ID

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -209,7 +209,7 @@ pub mod test_helpers {
     }
 
     /// Remove the provided key ids from the list of private shares and execute compute secrets
-    fn compute_secrets_not_enough_shares<RNG: RngCore + CryptoRng, Signer: super::Signer>(
+    fn compute_secrets_missing_private_shares<RNG: RngCore + CryptoRng, Signer: super::Signer>(
         signers: &mut [Signer],
         rng: &mut RNG,
         missing_key_ids: &[u32],
@@ -251,8 +251,8 @@ pub mod test_helpers {
     }
 
     #[allow(non_snake_case)]
-    /// Run compute secrets test to trigger NotEnoughShares code path
-    pub fn run_compute_secrets_not_enough_shares<Signer: super::Signer>() {
+    /// Run compute secrets test to trigger MissingPrivateShares code path
+    pub fn run_compute_secrets_missing_private_shares<Signer: super::Signer>() {
         let Nk: u32 = 10;
         let Np: u32 = 4;
         let T: u32 = 7;
@@ -265,11 +265,11 @@ pub mod test_helpers {
             .map(|(id, ids)| Signer::new(id.try_into().unwrap(), ids, Nk, Np, T, &mut rng))
             .collect();
 
-        match compute_secrets_not_enough_shares(&mut signers, &mut rng, &missing_key_ids) {
+        match compute_secrets_missing_private_shares(&mut signers, &mut rng, &missing_key_ids) {
             Ok(polys) => panic!("Got a result with missing public shares: {polys:?}"),
             Err(secret_errors) => {
                 for (_, error) in secret_errors {
-                    assert!(matches!(error, DkgError::NotEnoughShares(_)));
+                    assert!(matches!(error, DkgError::MissingPrivateShares(_)));
                 }
             }
         }

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -416,7 +416,7 @@ impl traits::Aggregator for Aggregator {
 
     /// Initialize the Aggregator polynomial
     fn init(&mut self, comms: &HashMap<u32, PolyCommitment>) -> Result<(), AggregatorError> {
-        let threshold = self.threshold.try_into().unwrap();
+        let threshold = self.threshold.try_into()?;
         let mut bad_poly_commitments = Vec::new();
         for (_id, comm) in comms {
             if comm.poly.len() != threshold || !comm.verify() {

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -181,7 +181,7 @@ impl Party {
             return Err(DkgError::BadPrivateShares(bad_shares));
         }
 
-        self.private_key = private_shares.values().fold(Scalar::zero(), |a, s| a + s);
+        self.private_key = private_shares.values().sum();
         self.public_key = self.private_key * G;
 
         Ok(())

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -181,9 +181,7 @@ impl Party {
             return Err(DkgError::BadPrivateShares(bad_shares));
         }
 
-        for (_i, s) in private_shares.iter() {
-            self.private_key += s;
-        }
+        self.private_key = private_shares.values().fold(Scalar::zero(), |a, s| a + s);
         self.public_key = self.private_key * G;
 
         Ok(())

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -136,7 +136,7 @@ impl Party {
         self.private_key = Scalar::zero();
         self.group_key = Point::zero();
 
-        let threshold: usize = self.threshold.try_into().unwrap();
+        let threshold: usize = self.threshold.try_into()?;
         let mut bad_ids = Vec::new(); //: Vec<u32> = polys
         for (i, comm) in public_shares.iter() {
             if comm.poly.len() != threshold || !comm.verify() {

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -170,9 +170,12 @@ impl Party {
         if Point::multimult_trait(&mut check_shares)? != Point::zero() {
             let mut bad_shares = Vec::new();
             for (i, s) in private_shares.iter() {
-                let comm = &public_shares[i];
-                if s * G != compute::poly(&self.id(), &comm.poly)? {
-                    bad_shares.push(*i);
+                if let Some(comm) = public_shares.get(i) {
+                    if s * G != compute::poly(&self.id(), &comm.poly)? {
+                        bad_shares.push(*i);
+                    }
+                } else {
+                    warn!("unable to check private share from {}: no corresponding public share, even though we checked for it above", i);
                 }
             }
             return Err(DkgError::BadPrivateShares(bad_shares));

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -168,10 +168,8 @@ impl Party {
         for key_id in &self.key_ids {
             self.private_keys.insert(*key_id, Scalar::zero());
             if let Some(shares) = private_shares.get(key_id) {
-                for (_sender, s) in shares {
-                    self.private_keys
-                        .insert(*key_id, self.private_keys[key_id] + s);
-                }
+                let secret = shares.values().fold(Scalar::zero(), |acc, s| acc + s);
+                self.private_keys.insert(*key_id, secret);
             } else {
                 warn!(
                     "no private shares for key_id {}, even though we checked for it above",

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -168,7 +168,7 @@ impl Party {
         for key_id in &self.key_ids {
             self.private_keys.insert(*key_id, Scalar::zero());
             if let Some(shares) = private_shares.get(key_id) {
-                let secret = shares.values().fold(Scalar::zero(), |acc, s| acc + s);
+                let secret = shares.values().sum();
                 self.private_keys.insert(*key_id, secret);
             } else {
                 warn!(

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -395,7 +395,7 @@ impl traits::Aggregator for Aggregator {
 
     /// Initialize the Aggregator polynomial
     fn init(&mut self, comms: &HashMap<u32, PolyCommitment>) -> Result<(), AggregatorError> {
-        let threshold: usize = self.threshold.try_into().unwrap();
+        let threshold: usize = self.threshold.try_into()?;
         let mut bad_poly_commitments = Vec::new();
         for (_id, comm) in comms {
             if comm.poly.len() != threshold || !comm.verify() {
@@ -406,7 +406,7 @@ impl traits::Aggregator for Aggregator {
             return Err(AggregatorError::BadPolyCommitments(bad_poly_commitments));
         }
 
-        let mut poly = Vec::with_capacity(self.threshold.try_into().unwrap());
+        let mut poly = Vec::with_capacity(threshold);
 
         for i in 0..poly.capacity() {
             poly.push(Point::zero());


### PR DESCRIPTION
Error handling in `compute_secret` has always been problematic.  This PR cleans it up, checking for the same errors in `v1` and `v2`.  

One issue is that if there is any non-overlap between public and private shares, we didn't have a good way to determine which should be treated as canonical.  But the network state machines give a good hint; since `DkgEngBegin` will specify which are the signers taking part, we should expect to have exactly those `DkgPublicShares`.

Since we're making API breaking changes to the errors, I also added `TryFromInt` variants to `DkgError` and `AggregatorError` and used them to remove most `unwrap` calls from `v1` and `v2`.

Fixes #47 and addresses #89 