### PR TITLE
Embed public and private shares into DkgPrivateBegin and DkgEndBegin

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -326,7 +326,7 @@ pub mod test_helpers {
 
 #[cfg(test)]
 /// Test module for common functionality
-pub mod test {
+mod test {
     use super::*;
     use crate::util::create_rng;
 


### PR DESCRIPTION
This change addresses issues arising from out-of-order messages that may arise when `WSTS` is used in a `p2p` network.  It adds a config option to the `Coordinator` and `Signer` state machines, that when enabled embeds the `DkgPublicShares` and `DkgPrivateShares` messages into `DkgPrivateBegin` and `DkgPrivateEnd`.  