### PR TITLE
Refactor import order and clean up whitespace in the code

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use std::{env, time};
 
-use wsts::{common::test_helpers::gen_signer_ids, traits::Aggregator, v1, v2, util::create_rng};
+use wsts::{common::test_helpers::gen_signer_ids, traits::Aggregator, util::create_rng, v1, v2};
 
 #[allow(non_snake_case)]
 fn main() {

--- a/src/net.rs
+++ b/src/net.rs
@@ -605,8 +605,8 @@ impl Packet {
 mod test {
     use super::*;
     use crate::schnorr::ID;
-    use rand_core::{CryptoRng, RngCore};
     use crate::util::create_rng;
+    use rand_core::{CryptoRng, RngCore};
 
     #[derive(Clone, Debug)]
     #[allow(dead_code)]
@@ -624,12 +624,12 @@ mod test {
             let coordinator_public_key = ecdsa::PublicKey::new(&coordinator_private_key).unwrap();
             let signer_private_key = Scalar::random(rng);
             let signer_public_key = ecdsa::PublicKey::new(&signer_private_key).unwrap();
-            
+
             let mut signer_ids_map = HashMap::new();
             let mut key_ids_map = HashMap::new();
             signer_ids_map.insert(0, signer_public_key);
             key_ids_map.insert(1, signer_public_key);
-            
+
             let public_keys = PublicKeys {
                 signers: signer_ids_map,
                 key_ids: key_ids_map,
@@ -651,7 +651,7 @@ mod test {
             Self::new(&mut rng)
         }
     }
-    
+
     #[test]
     fn dkg_begin_verify_msg() {
         let test_config = TestConfig::default();

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -1282,8 +1282,8 @@ pub mod test {
             DkgError, OperationResult, SignError,
         },
         traits::{Aggregator as AggregatorTrait, Signer as SignerTrait},
-        v1, v2,
         util::create_rng,
+        v1, v2,
     };
     use hashbrown::HashMap;
     use std::{thread, time::Duration};

--- a/src/state_machine/coordinator/frost.rs
+++ b/src/state_machine/coordinator/frost.rs
@@ -774,10 +774,9 @@ pub mod test {
             Config, Coordinator as CoordinatorTrait, State,
         },
         traits::Aggregator as AggregatorTrait,
-        v1, v2,
         util::create_rng,
+        v1, v2,
     };
-    
 
     #[test]
     fn new_coordinator_v1() {

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -567,7 +567,9 @@ pub mod test {
             inbound_messages.extend(outbound_messages);
         }
         for signer in signers.iter_mut() {
-            let outbound_messages = signer.process_inbound_messages(&feedback_messages, &mut rng).unwrap();
+            let outbound_messages = signer
+                .process_inbound_messages(&feedback_messages, &mut rng)
+                .unwrap();
             inbound_messages.extend(outbound_messages);
         }
         for coordinator in coordinators.iter_mut() {

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -182,7 +182,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
         rng: &mut R,
     ) -> Self {
         assert!(threshold <= total_keys);
-        
+
         let signer = SignerType::new(
             signer_id,
             &key_ids,
@@ -324,7 +324,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             Message::DkgPublicShares(dkg_public_shares) => self.dkg_public_share(dkg_public_shares),
             Message::DkgPrivateShares(dkg_private_shares) => {
                 self.dkg_private_shares(dkg_private_shares, rng)
-            }    
+            }
             Message::SignatureShareRequest(sign_share_request) => {
                 self.sign_share_request(sign_share_request)
             }
@@ -346,10 +346,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
     }
 
     /// DKG is done so compute secrets
-    pub fn dkg_ended<R: RngCore + CryptoRng>(
-        &mut self,
-        rng: &mut R,
-    ) -> Result<Message, Error> {
+    pub fn dkg_ended<R: RngCore + CryptoRng>(&mut self, rng: &mut R) -> Result<Message, Error> {
         if !self.can_dkg_end() {
             return Ok(Message::DkgEnd(DkgEnd {
                 dkg_id: self.dkg_id,
@@ -649,7 +646,6 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
         &mut self,
         rng: &mut R,
     ) -> Result<Vec<Message>, Error> {
-
         let mut msgs = vec![];
         let comms = self.signer.get_poly_commitments(rng);
 
@@ -726,8 +722,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                     let dst_public_key = Point::try_from(&compressed).unwrap();
                     let shared_secret =
                         make_shared_secret(&self.network_private_key, &dst_public_key);
-                    let encrypted_share =
-                        encrypt(&shared_secret, &private_share.to_bytes(), rng)?;
+                    let encrypted_share = encrypt(&shared_secret, &private_share.to_bytes(), rng)?;
 
                     encrypted_shares.insert(*dst_key_id, encrypted_share);
                 }
@@ -812,8 +807,10 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                         },
                         Err(e) => {
                             warn!("Failed to decrypt dkg private share from src_id {} to dst_id {}: {:?}", src_id, dst_key_id, e);
-                            self.invalid_private_shares
-                                .insert(src_signer_id, self.make_bad_private_share(src_signer_id, rng));
+                            self.invalid_private_shares.insert(
+                                src_signer_id,
+                                self.make_bad_private_share(src_signer_id, rng),
+                            );
                         }
                     }
                 }
@@ -837,7 +834,6 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
         signer_id: u32,
         rng: &mut R,
     ) -> BadPrivateShare {
-
         let a = self.network_private_key;
         let A = a * G;
         let B = Point::try_from(&Compressed::from(
@@ -899,8 +895,8 @@ pub mod test {
             PublicKeys,
         },
         traits::Signer as SignerTrait,
-        v1, v2,
         util::create_rng,
+        v1, v2,
     };
 
     #[test]
@@ -915,8 +911,16 @@ pub mod test {
 
     fn dkg_public_share<SignerType: SignerTrait>() {
         let mut rng = create_rng();
-        let mut signer =
-            Signer::<SignerType>::new(1, 1, 1, 1, vec![1], Default::default(), Default::default(), &mut rng);
+        let mut signer = Signer::<SignerType>::new(
+            1,
+            1,
+            1,
+            1,
+            vec![1],
+            Default::default(),
+            Default::default(),
+            &mut rng,
+        );
         let public_share = DkgPublicShares {
             dkg_id: 0,
             signer_id: 0,
@@ -944,8 +948,16 @@ pub mod test {
 
     fn public_shares_done<SignerType: SignerTrait>() {
         let mut rng = create_rng();
-        let mut signer =
-            Signer::<SignerType>::new(1, 1, 1, 1, vec![1], Default::default(), Default::default(), &mut rng);
+        let mut signer = Signer::<SignerType>::new(
+            1,
+            1,
+            1,
+            1,
+            vec![1],
+            Default::default(),
+            Default::default(),
+            &mut rng,
+        );
         // publich_shares_done starts out as false
         assert!(!signer.public_shares_done());
 
@@ -982,7 +994,8 @@ pub mod test {
         public_keys.signers.insert(0, public_key.clone());
         public_keys.key_ids.insert(1, public_key.clone());
 
-        let mut signer = Signer::<SignerType>::new(1, 1, 1, 0, vec![1], private_key, public_keys, &mut rng);
+        let mut signer =
+            Signer::<SignerType>::new(1, 1, 1, 0, vec![1], private_key, public_keys, &mut rng);
         // can_dkg_end starts out as false
         assert!(!signer.can_dkg_end());
 
@@ -1035,8 +1048,16 @@ pub mod test {
         .with(EnvFilter::from_default_env())
         .init();*/
         let mut rng = create_rng();
-        let mut signer =
-            Signer::<SignerType>::new(1, 1, 1, 0, vec![1], Default::default(), Default::default(), &mut rng);
+        let mut signer = Signer::<SignerType>::new(
+            1,
+            1,
+            1,
+            0,
+            vec![1],
+            Default::default(),
+            Default::default(),
+            &mut rng,
+        );
 
         if let Ok(Message::DkgEnd(dkg_end)) = signer.dkg_ended(&mut rng) {
             match dkg_end.status {

--- a/src/taproot.rs
+++ b/src/taproot.rs
@@ -148,8 +148,7 @@ pub mod test_helpers {
 mod test {
     use super::{test_helpers, Point, Scalar, SchnorrProof, G};
 
-    use crate::{compute, traits::Aggregator, traits::Signer, v1, v2, util::create_rng};
-    
+    use crate::{compute, traits::Aggregator, traits::Signer, util::create_rng, v1, v2};
 
     #[test]
     #[allow(non_snake_case)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,5 @@
 use aes_gcm::{aead::Aead, Aes256Gcm, Error as AesGcmError, KeyInit, Nonce};
-use rand_core::{CryptoRng, RngCore, OsRng};
+use rand_core::{CryptoRng, OsRng, RngCore};
 use sha2::{Digest, Sha256};
 
 use crate::curve::{point::Point, scalar::Scalar};

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -18,7 +18,6 @@ use crate::{
     vss::VSS,
 };
 
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 /// A FROST party, which encapsulates a single polynomial, nonce, and key
 pub struct Party {
@@ -790,8 +789,8 @@ mod tests {
     use crate::traits;
     use crate::traits::test_helpers::run_compute_secrets_missing_private_shares;
     use crate::traits::{Aggregator, Signer};
-    use crate::v1;
     use crate::util::create_rng;
+    use crate::v1;
 
     use num_traits::Zero;
 

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -732,13 +732,13 @@ pub mod test_helpers {
 
 #[cfg(test)]
 mod tests {
+    use crate::util::create_rng;
     use crate::{
         traits::{
             self, test_helpers::run_compute_secrets_missing_private_shares, Aggregator, Signer,
         },
         v2,
     };
-    use crate::util::create_rng;
 
     #[test]
     fn party_save_load() {


### PR DESCRIPTION
Fix this formatting check error: https://github.com/Trust-Machines/wsts/actions/runs/12052861798/job/33607158612#step:5:281


Tested it pass new fmt check locally.

```
cargo fmt --all -- --check
```