### PR TITLE
Fix bad public shares check

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -214,6 +214,11 @@ impl TupleProof {
     }
 }
 
+/// Check that the PolyCommitment is properly signed and has the correct degree polynomial
+pub fn check_public_shares(poly_comm: &PolyCommitment, threshold: usize) -> bool {
+    poly_comm.verify() && poly_comm.poly.len() == threshold
+}
+
 /// An implementation of p256k1's MultiMult trait that allows fast checking of DKG private shares
 /// We convert a set of checked polynomial evaluations into a single giant multimult
 /// These evaluations take the form of s * G == \Sum{k=0}{T+1}(a_k * x^k) where the a vals are the coeffs of the polys

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -4,7 +4,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use tracing::{debug, info, trace, warn};
 
 use crate::{
-    common::{PolyCommitment, PublicNonce, TupleProof},
+    common::{check_public_shares, PolyCommitment, PublicNonce, TupleProof},
     curve::{
         point::{Compressed, Point, G},
         scalar::Scalar,
@@ -357,7 +357,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             for signer_id in &dkg_end_begin.signer_ids {
                 if let Some(shares) = self.dkg_public_shares.get(signer_id) {
                     for (party_id, comm) in shares.comms.iter() {
-                        if comm.poly.len() != threshold || !comm.verify() {
+                        if !check_public_shares(comm, threshold) {
                             bad_public_shares.insert(*signer_id);
                         } else {
                             self.commitments.insert(*party_id, comm.clone());

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -5,7 +5,10 @@ use rand_core::{CryptoRng, RngCore};
 use tracing::warn;
 
 use crate::{
-    common::{CheckPrivateShares, Nonce, PolyCommitment, PublicNonce, Signature, SignatureShare},
+    common::{
+        check_public_shares, CheckPrivateShares, Nonce, PolyCommitment, PublicNonce, Signature,
+        SignatureShare,
+    },
     compute,
     curve::{
         point::{Point, G},
@@ -139,7 +142,7 @@ impl Party {
         let threshold: usize = self.threshold.try_into()?;
         let mut bad_ids = Vec::new(); //: Vec<u32> = polys
         for (i, comm) in public_shares.iter() {
-            if comm.poly.len() != threshold || !comm.verify() {
+            if !check_public_shares(comm, threshold) {
                 bad_ids.push(*i);
             } else {
                 self.group_key += comm.poly[0];
@@ -420,7 +423,7 @@ impl traits::Aggregator for Aggregator {
         let threshold = self.threshold.try_into()?;
         let mut bad_poly_commitments = Vec::new();
         for (_id, comm) in comms {
-            if comm.poly.len() != threshold || !comm.verify() {
+            if !check_public_shares(comm, threshold) {
                 bad_poly_commitments.push(comm.id.id);
             }
         }

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -5,7 +5,7 @@ use rand_core::{CryptoRng, RngCore};
 use tracing::warn;
 
 use crate::{
-    common::{Nonce, PolyCommitment, PublicNonce, Signature, SignatureShare},
+    common::{check_public_shares, Nonce, PolyCommitment, PublicNonce, Signature, SignatureShare},
     compute,
     curve::{
         point::{Point, G},
@@ -112,7 +112,7 @@ impl Party {
 
         let mut bad_ids = Vec::new();
         for (i, comm) in public_shares.iter() {
-            if comm.poly.len() != threshold || !comm.verify() {
+            if !check_public_shares(comm, threshold) {
                 bad_ids.push(*i);
             } else {
                 self.group_key += comm.poly[0];
@@ -411,7 +411,7 @@ impl traits::Aggregator for Aggregator {
         let threshold: usize = self.threshold.try_into()?;
         let mut bad_poly_commitments = Vec::new();
         for (_id, comm) in comms {
-            if comm.poly.len() != threshold || !comm.verify() {
+            if !check_public_shares(comm, threshold) {
                 bad_poly_commitments.push(comm.id.id);
             }
         }


### PR DESCRIPTION
We saw an issue on `sBTC` testnet where a single signer with a bad threshold not only prevented `DKG` from completing, but also caused the `Coordinator` to think that all signers were malicious.  This was because the signers were checking the threshold when evaluating `DkgPublicShares`, but the `Coordinator` was not.

To fix this, move the public shares check to common code, and call it from everywhere.  

Fixes #105 