### PR TITLE
fix: cleaner sign share request implementation

### DIFF
--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -1117,7 +1117,6 @@ pub mod test {
             }
         }
 
-        assert_eq!(outbound_messages.len(), 1);
         let messages = outbound_messages.clone();
         let result = feedback_messages_with_errors(&mut coordinators, &mut signers, &messages);
         assert!(result.is_ok());

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -1121,12 +1121,48 @@ pub mod test {
         let result = feedback_messages_with_errors(&mut coordinators, &mut signers, &messages);
         assert!(result.is_ok());
 
-        // add NonceResponses so there's more than the number of signers
+        // test request with no NonceResponses
+        let mut packet = outbound_messages[0].clone();
+        if let Message::SignatureShareRequest(ref mut request) = packet.msg {
+            request.nonce_responses.clear();
+        } else {
+            panic!("failed to match message");
+        }
+
+        // Send the SignatureShareRequest message to all signers and share
+        // their responses with the coordinator and signers
+        let result = feedback_messages_with_errors(&mut coordinators, &mut signers, &[packet]);
+        if !matches!(
+            result,
+            Err(StateMachineError::Signer(SignerError::InvalidNonceResponse))
+        ) {
+            panic!("Should have received signer invalid nonce response error, got {result:?}");
+        }
+
+        // test request with a duplicate NonceResponse
         let mut packet = outbound_messages[0].clone();
         if let Message::SignatureShareRequest(ref mut request) = packet.msg {
             request
                 .nonce_responses
                 .push(request.nonce_responses[0].clone());
+        } else {
+            panic!("failed to match message");
+        }
+
+        // Send the SignatureShareRequest message to all signers and share
+        // their responses with the coordinator and signers
+        let result = feedback_messages_with_errors(&mut coordinators, &mut signers, &[packet]);
+        if !matches!(
+            result,
+            Err(StateMachineError::Signer(SignerError::InvalidNonceResponse))
+        ) {
+            panic!("Should have received signer invalid nonce response error, got {result:?}");
+        }
+
+        // test request with an out of range signer_id
+        let mut packet = outbound_messages[0].clone();
+        if let Message::SignatureShareRequest(ref mut request) = packet.msg {
+            request.nonce_responses[0].signer_id = num_signers;
         } else {
             panic!("failed to match message");
         }

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -1117,19 +1117,23 @@ pub mod test {
             }
         }
 
+        assert_eq!(outbound_messages.len(), 1);
+        let messages = outbound_messages.clone();
+        let result = feedback_messages_with_errors(&mut coordinators, &mut signers, &messages);
+        assert!(result.is_ok());
+
         // add NonceResponses so there's more than the number of signers
         let mut packet = outbound_messages[0].clone();
         if let Message::SignatureShareRequest(ref mut request) = packet.msg {
-            for _ in 0..1000 {
-                request
-                    .nonce_responses
-                    .push(request.nonce_responses.first().unwrap().clone());
-            }
+            request
+                .nonce_responses
+                .push(request.nonce_responses[0].clone());
         } else {
             panic!("failed to match message");
         }
 
-        // Send the SignatureShareRequest message to all signers and share their responses with the coordinator and signers
+        // Send the SignatureShareRequest message to all signers and share
+        // their responses with the coordinator and signers
         let result = feedback_messages_with_errors(&mut coordinators, &mut signers, &[packet]);
         if !matches!(
             result,

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -573,16 +573,16 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
         // increment by one until self.total_signers - 1. So the checks
         // here should be sufficient for catching empty signer ID sets,
         // duplicate signer IDs, or unknown signer IDs.
-        let is_valid_request = sign_request.nonce_responses.len() != signer_id_set.len()
+        let is_invalid_request = sign_request.nonce_responses.len() != signer_id_set.len()
             || signer_id_set.is_empty()
             || signer_id_set.last() >= Some(&self.total_signers);
 
-        if is_valid_request {
+        if is_invalid_request {
             warn!("received an invalid SignatureShareRequest");
             return Err(Error::InvalidNonceResponse);
         }
 
-        debug!(%self.signer_id, "received a valid SignatureShareRequest");
+        debug!(signer_id = %self.signer_id, "received a valid SignatureShareRequest");
 
         if signer_id_set.contains(&self.signer_id) {
             let key_ids: Vec<u32> = sign_request


### PR DESCRIPTION
## Description

This builds off of https://github.com/Trust-Machines/wsts/pull/107, which addressed https://github.com/Trust-Machines/wsts/issues/108.

## Changes 

* Fixes an off-by-one error in the current implementation.
* Simplifies the implementation of `sign_share_request` slightly.

## Testing

I still need to test all of the conditions checked for in the `sign_share_request` function.