### PR TITLE
fix: check threshold keys during DKG

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -320,7 +320,7 @@ pub mod test_helpers {
 }
 
 #[cfg(test)]
-pub mod test {
+mod test {
     use rand_core::OsRng;
 
     use crate::{

--- a/src/net.rs
+++ b/src/net.rs
@@ -57,6 +57,8 @@ pub struct BadPrivateShare {
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 /// Final DKG status after receiving public and private shares
 pub enum DkgFailure {
+    /// DKG threshold not met
+    Threshold,
     /// Signer was in the wrong internal state to complete DKG
     BadState,
     /// DKG public shares were missing from these signer_ids
@@ -625,12 +627,17 @@ mod test {
             let signer_private_key = Scalar::random(&mut rng);
             let signer_public_key = ecdsa::PublicKey::new(&signer_private_key).unwrap();
             let mut signer_ids_map = HashMap::new();
+            let mut signer_key_ids = HashMap::new();
             let mut key_ids_map = HashMap::new();
+            let mut key_ids_set = HashSet::new();
             signer_ids_map.insert(0, signer_public_key);
             key_ids_map.insert(1, signer_public_key);
+            key_ids_set.insert(1);
+            signer_key_ids.insert(0, key_ids_set);
             let public_keys = PublicKeys {
                 signers: signer_ids_map,
                 key_ids: key_ids_map,
+                signer_key_ids,
             };
             let coordinator_private_key = Scalar::random(&mut rng);
             let coordinator_public_key = ecdsa::PublicKey::new(&coordinator_private_key).unwrap();

--- a/src/state_machine/coordinator/frost.rs
+++ b/src/state_machine/coordinator/frost.rs
@@ -761,7 +761,7 @@ impl<Aggregator: AggregatorTrait> CoordinatorTrait for Coordinator<Aggregator> {
 }
 
 #[cfg(test)]
-pub mod test {
+mod test {
     use crate::{
         curve::scalar::Scalar,
         net::{DkgBegin, Message, NonceRequest, Packet, SignatureType},

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -443,6 +443,7 @@ pub mod test {
         )
     }
 
+    #[allow(static_mut_refs)]
     pub fn setup_with_timeouts<Coordinator: CoordinatorTrait, SignerType: SignerTrait>(
         num_signers: u32,
         keys_per_signer: u32,
@@ -497,6 +498,7 @@ pub mod test {
         let public_keys = PublicKeys {
             signers: signer_ids_map,
             key_ids: key_ids_map,
+            signer_key_ids: signer_key_ids_set.clone(),
         };
 
         let signers = key_pairs
@@ -505,6 +507,7 @@ pub mod test {
             .map(|(signer_id, (private_key, _public_key))| {
                 Signer::<SignerType>::new(
                     threshold,
+                    dkg_threshold,
                     num_signers,
                     num_keys,
                     signer_id as u32,
@@ -512,6 +515,7 @@ pub mod test {
                     *private_key,
                     public_keys.clone(),
                 )
+                .unwrap()
             })
             .collect::<Vec<Signer<SignerType>>>();
         let coordinators = key_pairs

--- a/src/state_machine/mod.rs
+++ b/src/state_machine/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use hashbrown::HashMap;
+use hashbrown::{HashMap, HashSet};
 use thiserror::Error;
 
 use crate::{
@@ -79,6 +79,8 @@ pub struct PublicKeys {
     pub signers: HashMap<u32, ecdsa::PublicKey>,
     /// key_id -> public key
     pub key_ids: HashMap<u32, ecdsa::PublicKey>,
+    /// map of signer_id to controlled key_ids
+    pub signer_key_ids: HashMap<u32, HashSet<u32>>,
 }
 
 impl std::fmt::Debug for PublicKeys {


### PR DESCRIPTION
## Description

## Changes

* Add a DKG threshold parameter to signer state machines. This parameter mirrors the parameter given to the coordinator state machines.
* Have signer state machines check that the number of distinct keys sent from the coordinator when ending DKG passes the new DKG threshold parameter.


## Testing Information

This PR adds a test for the above

## Checklist:

- [x] I have performed a self-review of my code

