### PR TITLE
Check DKG threshold in Signer state machine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,26 +64,26 @@ jobs:
           command: clippy
           args: -- -D warnings -A clippy::op-ref -A clippy::needless-range-loop
 
-  doc:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - name: Install LaTeX
-        run: ./.doc/install-latex-ubuntu.sh
-      - name: Build WebSite
-        run: ./.doc/build.sh
-      - name: upload pdf
-        uses: actions/upload-artifact@v3
-        with:
-          name: wsts.pdf
-          path: wsts.pdf
-      - name: upload website
-        uses: actions/upload-artifact@v3
-        with:
-          name: website
-          path: ./target/doc/
+#  doc:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v2
+#      - uses: actions-rs/toolchain@v1
+#        with:
+#          profile: minimal
+#          toolchain: stable
+#          override: true
+#      - name: Install LaTeX
+#        run: ./.doc/install-latex-ubuntu.sh
+#      - name: Build WebSite
+#        run: ./.doc/build.sh
+#      - name: upload pdf
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: wsts.pdf
+#          path: wsts.pdf
+#      - name: upload website
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: website
+#          path: ./target/doc/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsts"
-version = "11.0.0"
+version = "12.0.0"
 edition = "2021"
 authors = ["Joey Yandle <xoloki@gmail.com>"]
 license = "Apache-2.0"

--- a/src/net.rs
+++ b/src/net.rs
@@ -57,6 +57,8 @@ pub struct BadPrivateShare {
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 /// Final DKG status after receiving public and private shares
 pub enum DkgFailure {
+    /// DKG threshold not met
+    Threshold,
     /// Signer was in the wrong internal state to complete DKG
     BadState,
     /// DKG public shares were missing from these signer_ids
@@ -626,13 +628,18 @@ mod test {
             let signer_public_key = ecdsa::PublicKey::new(&signer_private_key).unwrap();
 
             let mut signer_ids_map = HashMap::new();
+            let mut signer_key_ids = HashMap::new();
             let mut key_ids_map = HashMap::new();
+            let mut key_ids_set = HashSet::new();
             signer_ids_map.insert(0, signer_public_key);
             key_ids_map.insert(1, signer_public_key);
+            key_ids_set.insert(1);
+            signer_key_ids.insert(0, key_ids_set);
 
             let public_keys = PublicKeys {
                 signers: signer_ids_map,
                 key_ids: key_ids_map,
+                signer_key_ids,
             };
 
             Self {

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -419,16 +419,11 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
             dkg_id = %self.current_dkg_id,
             "Starting Private Share Distribution"
         );
-        let active_key_ids = self
-            .dkg_public_shares
-            .keys()
-            .flat_map(|signer_id| self.config.signer_key_ids[signer_id].clone())
-            .collect::<Vec<u32>>();
 
         let dkg_begin = DkgPrivateBegin {
             dkg_id: self.current_dkg_id,
-            key_ids: active_key_ids,
             signer_ids: self.dkg_public_shares.keys().cloned().collect(),
+            key_ids: vec![],
         };
         let dkg_private_begin_msg = Packet {
             sig: dkg_begin
@@ -453,16 +448,11 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
             dkg_id = %self.current_dkg_id,
             "Starting DkgEnd Distribution"
         );
-        let active_key_ids = self
-            .dkg_private_shares
-            .keys()
-            .flat_map(|signer_id| self.config.signer_key_ids[signer_id].clone())
-            .collect::<Vec<u32>>();
 
         let dkg_end_begin = DkgEndBegin {
             dkg_id: self.current_dkg_id,
-            key_ids: active_key_ids,
             signer_ids: self.dkg_private_shares.keys().cloned().collect(),
+            key_ids: vec![],
         };
         let dkg_end_begin_msg = Packet {
             sig: dkg_end_begin
@@ -573,10 +563,15 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
             // if there are any errors, mark signers malicious and retry
             for (signer_id, dkg_end) in &self.dkg_end_messages {
                 if let DkgStatus::Failure(dkg_failure) = &dkg_end.status {
+                    warn!(%signer_id, ?dkg_failure, "DkgEnd failure");
                     match dkg_failure {
                         DkgFailure::BadState => {
                             // signer should not be in a bad state so treat as malicious
                             self.malicious_dkg_signer_ids.insert(*signer_id);
+                            dkg_failures.insert(*signer_id, dkg_failure.clone());
+                        }
+                        DkgFailure::Threshold => {
+                            dkg_failures.insert(*signer_id, dkg_failure.clone());
                         }
                         DkgFailure::BadPublicShares(bad_shares) => {
                             // bad_shares is a set of signer_ids
@@ -686,14 +681,21 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                                 }
                             }
                         }
-                        _ => (),
+                        DkgFailure::MissingPublicShares(_) => {
+                            dkg_failures.insert(*signer_id, dkg_failure.clone());
+                        }
+                        DkgFailure::MissingPrivateShares(_) => {
+                            dkg_failures.insert(*signer_id, dkg_failure.clone());
+                        }
                     }
                 }
             }
             if dkg_failures.is_empty() {
+                warn!("no dkg failures");
                 self.dkg_end_gathered()?;
             } else {
                 // TODO: see if we have sufficient non-malicious signers to continue
+                warn!("got dkg failures");
                 return Err(Error::DkgFailure(dkg_failures));
             }
         }
@@ -1501,7 +1503,7 @@ pub mod test {
         // Send the DKG Private Begin message to all signers and share their responses with the coordinators and signers
         let (outbound_messages, operation_results) =
             feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
-        assert_eq!(operation_results.len(), 0);
+        assert!(operation_results.is_empty());
         assert_eq!(outbound_messages.len(), 1);
         match &outbound_messages[0].msg {
             Message::DkgEndBegin(_) => {}
@@ -1513,7 +1515,7 @@ pub mod test {
         // Send the DkgEndBegin message to all signers and share their responses with the coordinators and signers
         let (outbound_messages, operation_results) =
             feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
-        assert_eq!(outbound_messages.len(), 0);
+        assert!(outbound_messages.is_empty());
         assert_eq!(operation_results.len(), 1);
         match operation_results[0] {
             OperationResult::Dkg(point) => {
@@ -1587,8 +1589,8 @@ pub mod test {
             &[message.clone()],
         );
 
-        assert_eq!(outbound_messages.len(), 0);
-        assert_eq!(operation_results.len(), 0);
+        assert!(outbound_messages.is_empty());
+        assert!(operation_results.is_empty());
         assert_eq!(coordinators.first().unwrap().state, State::DkgPublicGather,);
 
         // Sleep long enough to hit the timeout
@@ -1601,7 +1603,7 @@ pub mod test {
             .unwrap();
 
         assert_eq!(outbound_messages.len(), 1);
-        assert_eq!(operation_results.len(), 0);
+        assert!(operation_results.is_empty());
         assert_eq!(
             minimum_coordinators.first().unwrap().state,
             State::DkgPrivateGather,
@@ -1658,8 +1660,8 @@ pub mod test {
             &[message.clone()],
         );
 
-        assert_eq!(outbound_messages.len(), 0);
-        assert_eq!(operation_results.len(), 0);
+        assert!(outbound_messages.is_empty());
+        assert!(operation_results.is_empty());
         assert_eq!(
             minimum_coordinators.first().unwrap().state,
             State::DkgPublicGather,
@@ -1675,7 +1677,7 @@ pub mod test {
             .unwrap();
 
         assert_eq!(outbound_messages.len(), 1);
-        assert_eq!(operation_results.len(), 0);
+        assert!(operation_results.is_empty());
         assert_eq!(
             minimum_coordinators.first().unwrap().state,
             State::DkgPrivateGather,
@@ -1714,7 +1716,7 @@ pub mod test {
             &outbound_messages,
         );
         assert!(outbound_messages.is_empty());
-        assert_eq!(operation_results.len(), 0);
+        assert!(operation_results.is_empty());
         assert_eq!(
             minimum_coordinator.first().unwrap().state,
             State::DkgPrivateGather,
@@ -1730,7 +1732,7 @@ pub mod test {
             .unwrap();
 
         assert_eq!(outbound_messages.len(), 1);
-        assert_eq!(operation_results.len(), 0);
+        assert!(operation_results.is_empty());
         match &outbound_messages[0].msg {
             Message::DkgEndBegin(_) => {}
             _ => {
@@ -1748,7 +1750,7 @@ pub mod test {
             &mut minimum_signers,
             &outbound_messages,
         );
-        assert_eq!(outbound_messages.len(), 0);
+        assert!(outbound_messages.is_empty());
         assert_eq!(operation_results.len(), 1);
         match operation_results[0] {
             OperationResult::Dkg(point) => {
@@ -1812,8 +1814,8 @@ pub mod test {
         );
 
         // Failed to get an aggregate public key
-        assert_eq!(outbound_messages.len(), 0);
-        assert_eq!(operation_results.len(), 0);
+        assert!(outbound_messages.is_empty());
+        assert!(operation_results.is_empty());
         for coordinator in &insufficient_coordinators {
             assert_eq!(coordinator.state, State::DkgPublicGather);
         }
@@ -1878,7 +1880,7 @@ pub mod test {
             &outbound_messages,
         );
         assert!(outbound_messages.is_empty());
-        assert_eq!(operation_results.len(), 0);
+        assert!(operation_results.is_empty());
         assert_eq!(
             insufficient_coordinator.first().unwrap().state,
             State::DkgPrivateGather,
@@ -1992,7 +1994,7 @@ pub mod test {
                 }
             },
         );
-        assert_eq!(operation_results.len(), 0);
+        assert!(operation_results.is_empty());
         assert_eq!(outbound_messages.len(), 1);
         match &outbound_messages[0].msg {
             Message::DkgEndBegin(_) => {}
@@ -2004,7 +2006,7 @@ pub mod test {
         // Send the DkgEndBegin message to all signers and share their responses with the coordinators and signers
         let (outbound_messages, operation_results) =
             feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
-        assert_eq!(outbound_messages.len(), 0);
+        assert!(outbound_messages.is_empty());
         assert_eq!(operation_results.len(), 1);
         match &operation_results[0] {
             OperationResult::DkgError(dkg_error) => {
@@ -2109,7 +2111,7 @@ pub mod test {
 
         let (outbound_messages, operation_results) =
             feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
-        assert_eq!(operation_results.len(), 0);
+        assert!(operation_results.is_empty());
         assert_eq!(outbound_messages.len(), 1);
         match &outbound_messages[0].msg {
             Message::DkgEndBegin(_) => {}
@@ -2121,7 +2123,7 @@ pub mod test {
         // Send the DkgEndBegin message to all signers and share their responses with the coordinators and signers
         let (outbound_messages, operation_results) =
             feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
-        assert_eq!(outbound_messages.len(), 0);
+        assert!(outbound_messages.is_empty());
         assert_eq!(operation_results.len(), 1);
         match &operation_results[0] {
             OperationResult::DkgError(dkg_error) => {
@@ -2433,7 +2435,7 @@ pub mod test {
         // Send the DKG Private Begin message to all signers and share their responses with the coordinators and signers
         let (outbound_messages, operation_results) =
             feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
-        assert_eq!(operation_results.len(), 0);
+        assert!(operation_results.is_empty());
         assert_eq!(outbound_messages.len(), 1);
         match &outbound_messages[0].msg {
             Message::DkgEndBegin(_) => {}
@@ -2576,7 +2578,7 @@ pub mod test {
             .unwrap();
 
         assert_eq!(outbound_messages.len(), 1);
-        assert_eq!(operation_results.len(), 0);
+        assert!(operation_results.is_empty());
         assert_eq!(
             insufficient_coordinators.first().unwrap().state,
             State::NonceGather(signature_type)
@@ -2594,7 +2596,7 @@ pub mod test {
             &outbound_messages,
         );
         assert_eq!(outbound_messages.len(), 1);
-        assert_eq!(operation_results.len(), 0);
+        assert!(operation_results.is_empty());
 
         for coordinator in &insufficient_coordinators {
             assert_eq!(coordinator.state, State::SigShareGather(signature_type));
@@ -2627,7 +2629,7 @@ pub mod test {
             .process_inbound_messages(&[])
             .unwrap();
 
-        assert_eq!(outbound_messages.len(), 0);
+        assert!(outbound_messages.is_empty());
         assert_eq!(operation_results.len(), 1);
         assert_eq!(
             insufficient_coordinators.first_mut().unwrap().state,
@@ -2895,7 +2897,7 @@ pub mod test {
         // Send the DKG Private Begin message to all signers and share their responses with the coordinator and signers
         let (outbound_messages, operation_results) =
             feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
-        assert_eq!(operation_results.len(), 0);
+        assert!(operation_results.is_empty());
         assert_eq!(outbound_messages.len(), 1);
         match &outbound_messages[0].msg {
             Message::DkgEndBegin(_) => {}
@@ -2907,7 +2909,7 @@ pub mod test {
         // Send the DkgEndBegin message to all signers and share their responses with the coordinator and signers
         let (outbound_messages, operation_results) =
             feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
-        assert_eq!(outbound_messages.len(), 0);
+        assert!(outbound_messages.is_empty());
         assert_eq!(operation_results.len(), 1);
         match &operation_results[0] {
             OperationResult::DkgError(DkgError::DkgEndFailure(failure_map)) => {
@@ -2946,6 +2948,85 @@ pub mod test {
                 "Expected OperationResult::DkgError(DkgError::DkgEndFailure), got {:?}",
                 &result
             ),
+        }
+    }
+
+    #[test]
+    fn bad_dkg_threshold_v1() {
+        bad_dkg_threshold::<v1::Aggregator, v1::Signer>();
+    }
+
+    #[test]
+    fn bad_dkg_threshold_v2() {
+        bad_dkg_threshold::<v2::Aggregator, v2::Signer>();
+    }
+
+    fn bad_dkg_threshold<Aggregator: AggregatorTrait, SignerType: SignerTrait>() {
+        let (mut coordinators, mut signers) =
+            setup::<FireCoordinator<Aggregator>, SignerType>(10, 1);
+
+        // We have started a dkg round
+        let message = coordinators.first_mut().unwrap().start_dkg_round().unwrap();
+        assert!(coordinators
+            .first_mut()
+            .unwrap()
+            .get_aggregate_public_key()
+            .is_none());
+        assert_eq!(
+            coordinators.first_mut().unwrap().get_state(),
+            State::DkgPublicGather
+        );
+
+        // Send the DKG Begin message to all signers and gather responses by sharing with all other signers and coordinator
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &[message]);
+        assert!(operation_results.is_empty());
+        for coordinator in coordinators.iter() {
+            assert_eq!(coordinator.get_state(), State::DkgPrivateGather);
+        }
+
+        assert_eq!(outbound_messages.len(), 1);
+        match &outbound_messages[0].msg {
+            Message::DkgPrivateBegin(_) => {}
+            _ => {
+                panic!("Expected DkgPrivateBegin message");
+            }
+        }
+
+        // Send the DKG Private Begin message to all signers and share their responses with the coordinator and signers
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
+        assert!(operation_results.is_empty());
+        assert_eq!(outbound_messages.len(), 1);
+        match &outbound_messages[0].msg {
+            Message::DkgEndBegin(_) => {}
+            _ => {
+                panic!("Expected DkgEndBegin message");
+            }
+        }
+
+        // alter the DkgEndBegin message
+        let mut packet = outbound_messages[0].clone();
+        if let Message::DkgEndBegin(ref mut dkg_end_begin) = packet.msg {
+            dkg_end_begin.signer_ids = vec![0u32];
+        }
+
+        // Send the DkgEndBegin message to all signers and share their responses with the coordinator and signers
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &[packet]);
+        assert!(outbound_messages.is_empty());
+        assert_eq!(operation_results.len(), 1);
+        match &operation_results[0] {
+            OperationResult::DkgError(DkgError::DkgEndFailure(failure_map)) => {
+                for (signer_id, failure) in failure_map {
+                    if !matches!(failure, DkgFailure::Threshold) {
+                        panic!("{signer_id} had wrong failure {:?}", failure);
+                    }
+                }
+            }
+            result => {
+                panic!("Expected DkgEndFailure got {:?}", result);
+            }
         }
     }
 }

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -491,6 +491,7 @@ pub mod test {
         let public_keys = PublicKeys {
             signers: signer_ids_map,
             key_ids: key_ids_map,
+            signer_key_ids: signer_key_ids_set.clone(),
         };
 
         let signers = key_pairs
@@ -499,6 +500,7 @@ pub mod test {
             .map(|(signer_id, (private_key, _public_key))| {
                 Signer::<SignerType>::new(
                     threshold,
+                    dkg_threshold,
                     num_signers,
                     num_keys,
                     signer_id as u32,
@@ -507,6 +509,7 @@ pub mod test {
                     public_keys.clone(),
                     &mut rng,
                 )
+                .unwrap()
             })
             .collect::<Vec<Signer<SignerType>>>();
         let coordinators = key_pairs

--- a/src/state_machine/mod.rs
+++ b/src/state_machine/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use hashbrown::HashMap;
+use hashbrown::{HashMap, HashSet};
 use thiserror::Error as ThisError;
 
 use crate::{
@@ -92,6 +92,8 @@ pub struct PublicKeys {
     pub signers: HashMap<u32, ecdsa::PublicKey>,
     /// key_id -> public key
     pub key_ids: HashMap<u32, ecdsa::PublicKey>,
+    /// map of signer_id to controlled key_ids
+    pub signer_key_ids: HashMap<u32, HashSet<u32>>,
 }
 
 impl std::fmt::Debug for PublicKeys {

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -1,3 +1,4 @@
+use core::num::TryFromIntError;
 use hashbrown::{HashMap, HashSet};
 use rand_core::{CryptoRng, RngCore};
 use std::collections::{BTreeMap, BTreeSet};
@@ -40,6 +41,9 @@ pub enum State {
 #[derive(thiserror::Error, Clone, Debug)]
 /// The error type for a signer
 pub enum Error {
+    /// The threshold was invalid
+    #[error("InvalidThreshold")]
+    InvalidThreshold,
     /// The party ID was invalid
     #[error("InvalidPartyID")]
     InvalidPartyID,
@@ -61,6 +65,15 @@ pub enum Error {
     /// An encryption error occurred
     #[error("Encryption error: {0}")]
     Encryption(#[from] EncryptionError),
+    #[error("integer conversion error")]
+    /// An error during integer conversion operations
+    TryFromInt,
+}
+
+impl From<TryFromIntError> for Error {
+    fn from(_e: TryFromIntError) -> Self {
+        Self::TryFromInt
+    }
 }
 
 /// The saved state required to reconstruct a signer
@@ -74,6 +87,8 @@ pub struct SavedState {
     pub sign_iter_id: u64,
     /// the threshold of the keys needed for a valid signature
     pub threshold: u32,
+    /// the threshold of the keys needed for a valid DKG
+    pub dkg_threshold: u32,
     /// the total number of signers
     pub total_signers: u32,
     /// the total number of keys
@@ -123,6 +138,8 @@ pub struct Signer<SignerType: SignerTrait> {
     pub sign_iter_id: u64,
     /// the threshold of the keys needed for a valid signature
     pub threshold: u32,
+    /// the threshold of the keys needed for a valid DKG
+    pub dkg_threshold: u32,
     /// the total number of signers
     pub total_signers: u32,
     /// the total number of keys
@@ -166,6 +183,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
     #[allow(clippy::too_many_arguments)]
     pub fn new<R: RngCore + CryptoRng>(
         threshold: u32,
+        dkg_threshold: u32,
         total_signers: u32,
         total_keys: u32,
         signer_id: u32,
@@ -173,8 +191,14 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
         network_private_key: Scalar,
         public_keys: PublicKeys,
         rng: &mut R,
-    ) -> Self {
-        assert!(threshold <= total_keys);
+    ) -> Result<Self, Error> {
+        if threshold == 0 || threshold > total_keys {
+            return Err(Error::InvalidThreshold);
+        }
+
+        if dkg_threshold == 0 || dkg_threshold < threshold {
+            return Err(Error::InvalidThreshold);
+        }
 
         let signer = SignerType::new(
             signer_id,
@@ -188,11 +212,12 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             "new Signer for signer_id {} with key_ids {:?}",
             signer_id, &key_ids
         );
-        Self {
+        Ok(Self {
             dkg_id: 0,
             sign_id: 1,
             sign_iter_id: 1,
             threshold,
+            dkg_threshold,
             total_signers,
             total_keys,
             signer,
@@ -209,7 +234,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             dkg_private_shares: Default::default(),
             dkg_private_begin_msg: Default::default(),
             dkg_end_begin_msg: Default::default(),
-        }
+        })
     }
 
     /// Load a coordinator from the previously saved `state`
@@ -219,6 +244,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             sign_id: state.sign_id,
             sign_iter_id: state.sign_iter_id,
             threshold: state.threshold,
+            dkg_threshold: state.dkg_threshold,
             total_signers: state.total_signers,
             total_keys: state.total_keys,
             signer: SignerType::load(&state.signer),
@@ -245,6 +271,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             sign_id: self.sign_id,
             sign_iter_id: self.sign_iter_id,
             threshold: self.threshold,
+            dkg_threshold: self.dkg_threshold,
             total_signers: self.total_signers,
             total_keys: self.total_keys,
             signer: self.signer.save(),
@@ -353,31 +380,62 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
         let mut missing_private_shares = HashSet::new();
         let mut bad_public_shares = HashSet::new();
         let threshold: usize = self.threshold.try_into().unwrap();
-        if let Some(dkg_end_begin) = &self.dkg_end_begin_msg {
-            for signer_id in &dkg_end_begin.signer_ids {
-                if let Some(shares) = self.dkg_public_shares.get(signer_id) {
-                    for (party_id, comm) in shares.comms.iter() {
-                        if !check_public_shares(comm, threshold) {
-                            bad_public_shares.insert(*signer_id);
-                        } else {
-                            self.commitments.insert(*party_id, comm.clone());
+
+        let Some(dkg_end_begin) = &self.dkg_end_begin_msg else {
+            // no cached DkgEndBegin message
+            return Ok(Message::DkgEnd(DkgEnd {
+                dkg_id: self.dkg_id,
+                signer_id: self.signer_id,
+                status: DkgStatus::Failure(DkgFailure::BadState),
+            }));
+        };
+
+        // fist check to see if dkg_threshold has been met
+        let signer_ids_set: HashSet<u32> = dkg_end_begin
+            .signer_ids
+            .iter()
+            .filter(|&&id| id < self.total_signers)
+            .copied()
+            .collect::<HashSet<u32>>();
+        let mut num_dkg_keys = 0u32;
+        for id in &signer_ids_set {
+            if let Some(key_ids) = self.public_keys.signer_key_ids.get(id) {
+                let len: u32 = key_ids.len().try_into()?;
+                num_dkg_keys = num_dkg_keys.saturating_add(len);
+            }
+        }
+
+        if num_dkg_keys < self.dkg_threshold {
+            return Ok(Message::DkgEnd(DkgEnd {
+                dkg_id: self.dkg_id,
+                signer_id: self.signer_id,
+                status: DkgStatus::Failure(DkgFailure::Threshold),
+            }));
+        }
+
+        for signer_id in &signer_ids_set {
+            if let Some(shares) = self.dkg_public_shares.get(signer_id) {
+                for (party_id, comm) in shares.comms.iter() {
+                    if !check_public_shares(comm, threshold) {
+                        bad_public_shares.insert(*signer_id);
+                    } else {
+                        self.commitments.insert(*party_id, comm.clone());
+                    }
+                }
+            } else {
+                missing_public_shares.insert(*signer_id);
+            }
+            if let Some(shares) = self.dkg_private_shares.get(signer_id) {
+                // signer_id sent shares, but make sure that it sent shares for every one of this signer's key_ids
+                for dst_key_id in self.signer.get_key_ids() {
+                    for (_src_key_id, shares) in &shares.shares {
+                        if shares.get(&dst_key_id).is_none() {
+                            missing_private_shares.insert(*signer_id);
                         }
                     }
-                } else {
-                    missing_public_shares.insert(*signer_id);
                 }
-                if let Some(shares) = self.dkg_private_shares.get(signer_id) {
-                    // signer_id sent shares, but make sure that it sent shares for every one of this signer's key_ids
-                    for dst_key_id in self.signer.get_key_ids() {
-                        for (_src_key_id, shares) in &shares.shares {
-                            if shares.get(&dst_key_id).is_none() {
-                                missing_private_shares.insert(*signer_id);
-                            }
-                        }
-                    }
-                } else {
-                    missing_private_shares.insert(*signer_id);
-                }
+            } else {
+                missing_private_shares.insert(*signer_id);
             }
         }
 
@@ -690,11 +748,14 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             signer_id: self.signer_id,
             shares: Vec::new(),
         };
-        let active_key_ids = dkg_private_begin
-            .key_ids
-            .iter()
-            .cloned()
-            .collect::<HashSet<u32>>();
+        let mut active_key_ids = HashSet::new();
+        for signer_id in &dkg_private_begin.signer_ids {
+            if let Some(key_ids) = self.public_keys.signer_key_ids.get(signer_id) {
+                for key_id in key_ids {
+                    active_key_ids.insert(*key_id);
+                }
+            }
+        }
 
         self.dkg_private_begin_msg = Some(dkg_private_begin.clone());
         self.move_to(State::DkgPrivateDistribute)?;
@@ -921,11 +982,13 @@ pub mod test {
             1,
             1,
             1,
+            1,
             vec![1],
             Default::default(),
             Default::default(),
             &mut rng,
-        );
+        )
+        .unwrap();
         let public_share = DkgPublicShares {
             dkg_id: 0,
             signer_id: 0,
@@ -958,11 +1021,13 @@ pub mod test {
             1,
             1,
             1,
+            1,
             vec![1],
             Default::default(),
             Default::default(),
             &mut rng,
-        );
+        )
+        .unwrap();
         // publich_shares_done starts out as false
         assert!(!signer.public_shares_done());
 
@@ -1000,7 +1065,8 @@ pub mod test {
         public_keys.key_ids.insert(1, public_key.clone());
 
         let mut signer =
-            Signer::<SignerType>::new(1, 1, 1, 0, vec![1], private_key, public_keys, &mut rng);
+            Signer::<SignerType>::new(1, 1, 1, 1, 0, vec![1], private_key, public_keys, &mut rng)
+                .unwrap();
         // can_dkg_end starts out as false
         assert!(!signer.can_dkg_end());
 
@@ -1015,7 +1081,7 @@ pub mod test {
         let dkg_private_begin = Message::DkgPrivateBegin(DkgPrivateBegin {
             dkg_id: 1,
             signer_ids: vec![0],
-            key_ids: vec![1],
+            key_ids: vec![],
         });
         let dkg_private_shares = signer
             .process(&dkg_private_begin, &mut rng)
@@ -1026,7 +1092,7 @@ pub mod test {
         let dkg_end_begin = DkgEndBegin {
             dkg_id: 1,
             signer_ids: vec![0],
-            key_ids: vec![1],
+            key_ids: vec![],
         };
         let _ = signer
             .dkg_end_begin(&dkg_end_begin)
@@ -1057,12 +1123,14 @@ pub mod test {
             1,
             1,
             1,
+            1,
             0,
             vec![1],
             Default::default(),
             Default::default(),
             &mut rng,
-        );
+        )
+        .unwrap();
 
         if let Ok(Message::DkgEnd(dkg_end)) = signer.dkg_ended(&mut rng) {
             match dkg_end.status {


### PR DESCRIPTION
* add signer_key_ids to PublicKeys; pass dkg_threshold to signer state machine; check dkg_threshold in dkg_ended

* fmt fixes

* don't use array access; add explicit integer cast

* add test for dkg threshold

* use saturating_add when calculating num_dkg_keys

* assert is_empty rather than len of 0

* remove key_ids from DkgPrivateBegin and DkgEndBegin

* put key_ids back into DkgPrivateBegin and DkgEndBegin but keep them deprecated

* use signer_ids_set when checking public and private shares; use let/else do reduce indentation and put error case first

* remove assert; check thresholds and return error if invalid in signer ctor

* filter signer_id_set for only valid ids