### PR TITLE
Verify signer party and key IDs (#12)

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -462,6 +462,9 @@ impl Signable for SignatureShareResponse {
         for signature_share in &self.signature_shares {
             hasher.update(signature_share.id.to_be_bytes());
             hasher.update(signature_share.z_i.to_bytes());
+            for key_id in &signature_share.key_ids {
+                hasher.update(key_id.to_be_bytes());
+            }
         }
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,5 +1,5 @@
 use core::{cmp::PartialEq, fmt::Debug};
-use hashbrown::HashMap;
+use hashbrown::{HashMap, HashSet};
 use polynomial::Polynomial;
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
@@ -97,6 +97,13 @@ pub trait Signer: Clone + Debug + PartialEq {
         key_ids: &[u32],
         nonces: &[PublicNonce],
     ) -> (Vec<Point>, Point);
+
+    /// Validate that signer_id owns party_id
+    fn validate_party_id(
+        signer_id: u32,
+        party_id: u32,
+        signer_key_ids: &HashMap<u32, HashSet<u32>>,
+    ) -> bool;
 
     /// Sign `msg` using all this signer's keys
     fn sign(

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -1,4 +1,4 @@
-use hashbrown::HashMap;
+use hashbrown::{HashMap, HashSet};
 use num_traits::{One, Zero};
 use polynomial::Polynomial;
 use rand_core::{CryptoRng, RngCore};
@@ -611,6 +611,14 @@ impl traits::Signer for Party {
         compute::intermediate(msg, signer_ids, nonces)
     }
 
+    fn validate_party_id(
+        signer_id: u32,
+        party_id: u32,
+        _signer_key_ids: &HashMap<u32, HashSet<u32>>,
+    ) -> bool {
+        signer_id == party_id
+    }
+
     fn sign(
         &self,
         msg: &[u8],
@@ -722,6 +730,8 @@ pub mod test_helpers {
 
 #[cfg(test)]
 mod tests {
+    use hashbrown::{HashMap, HashSet};
+
     use crate::util::create_rng;
     use crate::{
         traits::{
@@ -825,5 +835,18 @@ mod tests {
     /// Run DKG and aggregator init with a bad polynomial commitment
     pub fn bad_polynomial_commitment() {
         traits::test_helpers::bad_polynomial_commitment::<v2::Signer>();
+    }
+
+    #[test]
+    /// Check that party_ids can be properly validated
+    fn validate_party_id() {
+        let mut signer_key_ids = HashMap::new();
+        let mut key_ids = HashSet::new();
+
+        key_ids.insert(1);
+        signer_key_ids.insert(0, key_ids);
+
+        assert!(v2::Signer::validate_party_id(0, 0, &signer_key_ids));
+        assert!(!v2::Signer::validate_party_id(0, 1, &signer_key_ids));
     }
 }


### PR DESCRIPTION
* verify signer party and key ids

* check that map contains key instead of getting it, since we don't need it

* restructure log using named fields

* use already extracted signer_key_ids