### PR TITLE
Use correct hash for `actions-rs/toolchain`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     environment: crates.io
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
-      - uses: actions-rs/toolchain@11bd71901bbe5b1630ceea73d27597364c9af683 #v1.0.7
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af #v1.0.7
         with:
           profile: minimal
           toolchain: stable


### PR DESCRIPTION
The previous PR used the `actions/checkout` hash not the `actions-rs/toolchain` hash.