### PR TITLE
Use PublicKeys in coordinators and verify packet signatures if configured to do so

### DIFF
--- a/src/compute.rs
+++ b/src/compute.rs
@@ -5,6 +5,7 @@ use sha2::{Digest, Sha256};
 use crate::{
     common::PublicNonce,
     curve::{
+        ecdsa,
         point::{Compressed, Error as PointError, Point, G},
         scalar::Scalar,
     },
@@ -184,4 +185,11 @@ pub fn merkle_root(data: &[u8]) -> [u8; 32] {
     hasher.update(data);
 
     hasher.finalize().into()
+}
+
+/// Get a Point from an ecdsa::PublicKey
+pub fn point(key: &ecdsa::PublicKey) -> Result<Point, PointError> {
+    let compressed = Compressed::from(key.to_bytes());
+    // this should not fail as long as the public key above was valid
+    Point::try_from(&compressed)
 }

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -688,7 +688,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                                     let Some(bad_dkg_public_shares) =
                                         self.dkg_public_shares.get(bad_signer_id)
                                     else {
-                                        warn!("Signer {signer_id} reported BadPrivateShare from signer {bad_signer_id} who didn't send public shares , mark {signer_id} as malicious");
+                                        warn!("Signer {signer_id} reported BadPrivateShare from signer {bad_signer_id} who didn't send public shares, mark {signer_id} as malicious");
                                         self.malicious_dkg_signer_ids.insert(*signer_id);
                                         continue;
                                     };

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -700,7 +700,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                                     let Some(dkg_private_shares) =
                                         self.dkg_private_shares.get(bad_signer_id)
                                     else {
-                                        warn!("Signer {signer_id} reported BadPrivateShare from signer {bad_signer_id} who didn't send public shares , mark {signer_id} as malicious");
+                                        warn!("Signer {signer_id} reported BadPrivateShare from signer {bad_signer_id} who didn't send public shares, mark {signer_id} as malicious");
                                         self.malicious_dkg_signer_ids.insert(*signer_id);
                                         continue;
                                     };

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -675,7 +675,7 @@ pub mod test {
         for coordinator in coordinators.iter_mut() {
             // Process all coordinator messages, but don't bother with propogating these results
             for message in messages {
-                let _ = coordinator.process(&message)?;
+                let _ = coordinator.process(message)?;
             }
         }
         let mut results = vec![];

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -1,12 +1,16 @@
 use crate::{
     common::{PolyCommitment, Signature, SignatureShare},
-    curve::{point::Point, scalar::Scalar},
+    curve::{
+        ecdsa,
+        point::{Error as PointError, Point},
+        scalar::Scalar,
+    },
     errors::AggregatorError,
     net::{DkgEnd, DkgPrivateShares, DkgPublicShares, NonceResponse, Packet, SignatureType},
-    state_machine::{DkgFailure, OperationResult, StateMachine},
+    state_machine::{DkgFailure, OperationResult, PublicKeys, StateMachine},
     taproot::SchnorrProof,
 };
-use core::{cmp::PartialEq, fmt::Debug};
+use core::{cmp::PartialEq, fmt::Debug, num::TryFromIntError};
 use hashbrown::{HashMap, HashSet};
 use std::{
     collections::BTreeMap,
@@ -99,6 +103,18 @@ pub enum Error {
     /// Supplied party polynomial contained duplicate party IDs
     #[error("Supplied party polynomials contained a duplicate party ID")]
     DuplicatePartyId,
+    #[error("Missing coordinator public key")]
+    /// Missing coordinator public key"
+    MissingCoordinatorPublicKey,
+    #[error("A packet had an invalid signature")]
+    /// A packet had an invalid signature
+    InvalidPacketSignature,
+    #[error("A curve point error {0}")]
+    /// A curve point error
+    Point(#[from] PointError),
+    #[error("integer conversion error")]
+    /// An error during integer conversion operations
+    TryFromInt(#[from] TryFromIntError),
 }
 
 impl From<AggregatorError> for Error {
@@ -130,10 +146,10 @@ pub struct Config {
     pub nonce_timeout: Option<Duration>,
     /// timeout to gather signature shares
     pub sign_timeout: Option<Duration>,
-    /// map of signer_id to controlled key_ids
-    pub signer_key_ids: HashMap<u32, HashSet<u32>>,
-    /// ECDSA public keys as Point objects indexed by signer_id
-    pub signer_public_keys: HashMap<u32, Point>,
+    /// the public keys and key_ids for all signers
+    pub public_keys: PublicKeys,
+    /// whether to verify the signature on Packets
+    pub verify_packet_sigs: bool,
 }
 
 impl fmt::Debug for Config {
@@ -147,8 +163,9 @@ impl fmt::Debug for Config {
             .field("dkg_end_timeout", &self.dkg_end_timeout)
             .field("nonce_timeout", &self.nonce_timeout)
             .field("sign_timeout", &self.sign_timeout)
-            .field("signer_key_ids", &self.signer_key_ids)
-            .field("signer_public_keys", &self.signer_public_keys)
+            .field("signer_key_ids", &self.public_keys.signer_key_ids)
+            .field("signer_public_keys", &self.public_keys.signers)
+            .field("verify_packet_sigs", &self.verify_packet_sigs)
             .finish_non_exhaustive()
     }
 }
@@ -172,8 +189,8 @@ impl Config {
             dkg_end_timeout: None,
             nonce_timeout: None,
             sign_timeout: None,
-            signer_key_ids: Default::default(),
-            signer_public_keys: Default::default(),
+            public_keys: Default::default(),
+            verify_packet_sigs: true,
         }
     }
 
@@ -190,8 +207,7 @@ impl Config {
         dkg_end_timeout: Option<Duration>,
         nonce_timeout: Option<Duration>,
         sign_timeout: Option<Duration>,
-        signer_key_ids: HashMap<u32, HashSet<u32>>,
-        signer_public_keys: HashMap<u32, Point>,
+        public_keys: PublicKeys,
     ) -> Self {
         Config {
             num_signers,
@@ -204,8 +220,8 @@ impl Config {
             dkg_end_timeout,
             nonce_timeout,
             sign_timeout,
-            signer_key_ids,
-            signer_public_keys,
+            public_keys,
+            verify_packet_sigs: true,
         }
     }
 }
@@ -272,6 +288,8 @@ pub struct SavedState {
     pub malicious_signer_ids: HashSet<u32>,
     /// set of malicious signers during dkg round
     pub malicious_dkg_signer_ids: HashSet<u32>,
+    /// coordinator public key
+    pub coordinator_public_key: Option<ecdsa::PublicKey>,
 }
 
 /// Coordinator trait for handling the coordination of DKG and sign messages
@@ -287,6 +305,13 @@ pub trait Coordinator: Clone + Debug + PartialEq + StateMachine<State, Error> {
 
     /// Retrieve the config
     fn get_config(&self) -> Config;
+
+    /// Retrieve a mutable reference to the config
+    #[cfg(test)]
+    fn get_config_mut(&mut self) -> &mut Config;
+
+    /// Set the coordinator public key
+    fn set_coordinator_public_key(&mut self, key: Option<ecdsa::PublicKey>);
 
     /// Initialize Coordinator from partial saved state
     fn set_key_and_party_polynomials(
@@ -550,7 +575,7 @@ pub mod test {
             .iter()
             .enumerate()
             .map(|(signer_id, (private_key, _public_key))| {
-                Signer::<SignerType>::new(
+                let mut signer = Signer::<SignerType>::new(
                     threshold,
                     dkg_threshold,
                     num_signers,
@@ -561,13 +586,15 @@ pub mod test {
                     public_keys.clone(),
                     &mut rng,
                 )
-                .unwrap()
+                .unwrap();
+                signer.verify_packet_sigs = false;
+                signer
             })
             .collect::<Vec<Signer<SignerType>>>();
         let coordinators = key_pairs
             .into_iter()
             .map(|(private_key, _public_key)| {
-                let config = Config::with_timeouts(
+                let mut config = Config::with_timeouts(
                     num_signers,
                     num_keys,
                     threshold,
@@ -578,9 +605,9 @@ pub mod test {
                     dkg_end_timeout,
                     nonce_timeout,
                     sign_timeout,
-                    signer_key_ids_set.clone(),
-                    signer_public_keys.clone(),
+                    public_keys.clone(),
                 );
+                config.verify_packet_sigs = false;
                 Coordinator::new(config)
             })
             .collect::<Vec<Coordinator>>();
@@ -648,7 +675,7 @@ pub mod test {
         for coordinator in coordinators.iter_mut() {
             // Process all coordinator messages, but don't bother with propogating these results
             for message in messages {
-                let _ = coordinator.process(message).unwrap();
+                let _ = coordinator.process(&message)?;
             }
         }
         let mut results = vec![];
@@ -931,6 +958,260 @@ pub mod test {
         );
     }
 
+    pub fn verify_packet_sigs<Coordinator: CoordinatorTrait, SignerType: SignerTrait>() {
+        verify_removed_coordinator_key_on_signers::<Coordinator, SignerType>();
+        verify_removed_coordinator_key_on_coordinator::<Coordinator, SignerType>();
+        verify_changed_coordinator_key_on_signers::<Coordinator, SignerType>();
+        verify_changed_coordinator_key_on_coordinator::<Coordinator, SignerType>();
+    }
+
+    pub fn verify_removed_coordinator_key_on_signers<
+        Coordinator: CoordinatorTrait,
+        SignerType: SignerTrait,
+    >() {
+        let (coordinators, mut signers) = setup::<Coordinator, SignerType>(5, 1);
+        let mut coordinators = vec![coordinators[0].clone()];
+
+        for coordinator in coordinators.iter_mut() {
+            let config = coordinator.get_config_mut();
+            config.verify_packet_sigs = true;
+
+            let coordinator_public_key = config.public_keys.signers[&0];
+            coordinator.set_coordinator_public_key(Some(coordinator_public_key));
+        }
+
+        for signer in signers.iter_mut() {
+            signer.verify_packet_sigs = true;
+
+            let coordinator_public_key = signer.public_keys.signers[&0];
+            signer.coordinator_public_key = Some(coordinator_public_key);
+        }
+
+        // We have started a dkg round
+        let message = coordinators
+            .first_mut()
+            .unwrap()
+            .start_dkg_round(None)
+            .unwrap();
+        assert!(coordinators
+            .first_mut()
+            .unwrap()
+            .get_aggregate_public_key()
+            .is_none());
+        assert_eq!(
+            coordinators.first_mut().unwrap().get_state(),
+            State::DkgPublicGather
+        );
+
+        // Send the DKG Begin message to all signers and gather responses by sharing with all other signers and coordinator
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &[message]);
+        assert!(operation_results.is_empty());
+        for coordinator in coordinators.iter() {
+            assert_eq!(coordinator.get_state(), State::DkgPrivateGather);
+        }
+
+        assert_eq!(outbound_messages.len(), 1);
+        match &outbound_messages[0].msg {
+            Message::DkgPrivateBegin(_) => {}
+            _ => {
+                panic!("Expected DkgPrivateBegin message");
+            }
+        }
+
+        // Send the DKG Private Begin message to all signers and share their responses with the coordinator and signers
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
+        assert_eq!(operation_results.len(), 0);
+        assert_eq!(outbound_messages.len(), 1);
+        match &outbound_messages[0].msg {
+            Message::DkgEndBegin(_) => {}
+            _ => {
+                panic!("Expected DkgEndBegin message");
+            }
+        }
+
+        // Send the DkgEndBegin message to all signers and share their responses with the coordinator and signers
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
+        assert_eq!(outbound_messages.len(), 0);
+        assert_eq!(operation_results.len(), 1);
+        match operation_results[0] {
+            OperationResult::Dkg(point) => {
+                assert_ne!(point, Point::default());
+                for coordinator in coordinators.iter() {
+                    assert_eq!(coordinator.get_aggregate_public_key(), Some(point));
+                    assert_eq!(coordinator.get_state(), State::Idle);
+                }
+            }
+            _ => panic!("Expected Dkg Operation result"),
+        }
+
+        // clear the polynomials before persisting
+        for signer in &mut signers {
+            signer.signer.clear_polys();
+        }
+
+        let msg = "It was many and many a year ago, in a kingdom by the sea"
+            .as_bytes()
+            .to_vec();
+
+        run_sign::<Coordinator, SignerType>(
+            &mut coordinators,
+            &mut signers,
+            &msg,
+            SignatureType::Frost,
+        );
+
+        // Remove the coordinator public key on the signers and show that signers fail to verify
+        for signer in signers.iter_mut() {
+            signer.coordinator_public_key = None;
+        }
+
+        let message = coordinators
+            .first_mut()
+            .unwrap()
+            .start_dkg_round(None)
+            .unwrap();
+        assert_eq!(
+            coordinators.first_mut().unwrap().get_state(),
+            State::DkgPublicGather
+        );
+
+        let result = feedback_messages_with_errors(&mut coordinators, &mut signers, &[message]);
+        assert!(matches!(
+            result,
+            Err(StateMachineError::Signer(
+                SignerError::MissingCoordinatorPublicKey
+            ))
+        ));
+    }
+
+    // Remove the coordinator public key on the coordinator and show that signatures fail to verify
+    pub fn verify_removed_coordinator_key_on_coordinator<
+        Coordinator: CoordinatorTrait,
+        SignerType: SignerTrait,
+    >() {
+        let (coordinators, mut signers) = setup::<Coordinator, SignerType>(5, 1);
+        let mut coordinators = vec![coordinators[0].clone()];
+
+        for coordinator in coordinators.iter_mut() {
+            let config = coordinator.get_config_mut();
+            config.verify_packet_sigs = true;
+
+            coordinator.set_coordinator_public_key(None);
+        }
+
+        for signer in signers.iter_mut() {
+            signer.verify_packet_sigs = true;
+
+            let coordinator_public_key = signer.public_keys.signers[&0];
+            signer.coordinator_public_key = Some(coordinator_public_key);
+        }
+
+        let message = coordinators
+            .first_mut()
+            .unwrap()
+            .start_dkg_round(None)
+            .unwrap();
+        assert_eq!(
+            coordinators.first_mut().unwrap().get_state(),
+            State::DkgPublicGather
+        );
+
+        let result = feedback_messages_with_errors(&mut coordinators, &mut signers, &[message]);
+        assert!(matches!(
+            result,
+            Err(StateMachineError::Coordinator(
+                Error::MissingCoordinatorPublicKey
+            ))
+        ));
+    }
+
+    // Change the coordinator public key on the signers and show that signatures fail to verify
+    pub fn verify_changed_coordinator_key_on_signers<
+        Coordinator: CoordinatorTrait,
+        SignerType: SignerTrait,
+    >() {
+        let (coordinators, mut signers) = setup::<Coordinator, SignerType>(5, 1);
+        let mut coordinators = vec![coordinators[0].clone()];
+
+        for coordinator in coordinators.iter_mut() {
+            let config = coordinator.get_config_mut();
+            config.verify_packet_sigs = true;
+
+            let coordinator_public_key = config.public_keys.signers[&0];
+            coordinator.set_coordinator_public_key(Some(coordinator_public_key));
+        }
+
+        for signer in signers.iter_mut() {
+            signer.verify_packet_sigs = true;
+
+            let coordinator_public_key = signer.public_keys.signers[&1];
+            signer.coordinator_public_key = Some(coordinator_public_key);
+        }
+
+        let message = coordinators
+            .first_mut()
+            .unwrap()
+            .start_dkg_round(None)
+            .unwrap();
+        assert_eq!(
+            coordinators.first_mut().unwrap().get_state(),
+            State::DkgPublicGather
+        );
+
+        let result = feedback_messages_with_errors(&mut coordinators, &mut signers, &[message]);
+        assert!(matches!(
+            result,
+            Err(StateMachineError::Signer(
+                SignerError::InvalidPacketSignature
+            ))
+        ));
+    }
+
+    // Change the coordinator public key on the coordinator and show that signatures fail to verify
+    pub fn verify_changed_coordinator_key_on_coordinator<
+        Coordinator: CoordinatorTrait,
+        SignerType: SignerTrait,
+    >() {
+        let (coordinators, mut signers) = setup::<Coordinator, SignerType>(5, 1);
+        let mut coordinators = vec![coordinators[0].clone()];
+
+        for coordinator in coordinators.iter_mut() {
+            let config = coordinator.get_config_mut();
+            config.verify_packet_sigs = true;
+
+            let coordinator_public_key = config.public_keys.signers[&1];
+            coordinator.set_coordinator_public_key(Some(coordinator_public_key));
+        }
+
+        for signer in signers.iter_mut() {
+            signer.verify_packet_sigs = true;
+
+            let coordinator_public_key = signer.public_keys.signers[&0];
+            signer.coordinator_public_key = Some(coordinator_public_key);
+        }
+
+        let message = coordinators
+            .first_mut()
+            .unwrap()
+            .start_dkg_round(None)
+            .unwrap();
+        assert_eq!(
+            coordinators.first_mut().unwrap().get_state(),
+            State::DkgPublicGather
+        );
+
+        let result = feedback_messages_with_errors(&mut coordinators, &mut signers, &[message]);
+        assert!(matches!(
+            result,
+            Err(StateMachineError::Coordinator(
+                Error::InvalidPacketSignature
+            ))
+        ));
+    }
+
     /// Run DKG then sign a message, but alter the signature shares for signer 0.  This should trigger the aggregator internal check_signature_shares function to run and determine which parties signatures were bad.
     /// Because of the differences between how parties are represented in v1 and v2, we need to pass in a vector of the expected bad parties.
     pub fn check_signature_shares<Coordinator: CoordinatorTrait, SignerType: SignerTrait>(
@@ -1096,15 +1377,11 @@ pub mod test {
 
         // Pass the SignatureShareRequest to the first signer and get his SignatureShares
         // which should use the nonce generated before sending out NonceResponse above
-        let messages1 = signers[0]
-            .process(&outbound_messages[0].msg, &mut rng)
-            .unwrap();
+        let messages1 = signers[0].process(&outbound_messages[0], &mut rng).unwrap();
 
         // Pass the SignatureShareRequest to the second signer and get his SignatureShares
         // which should use the nonce generated just before sending out the previous SignatureShare
-        let messages2 = signers[0]
-            .process(&outbound_messages[0].msg, &mut rng)
-            .unwrap();
+        let messages2 = signers[0].process(&outbound_messages[0], &mut rng).unwrap();
 
         // iterate through the responses and collect the embedded shares
         // if the signer didn't generate a nonce after sending the first signature shares

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -12,14 +12,16 @@ use crate::{
         check_public_shares, validate_key_id, validate_signer_id, PolyCommitment, PublicNonce,
         TupleProof,
     },
+    compute,
     curve::{
-        point::{Compressed, Point, G},
+        ecdsa,
+        point::{Compressed, Error as PointError, Point, G},
         scalar::Scalar,
     },
     errors::{DkgError, EncryptionError},
     net::{
         BadPrivateShare, DkgBegin, DkgEnd, DkgEndBegin, DkgFailure, DkgPrivateBegin,
-        DkgPrivateShares, DkgPublicShares, DkgStatus, Message, NonceRequest, NonceResponse,
+        DkgPrivateShares, DkgPublicShares, DkgStatus, Message, NonceRequest, NonceResponse, Packet,
         SignatureShareRequest, SignatureShareResponse, SignatureType,
     },
     state_machine::{PublicKeys, StateMachine},
@@ -28,7 +30,7 @@ use crate::{
 };
 
 #[cfg(test)]
-use crate::net::{Packet, Signable};
+use crate::net::Signable;
 
 #[derive(Debug, Clone, PartialEq)]
 /// Signer states
@@ -94,6 +96,15 @@ pub enum Error {
     #[error("integer conversion error")]
     /// An error during integer conversion operations
     TryFromInt(#[from] TryFromIntError),
+    #[error("Missing coordinator public key")]
+    /// Missing coordinator public key
+    MissingCoordinatorPublicKey,
+    #[error("A packet had an invalid signature")]
+    /// A packet had an invalid signature
+    InvalidPacketSignature,
+    #[error("A curve point error {0}")]
+    /// A curve point error
+    Point(#[from] PointError),
 }
 
 /// The saved state required to reconstruct a signer
@@ -145,6 +156,10 @@ pub struct SavedState {
     pub dkg_private_begin_msg: Option<DkgPrivateBegin>,
     /// the DKG end begin message received in this round
     pub dkg_end_begin_msg: Option<DkgEndBegin>,
+    /// whether to verify the signature on Packets
+    pub verify_packet_sigs: bool,
+    /// coordinator public key
+    pub coordinator_public_key: Option<ecdsa::PublicKey>,
 }
 
 impl fmt::Debug for SavedState {
@@ -220,6 +235,10 @@ pub struct Signer<SignerType: SignerTrait> {
     pub dkg_private_begin_msg: Option<DkgPrivateBegin>,
     /// the DKG end begin message received in this round
     pub dkg_end_begin_msg: Option<DkgEndBegin>,
+    /// whether to verify the signature on Packets
+    pub verify_packet_sigs: bool,
+    /// coordinator public key
+    pub coordinator_public_key: Option<ecdsa::PublicKey>,
 }
 
 impl<SignerType: SignerTrait> fmt::Debug for Signer<SignerType> {
@@ -315,6 +334,8 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             dkg_private_shares: Default::default(),
             dkg_private_begin_msg: Default::default(),
             dkg_end_begin_msg: Default::default(),
+            verify_packet_sigs: true,
+            coordinator_public_key: None,
         })
     }
 
@@ -342,6 +363,8 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             dkg_private_shares: state.dkg_private_shares.clone(),
             dkg_private_begin_msg: state.dkg_private_begin_msg.clone(),
             dkg_end_begin_msg: state.dkg_end_begin_msg.clone(),
+            verify_packet_sigs: state.verify_packet_sigs,
+            coordinator_public_key: state.coordinator_public_key,
         }
     }
 
@@ -369,6 +392,8 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             dkg_private_shares: self.dkg_private_shares.clone(),
             dkg_private_begin_msg: self.dkg_private_begin_msg.clone(),
             dkg_end_begin_msg: self.dkg_end_begin_msg.clone(),
+            verify_packet_sigs: self.verify_packet_sigs,
+            coordinator_public_key: self.coordinator_public_key,
         }
     }
 
@@ -392,12 +417,12 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
     #[cfg(test)]
     pub fn process_inbound_messages<R: RngCore + CryptoRng>(
         &mut self,
-        messages: &[Packet],
+        packets: &[Packet],
         rng: &mut R,
     ) -> Result<Vec<Packet>, Error> {
         let mut responses = vec![];
-        for message in messages {
-            let outbounds = self.process(&message.msg, rng)?;
+        for packet in packets {
+            let outbounds = self.process(packet, rng)?;
             for out in outbounds {
                 let msg = Packet {
                     sig: out
@@ -414,10 +439,18 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
     /// process the passed incoming message, and return any outgoing messages needed in response
     pub fn process<R: RngCore + CryptoRng>(
         &mut self,
-        message: &Message,
+        packet: &Packet,
         rng: &mut R,
     ) -> Result<Vec<Message>, Error> {
-        let out_msgs = match message {
+        if self.verify_packet_sigs {
+            let Some(coordinator_public_key) = self.coordinator_public_key else {
+                return Err(Error::MissingCoordinatorPublicKey);
+            };
+            if !packet.verify(&self.public_keys, &coordinator_public_key) {
+                return Err(Error::InvalidPacketSignature);
+            }
+        }
+        let out_msgs = match &packet.msg {
             Message::DkgBegin(dkg_begin) => self.dkg_begin(dkg_begin, rng),
             Message::DkgPrivateBegin(dkg_private_begin) => {
                 self.dkg_private_begin(dkg_private_begin, rng)
@@ -882,10 +915,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             for (dst_key_id, private_share) in shares {
                 if active_key_ids.contains(dst_key_id) {
                     debug!("encrypting dkg private share for key_id {dst_key_id}");
-                    let compressed =
-                        Compressed::from(self.public_keys.key_ids[dst_key_id].to_bytes());
-                    // this should not fail as long as the public key above was valid
-                    let dst_public_key = Point::try_from(&compressed).unwrap();
+                    let dst_public_key = compute::point(&self.public_keys.key_ids[dst_key_id])?;
                     let shared_secret =
                         make_shared_secret(&self.network_private_key, &dst_public_key);
                     let encrypted_share = encrypt(&shared_secret, &private_share.to_bytes(), rng)?;
@@ -1496,27 +1526,44 @@ pub mod test {
         let mut signer =
             Signer::<SignerType>::new(1, 1, 1, 1, 0, vec![1], private_key, public_keys, &mut rng)
                 .unwrap();
+        signer.verify_packet_sigs = false;
         // can_dkg_end starts out as false
         assert!(!signer.can_dkg_end());
 
         // meet the conditions for DKG_END
         let dkg_begin = Message::DkgBegin(DkgBegin { dkg_id: 1 });
+        let dkg_begin_packet = Packet {
+            msg: dkg_begin,
+            sig: vec![],
+        };
         let dkg_public_shares = signer
-            .process(&dkg_begin, &mut rng)
+            .process(&dkg_begin_packet, &mut rng)
             .expect("failed to process DkgBegin");
+        let dkg_public_shares_packet = Packet {
+            msg: dkg_public_shares[0].clone(),
+            sig: vec![],
+        };
         let _ = signer
-            .process(&dkg_public_shares[0], &mut rng)
+            .process(&dkg_public_shares_packet, &mut rng)
             .expect("failed to process DkgPublicShares");
         let dkg_private_begin = Message::DkgPrivateBegin(DkgPrivateBegin {
             dkg_id: 1,
             signer_ids: vec![0],
             key_ids: vec![],
         });
+        let dkg_private_begin_packet = Packet {
+            msg: dkg_private_begin,
+            sig: vec![],
+        };
         let dkg_private_shares = signer
-            .process(&dkg_private_begin, &mut rng)
+            .process(&dkg_private_begin_packet, &mut rng)
             .expect("failed to process DkgBegin");
+        let dkg_private_shares_packet = Packet {
+            msg: dkg_private_shares[0].clone(),
+            sig: vec![],
+        };
         let _ = signer
-            .process(&dkg_private_shares[0], &mut rng)
+            .process(&dkg_private_shares_packet, &mut rng)
             .expect("failed to process DkgPrivateShares");
         let dkg_end_begin = DkgEndBegin {
             dkg_id: 1,


### PR DESCRIPTION
This PR adds the ability to verify packet signatures to signers and coordinators, and enables it by default.  It also updates the coordinators to use `state_machine::PublicKeys`, which makes the configuration of signers and coordinators consistent.

fixes #66, fixes #67, fixes #78
