### PR TITLE
CI: Use Wrapped External Actions From `stacks-sbtc/actions` Repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,69 +17,73 @@ jobs:
     name: check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          persist-credentials: false
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
+      - name: Checkout Repository
+        id: checkout_repository
+        uses: stacks-sbtc/actions/checkout@main
+
+      - name: Setup Rust
+        id: setup_rust
+        uses: stacks-sbtc/actions/setup-rust-toolchain@main
+
+      - name: Cargo Check
+        id: cargo_check
+        run: |
+          cargo check
 
   test-all:
     name: test-all
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          persist-credentials: false
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - name: Checkout Repository
+        id: checkout_repository
+        uses: stacks-sbtc/actions/checkout@main
+
+      - name: Setup Rust
+        id: setup_rust
+        uses: stacks-sbtc/actions/setup-rust-toolchain@main
+
+      - name: Cargo Test
+        id: cargo_test
+        run: |
+          cargo test
 
   fmt:
     name: fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout Repository
+        id: checkout_repository
+        uses: stacks-sbtc/actions/checkout@main
+
+      - name: Setup Rust
+        id: setup_rust
+        uses: stacks-sbtc/actions/setup-rust-toolchain@main
         with:
-          persist-credentials: false
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+          components: rustfmt
+
+      - name: Cargo Fmt
+        id: cargo_fmt
+        run: |
+          cargo fmt --all -- --check
 
   clippy:
     name: clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout Repository
+        id: checkout_repository
+        uses: stacks-sbtc/actions/checkout@main
+
+      - name: Setup Rust
+        id: setup_rust
+        uses: stacks-sbtc/actions/setup-rust-toolchain@main
         with:
-          persist-credentials: false
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings -A clippy::op-ref -A clippy::needless-range-loop
+          components: clippy
+
+      - name: Cargo Clippy
+        id: cargo_clippy
+        run: |
+          cargo clippy -- -D warnings -A clippy::op-ref -A clippy::needless-range-loop
 
   doc:
     permissions:
@@ -87,25 +91,32 @@ jobs:
       pages: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          persist-credentials: false
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - name: Checkout Repository
+        id: checkout_repository
+        uses: stacks-sbtc/actions/checkout@main
+
+      - name: Setup Rust
+        id: setup_rust
+        uses: stacks-sbtc/actions/setup-rust-toolchain@main
+
       - name: Install LaTeX
+        id: install_latex
         run: ./.doc/install-latex-ubuntu.sh
-      - name: Build WebSite
+
+      - name: Build Website
+        id: build_website
         run: ./.doc/build.sh
-      - name: upload pdf
-        uses: actions/upload-artifact@v4
+
+      - name: Upload PDF
+        id: upload_pdf
+        uses: stacks-sbtc/actions/upload-artifact@main
         with:
           name: wsts.pdf
           path: wsts.pdf
-      - name: upload website
-        uses: actions/upload-artifact@v4
+
+      - name: Upload Website
+        id: upload_website
+        uses: stacks-sbtc/actions/upload-artifact@main
         with:
           name: website
           path: ./target/doc/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,14 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     environment: crates.io
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af #v1.0.7
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 #v1.0.3
+      - name: Checkout Repository
+        id: checkout_repository
+        uses: stacks-sbtc/actions/checkout@main
+
+      - name: Setup Rust
+        id: setup_rust
+        uses: stacks-sbtc/actions/setup-rust-toolchain@main
+
+      - name: Cargo Publish
+        id: cargo_publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        with:
-          command: publish
+        run: |
+          cargo publish

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -28,18 +28,28 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
+      - name: Checkout Repository
+        id: checkout_repository
+        uses: stacks-sbtc/actions/checkout@main
+
       - name: Setup Pages
-        uses: actions/configure-pages@b8130d9ab958b325bbde9786d62f2c97a9885a0e #v3.0.7
+        id: setup_pages
+        uses: stacks-sbtc/actions/github-pages/configure-pages@main
+
       - name: Install LaTeX
+        id: install_latex
         run: ./.doc/install-latex-ubuntu.sh
-      - name: Build WebSite
+
+      - name: Build Website
+        id: build_website
         run: ./.doc/build.sh
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa #v3.0.1
+
+      - name: Upload Artifact
+        id: upload_artifact
+        uses: stacks-sbtc/actions/github-pages/upload-pages-artifact@main
         with:
           path: './target/doc/'
+
       - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e #v4.0.5
+        id: deploy_pages
+        uses: stacks-sbtc/actions/github-pages/deploy-pages@main


### PR DESCRIPTION
This PR replaces the actions used in the workflows with the ones from `actions` repository. I've also added `name` and `id` to all steps of the jobs and applied formatting for consistency and readability.

This PR should only be merged after https://github.com/stacks-sbtc/actions/pull/2, as it is dependent on some of the modifications included there.