### PR TITLE
Use a secret key to help scamble the nonces during generation

### DIFF
--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -676,7 +676,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
         let mut msgs = vec![];
         let signer_id = self.signer_id;
         let key_ids = self.signer.get_key_ids();
-        let nonces = self.signer.gen_nonces(rng);
+        let nonces = self.signer.gen_nonces(&self.network_private_key, rng);
 
         let response = NonceResponse {
             dkg_id: nonce_request.dkg_id,
@@ -765,7 +765,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                 SignatureType::Frost => self.signer.sign(msg, &signer_ids, &key_ids, &nonces),
             };
 
-            self.signer.gen_nonces(rng);
+            self.signer.gen_nonces(&self.network_private_key, rng);
 
             let response = SignatureShareResponse {
                 dkg_id: sign_request.dkg_id,

--- a/src/taproot.rs
+++ b/src/taproot.rs
@@ -72,6 +72,7 @@ impl From<[u8; 64]> for SchnorrProof {
 
 /// Helper functions for tests
 pub mod test_helpers {
+    use super::*;
     use crate::{
         common::{PolyCommitment, PublicNonce, SignatureShare},
         errors::DkgError,
@@ -119,9 +120,13 @@ pub mod test_helpers {
         signers: &mut [Signer],
         rng: &mut RNG,
     ) -> (Vec<u32>, Vec<u32>, Vec<PublicNonce>) {
+        let secret_key = Scalar::random(rng);
         let signer_ids: Vec<u32> = signers.iter().map(|s| s.get_id()).collect();
         let key_ids: Vec<u32> = signers.iter().flat_map(|s| s.get_key_ids()).collect();
-        let nonces: Vec<PublicNonce> = signers.iter_mut().flat_map(|s| s.gen_nonces(rng)).collect();
+        let nonces: Vec<PublicNonce> = signers
+            .iter_mut()
+            .flat_map(|s| s.gen_nonces(&secret_key, rng))
+            .collect();
 
         (signer_ids, key_ids, nonces)
     }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -95,7 +95,11 @@ pub trait Signer: Clone + Debug + PartialEq {
     ) -> Result<(), HashMap<u32, DkgError>>;
 
     /// Generate all nonces for this signer
-    fn gen_nonces<RNG: RngCore + CryptoRng>(&mut self, rng: &mut RNG) -> Vec<PublicNonce>;
+    fn gen_nonces<RNG: RngCore + CryptoRng>(
+        &mut self,
+        secret_key: &Scalar,
+        rng: &mut RNG,
+    ) -> Vec<PublicNonce>;
 
     /// Compute intermediate values
     fn compute_intermediate(


### PR DESCRIPTION
After re-reading the RFC 9591, it became apparent that we needed to mix a secret key in with the random fill when generating nonces, as opposed to doing another random fill.  This PR does that.

Fixes #80 