### PR TITLE
Use ephemeral keys for DkgPrivateShares DH key exchange

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -145,6 +145,8 @@ pub struct DkgPublicShares {
     pub signer_id: u32,
     /// List of (party_id, commitment)
     pub comms: Vec<(u32, PolyCommitment)>,
+    /// Ephemeral public key for key exchange
+    pub kex_public_key: Point,
 }
 
 impl Signable for DkgPublicShares {
@@ -726,6 +728,7 @@ mod test {
                     poly: vec![],
                 },
             )],
+            kex_public_key: Point::from(Scalar::random(&mut rng)),
         };
         let msg = Message::DkgPublicShares(public_shares.clone());
         let coordinator_packet_dkg_public_shares = Packet {

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -594,6 +594,8 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
         }
 
         let mut dkg_failures = HashMap::new();
+        // this will be used to report signers who were malicious in this DKG round, as opposed to
+        // self.self.malicious_dkg_signer_ids which contains all DKG signers who were ever malicious
         let mut malicious_signer_ids = HashSet::new();
         let threshold: usize = self.config.threshold.try_into().unwrap();
         if self.dkg_wait_signer_ids.is_empty() {

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -666,7 +666,8 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                                 let Some(bad_signer_public_shares) =
                                     self.dkg_public_shares.get(bad_signer_id)
                                 else {
-                                    warn!("Signer {signer_id} reported BadPrivateShares from {bad_signer_id} but there are no public shares from {bad_signer_id}");
+                                    warn!("Signer {signer_id} reported BadPrivateShares from {bad_signer_id} but there are no public shares from {bad_signer_id}, mark {signer_id} as malicious");
+                                    malicious_signer_ids.insert(*signer_id);
                                     continue;
                                 };
                                 let bad_signer_public_key = bad_signer_public_shares.kex_public_key;

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -595,7 +595,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
 
         let mut dkg_failures = HashMap::new();
         // this will be used to report signers who were malicious in this DKG round, as opposed to
-        // self.self.malicious_dkg_signer_ids which contains all DKG signers who were ever malicious
+        // self.malicious_dkg_signer_ids which contains all DKG signers who were ever malicious
         let mut malicious_signer_ids = HashSet::new();
         let threshold: usize = self.config.threshold.try_into().unwrap();
         if self.dkg_wait_signer_ids.is_empty() {

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -619,14 +619,9 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                                 let Some(dkg_public_shares) =
                                     self.dkg_public_shares.get(bad_signer_id)
                                 else {
-<<<<<<< HEAD
-                                    warn!("Signer {signer_id} reported BadPublicShares from invalid signer_id {bad_signer_id}, mark {signer_id} as malicious");
-                                    self.malicious_dkg_signer_ids.insert(*signer_id);
-=======
                                     warn!("Signer {signer_id} reported BadPublicShares from {bad_signer_id} but there are no public shares from that signer, mark {signer_id} as malicious");
                                     self.malicious_dkg_signer_ids.insert(*signer_id);
                                     malicious_signer_ids.insert(*signer_id);
->>>>>>> 1f77ea8 (use ephemeral keys for DkgPrivateShares DH key exchange)
                                     continue;
                                 };
                                 let mut bad_party_ids = Vec::new();
@@ -656,30 +651,12 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                             // bad_shares is a map of signer_id to BadPrivateShare
                             for (bad_signer_id, bad_private_share) in bad_shares {
                                 // verify the DH tuple proof first so we know the shared key is correct
-<<<<<<< HEAD
                                 let Some(signer_key_ids) =
                                     self.config.public_keys.signer_key_ids.get(signer_id)
                                 else {
                                     warn!("No key IDs for signer_id {signer_id} DkgEnd");
                                     continue;
                                 };
-                                let Some(signer_public_dsa_key) =
-                                    self.config.public_keys.signers.get(signer_id)
-                                else {
-                                    warn!("No public key for signer_id {signer_id} DkgEnd");
-                                    continue;
-                                };
-                                let signer_public_key = compute::point(signer_public_dsa_key)?;
-
-                                let Some(bad_signer_ecdsa_key) =
-                                    self.config.public_keys.signers.get(bad_signer_id)
-                                else {
-                                    warn!("Signer {signer_id} reported BadPrivateShare from invalid signer_id {bad_signer_id}, mark {signer_id} as malicious");
-                                    self.malicious_dkg_signer_ids.insert(*signer_id);
-                                    continue;
-                                };
-                                let bad_signer_public_key = compute::point(bad_signer_ecdsa_key)?;
-=======
                                 let Some(signer_public_shares) =
                                     self.dkg_public_shares.get(signer_id)
                                 else {
@@ -696,7 +673,6 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                                 };
                                 let bad_signer_public_key = bad_signer_public_shares.kex_public_key;
 
->>>>>>> 1f77ea8 (use ephemeral keys for DkgPrivateShares DH key exchange)
                                 let mut is_bad = false;
 
                                 if bad_private_share.tuple_proof.verify(
@@ -708,18 +684,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                                     let shared_secret =
                                         make_shared_secret_from_key(&bad_private_share.shared_key);
 
-<<<<<<< HEAD
-                                    let Some(bad_dkg_public_shares) =
-                                        self.dkg_public_shares.get(bad_signer_id)
-                                    else {
-                                        warn!("Signer {signer_id} reported BadPrivateShare from signer {bad_signer_id} who didn't send public shares, mark {signer_id} as malicious");
-                                        self.malicious_dkg_signer_ids.insert(*signer_id);
-                                        continue;
-                                    };
-                                    let dkg_public_shares = &bad_dkg_public_shares
-=======
                                     let polys = bad_signer_public_shares
->>>>>>> 1f77ea8 (use ephemeral keys for DkgPrivateShares DH key exchange)
                                         .comms
                                         .iter()
                                         .cloned()
@@ -727,17 +692,10 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                                     let Some(dkg_private_shares) =
                                         self.dkg_private_shares.get(bad_signer_id)
                                     else {
-<<<<<<< HEAD
                                         warn!("Signer {signer_id} reported BadPrivateShare from signer {bad_signer_id} who didn't send public shares, mark {signer_id} as malicious");
                                         self.malicious_dkg_signer_ids.insert(*signer_id);
                                         continue;
                                     };
-=======
-                                        warn!("Signer {signer_id} reported BadPrivateShares from {bad_signer_id} but there are no private shares from {bad_signer_id}");
-                                        continue;
-                                    };
-                                    let signer_key_ids = &self.config.signer_key_ids[signer_id];
->>>>>>> 1f77ea8 (use ephemeral keys for DkgPrivateShares DH key exchange)
 
                                     for (src_party_id, key_shares) in &dkg_private_shares.shares {
                                         let Some(poly) = polys.get(src_party_id) else {
@@ -1623,7 +1581,7 @@ pub mod test {
     #[test]
     #[cfg(feature = "with_v1")]
     fn dkg_public_share_v2() {
-        dkg_public_share::<v1::Aggregator, v2::Signer>();
+        dkg_public_share::<v1::Aggregator, v1::Signer>();
     }
 
     /// test basic insertion and detection of duplicates for DkgPublicShares
@@ -1817,9 +1775,8 @@ pub mod test {
     }
 
     #[test]
-    #[cfg(feature = "with_v1")]
     fn sig_share_v2() {
-        sig_share::<v2::Aggregator, v1::Signer>();
+        sig_share::<v2::Aggregator, v2::Signer>();
     }
 
     /// test basic insertion and detection of duplicates for SignatureShareResponse

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -1579,9 +1579,8 @@ pub mod test {
     }
 
     #[test]
-    #[cfg(feature = "with_v1")]
     fn dkg_public_share_v2() {
-        dkg_public_share::<v1::Aggregator, v1::Signer>();
+        dkg_public_share::<v2::Aggregator, v2::Signer>();
     }
 
     /// test basic insertion and detection of duplicates for DkgPublicShares

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -745,10 +745,10 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                                     }
                                 } else {
                                     warn!("TupleProof failed to verify, mark {signer_id} as malicious");
-                                    is_bad = true;
+                                    is_bad = false;
                                 }
 
-                                // if none of the shares were bad sender was malicious
+                                // if tuple proof failed or none of the shares were bad sender was malicious
                                 if !is_bad {
                                     warn!("Signer {signer_id} reported BadPrivateShare from {bad_signer_id} but the shares were valid, mark {signer_id} as malicious");
                                     malicious_signer_ids.insert(*signer_id);

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -282,10 +282,10 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                         if let Error::DkgFailure(dkg_failures, malicious_signer_ids) = error {
                             return Ok((
                                 None,
-                                Some(OperationResult::DkgError(DkgError::DkgEndFailure(
-                                    dkg_failures,
-                                    malicious_signer_ids,
-                                ))),
+                                Some(OperationResult::DkgError(DkgError::DkgEndFailure {
+                                    reported_failures: dkg_failures,
+                                    malicious_signers: malicious_signer_ids,
+                                })),
                             ));
                         } else {
                             return Err(error);
@@ -2556,8 +2556,10 @@ pub mod test {
             feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
         assert!(outbound_messages.is_empty());
         assert_eq!(operation_results.len(), 1);
-        let OperationResult::DkgError(DkgError::DkgEndFailure(failure_map, _)) =
-            &operation_results[0]
+        let OperationResult::DkgError(DkgError::DkgEndFailure {
+            reported_failures: failure_map,
+            ..
+        }) = &operation_results[0]
         else {
             panic!("Expected OperationResult::DkgError(DkgError::DkgEndFailure");
         };
@@ -2666,8 +2668,10 @@ pub mod test {
             feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
         assert!(outbound_messages.is_empty());
         assert_eq!(operation_results.len(), 1);
-        let OperationResult::DkgError(DkgError::DkgEndFailure(failure_map, _)) =
-            &operation_results[0]
+        let OperationResult::DkgError(DkgError::DkgEndFailure {
+            reported_failures: failure_map,
+            ..
+        }) = &operation_results[0]
         else {
             panic!("Expected OperationResult::DkgError(DkgError::DkgEndFailure)");
         };
@@ -3451,8 +3455,10 @@ pub mod test {
             feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
         assert!(outbound_messages.is_empty());
         assert_eq!(operation_results.len(), 1);
-        let OperationResult::DkgError(DkgError::DkgEndFailure(failure_map, malicious_signer_ids)) =
-            &operation_results[0]
+        let OperationResult::DkgError(DkgError::DkgEndFailure {
+            reported_failures: failure_map,
+            malicious_signers: malicious_signer_ids,
+        }) = &operation_results[0]
         else {
             panic!(
                 "Expected OperationResult::DkgError(DkgError::DkgEndFailure), got {:?}",
@@ -3568,8 +3574,10 @@ pub mod test {
             feedback_messages(&mut coordinators, &mut signers, &[packet]);
         assert!(outbound_messages.is_empty());
         assert_eq!(operation_results.len(), 1);
-        let OperationResult::DkgError(DkgError::DkgEndFailure(failure_map, _)) =
-            &operation_results[0]
+        let OperationResult::DkgError(DkgError::DkgEndFailure {
+            reported_failures: failure_map,
+            ..
+        }) = &operation_results[0]
         else {
             panic!("Expected DkgEndFailure got {:?}", operation_results[0]);
         };

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -2567,14 +2567,13 @@ pub mod test {
         assert!(outbound_messages.is_empty());
         assert_eq!(operation_results.len(), 1);
         let OperationResult::DkgError(DkgError::DkgEndFailure {
-            reported_failures: failure_map,
-            ..
+            reported_failures, ..
         }) = &operation_results[0]
         else {
             panic!("Expected OperationResult::DkgError(DkgError::DkgEndFailure");
         };
 
-        for (_signer_id, dkg_failure) in failure_map {
+        for (_signer_id, dkg_failure) in reported_failures {
             let DkgFailure::BadPrivateShares(bad_share_map) = dkg_failure else {
                 panic!("Expected DkgFailure::BadPrivateShares");
             };
@@ -2679,14 +2678,13 @@ pub mod test {
         assert!(outbound_messages.is_empty());
         assert_eq!(operation_results.len(), 1);
         let OperationResult::DkgError(DkgError::DkgEndFailure {
-            reported_failures: failure_map,
-            ..
+            reported_failures, ..
         }) = &operation_results[0]
         else {
             panic!("Expected OperationResult::DkgError(DkgError::DkgEndFailure)");
         };
 
-        for (_signer_id, dkg_failure) in failure_map {
+        for (_signer_id, dkg_failure) in reported_failures {
             let DkgFailure::BadPublicShares(bad_shares) = dkg_failure else {
                 panic!("Expected DkgFailure::BadPublicShares");
             };
@@ -3466,8 +3464,8 @@ pub mod test {
         assert!(outbound_messages.is_empty());
         assert_eq!(operation_results.len(), 1);
         let OperationResult::DkgError(DkgError::DkgEndFailure {
-            reported_failures: failure_map,
-            malicious_signers: malicious_signer_ids,
+            reported_failures,
+            malicious_signers,
         }) = &operation_results[0]
         else {
             panic!(
@@ -3476,7 +3474,7 @@ pub mod test {
             );
         };
         for i in 1..10 {
-            match failure_map.get(&i) {
+            match reported_failures.get(&i) {
                 Some(DkgFailure::BadPublicShares(set)) => {
                     if set.len() != 1 {
                         panic!("signer {i} should have reported a single BadPublicShares");
@@ -3493,7 +3491,7 @@ pub mod test {
             }
         }
 
-        match failure_map.get(&0) {
+        match reported_failures.get(&0) {
             Some(DkgFailure::BadPublicShares(set)) => {
                 if set.len() != 9 {
                     panic!("signer 0 should have reported BadPublicShares from all others");
@@ -3511,9 +3509,9 @@ pub mod test {
             }
         }
 
-        if !malicious_signer_ids.len() == 1 || !malicious_signer_ids.contains(&0) {
+        if !malicious_signers.len() == 1 || !malicious_signers.contains(&0) {
             panic!(
-                "Coordinator should have marked signer 0 as malicious, instead marked {malicious_signer_ids:?}",
+                "Coordinator should have marked signer 0 as malicious, instead marked {malicious_signers:?}",
             );
         }
     }
@@ -3585,13 +3583,12 @@ pub mod test {
         assert!(outbound_messages.is_empty());
         assert_eq!(operation_results.len(), 1);
         let OperationResult::DkgError(DkgError::DkgEndFailure {
-            reported_failures: failure_map,
-            ..
+            reported_failures, ..
         }) = &operation_results[0]
         else {
             panic!("Expected DkgEndFailure got {:?}", operation_results[0]);
         };
-        for (signer_id, failure) in failure_map {
+        for (signer_id, failure) in reported_failures {
             assert!(
                 matches!(failure, DkgFailure::Threshold),
                 "{signer_id} had wrong failure {failure:?}"

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -705,7 +705,10 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                                             continue;
                                         };
                                         for key_id in signer_key_ids {
-                                            let bytes = &key_shares[key_id];
+                                            let Some(bytes) = key_shares.get(key_id) else {
+                                                warn!("DkgPrivateShares from party_id {src_party_id} did not include a share for key_id {key_id}");
+                                                continue;
+                                            };
                                             match decrypt(&shared_secret, bytes) {
                                                 Ok(plain) => match Scalar::try_from(&plain[..]) {
                                                     Ok(private_eval) => {

--- a/src/state_machine/coordinator/frost.rs
+++ b/src/state_machine/coordinator/frost.rs
@@ -124,12 +124,16 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                 }
                 State::DkgEndGather => {
                     if let Err(error) = self.gather_dkg_end(packet) {
-                        if let Error::DkgFailure(dkg_failures, malicious_signer_ids) = error {
+                        if let Error::DkgFailure {
+                            reported_failures,
+                            malicious_signers,
+                        } = error
+                        {
                             return Ok((
                                 None,
                                 Some(OperationResult::DkgError(DkgError::DkgEndFailure {
-                                    reported_failures: dkg_failures,
-                                    malicious_signers: malicious_signer_ids,
+                                    reported_failures,
+                                    malicious_signers,
                                 })),
                             ));
                         } else {
@@ -394,19 +398,22 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
         }
 
         if self.ids_to_await.is_empty() {
-            let mut dkg_failures = HashMap::new();
+            let mut reported_failures = HashMap::new();
 
             for (signer_id, dkg_end) in &self.dkg_end_messages {
                 if let DkgStatus::Failure(dkg_failure) = &dkg_end.status {
                     warn!(%signer_id, ?dkg_failure, "DkgEnd failure");
-                    dkg_failures.insert(*signer_id, dkg_failure.clone());
+                    reported_failures.insert(*signer_id, dkg_failure.clone());
                 }
             }
 
-            if dkg_failures.is_empty() {
+            if reported_failures.is_empty() {
                 self.dkg_end_gathered()?;
             } else {
-                return Err(Error::DkgFailure(dkg_failures, Default::default()));
+                return Err(Error::DkgFailure {
+                    reported_failures,
+                    malicious_signers: Default::default(),
+                });
             }
         }
         Ok(())

--- a/src/state_machine/coordinator/frost.rs
+++ b/src/state_machine/coordinator/frost.rs
@@ -127,10 +127,10 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                         if let Error::DkgFailure(dkg_failures, malicious_signer_ids) = error {
                             return Ok((
                                 None,
-                                Some(OperationResult::DkgError(DkgError::DkgEndFailure(
-                                    dkg_failures,
-                                    malicious_signer_ids,
-                                ))),
+                                Some(OperationResult::DkgError(DkgError::DkgEndFailure {
+                                    reported_failures: dkg_failures,
+                                    malicious_signers: malicious_signer_ids,
+                                })),
                             ));
                         } else {
                             return Err(error);

--- a/src/state_machine/coordinator/frost.rs
+++ b/src/state_machine/coordinator/frost.rs
@@ -124,11 +124,12 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                 }
                 State::DkgEndGather => {
                     if let Err(error) = self.gather_dkg_end(packet) {
-                        if let Error::DkgFailure(dkg_failures) = error {
+                        if let Error::DkgFailure(dkg_failures, malicious_signer_ids) = error {
                             return Ok((
                                 None,
                                 Some(OperationResult::DkgError(DkgError::DkgEndFailure(
                                     dkg_failures,
+                                    malicious_signer_ids,
                                 ))),
                             ));
                         } else {
@@ -405,7 +406,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
             if dkg_failures.is_empty() {
                 self.dkg_end_gathered()?;
             } else {
-                return Err(Error::DkgFailure(dkg_failures));
+                return Err(Error::DkgFailure(dkg_failures, Default::default()));
             }
         }
         Ok(())
@@ -1154,6 +1155,7 @@ pub mod test {
                     poly: vec![],
                 },
             )],
+            kex_public_key: Point::from(Scalar::random(&mut rng)),
         };
         let packet = Packet {
             msg: Message::DkgPublicShares(public_shares.clone()),
@@ -1173,6 +1175,7 @@ pub mod test {
                     poly: vec![],
                 },
             )],
+            kex_public_key: Point::from(Scalar::random(&mut rng)),
         };
         let dup_packet = Packet {
             msg: Message::DkgPublicShares(dup_public_shares.clone()),

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -1748,8 +1748,7 @@ pub mod test {
         assert_eq!(outbound_messages.len(), 0);
         assert_eq!(operation_results.len(), 1);
         let OperationResult::DkgError(DkgError::DkgEndFailure {
-            reported_failures: dkg_failures,
-            ..
+            reported_failures, ..
         }) = &operation_results[0]
         else {
             panic!(
@@ -1758,13 +1757,13 @@ pub mod test {
             );
         };
         assert_eq!(
-            dkg_failures.len(),
+            reported_failures.len(),
             num_signers as usize,
             "Expected {num_signers} DkgFailures got {}",
-            dkg_failures.len()
+            reported_failures.len()
         );
         let expected_signer_ids = (0..1).collect::<HashSet<u32>>();
-        for dkg_failure in dkg_failures {
+        for dkg_failure in reported_failures {
             let (_, DkgFailure::MissingPublicShares(signer_ids)) = dkg_failure else {
                 panic!("Expected DkgFailure::MissingPublicShares got {dkg_failure:?}");
             };
@@ -1853,8 +1852,7 @@ pub mod test {
         assert_eq!(outbound_messages.len(), 0);
         assert_eq!(operation_results.len(), 1);
         let OperationResult::DkgError(DkgError::DkgEndFailure {
-            reported_failures: dkg_failures,
-            ..
+            reported_failures, ..
         }) = &operation_results[0]
         else {
             panic!(
@@ -1863,13 +1861,13 @@ pub mod test {
             );
         };
         assert_eq!(
-            dkg_failures.len(),
+            reported_failures.len(),
             num_signers as usize,
             "Expected {num_signers} DkgFailures got {}",
-            dkg_failures.len()
+            reported_failures.len()
         );
         let expected_signer_ids = (0..1).collect::<HashSet<u32>>();
-        for dkg_failure in dkg_failures {
+        for dkg_failure in reported_failures {
             let (_, DkgFailure::MissingPrivateShares(signer_ids)) = dkg_failure else {
                 panic!("Expected DkgFailure::MissingPublicShares got {dkg_failure:?}");
             };

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -92,9 +92,9 @@ pub enum Error {
     /// Bad key IDs for signer
     #[error("Bad key IDs for signer {0}")]
     BadKeyIDsForSigner(u32),
-    /// DKG failure from signers
+    /// DKG failure from signers, with a map of signer_id to reported errors and new malicious signer_ids
     #[error("DKG failure from signers")]
-    DkgFailure(HashMap<u32, DkgFailure>),
+    DkgFailure(HashMap<u32, DkgFailure>, HashSet<u32>),
     /// Aggregate key does not match supplied party polynomial
     #[error(
         "Aggregate key and computed key from party polynomials mismatch: got {0}, expected {1}"
@@ -1707,6 +1707,7 @@ pub mod test {
                             dkg_id: shares.dkg_id,
                             signer_id: shares.signer_id,
                             comms: vec![],
+                            kex_public_key: Point::new(),
                         };
                         Packet {
                             msg: Message::DkgPublicShares(public_shares),
@@ -1741,7 +1742,7 @@ pub mod test {
             feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
         assert_eq!(outbound_messages.len(), 0);
         assert_eq!(operation_results.len(), 1);
-        let OperationResult::DkgError(DkgError::DkgEndFailure(dkg_failures)) =
+        let OperationResult::DkgError(DkgError::DkgEndFailure(dkg_failures, _)) =
             &operation_results[0]
         else {
             panic!(
@@ -1844,7 +1845,7 @@ pub mod test {
             feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
         assert_eq!(outbound_messages.len(), 0);
         assert_eq!(operation_results.len(), 1);
-        let OperationResult::DkgError(DkgError::DkgEndFailure(dkg_failures)) =
+        let OperationResult::DkgError(DkgError::DkgEndFailure(dkg_failures, _)) =
             &operation_results[0]
         else {
             panic!(

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -1742,8 +1742,10 @@ pub mod test {
             feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
         assert_eq!(outbound_messages.len(), 0);
         assert_eq!(operation_results.len(), 1);
-        let OperationResult::DkgError(DkgError::DkgEndFailure(dkg_failures, _)) =
-            &operation_results[0]
+        let OperationResult::DkgError(DkgError::DkgEndFailure {
+            reported_failures: dkg_failures,
+            ..
+        }) = &operation_results[0]
         else {
             panic!(
                 "Expected OperationResult::DkgError got {:?}",
@@ -1845,8 +1847,10 @@ pub mod test {
             feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
         assert_eq!(outbound_messages.len(), 0);
         assert_eq!(operation_results.len(), 1);
-        let OperationResult::DkgError(DkgError::DkgEndFailure(dkg_failures, _)) =
-            &operation_results[0]
+        let OperationResult::DkgError(DkgError::DkgEndFailure {
+            reported_failures: dkg_failures,
+            ..
+        }) = &operation_results[0]
         else {
             panic!(
                 "Expected OperationResult::DkgError(DkgError::DkgEndFailure) got {:?}",

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -94,7 +94,12 @@ pub enum Error {
     BadKeyIDsForSigner(u32),
     /// DKG failure from signers, with a map of signer_id to reported errors and new malicious signer_ids
     #[error("DKG failure from signers")]
-    DkgFailure(HashMap<u32, DkgFailure>, HashSet<u32>),
+    DkgFailure {
+        /// failures reported by signers during DkgEnd
+        reported_failures: HashMap<u32, DkgFailure>,
+        /// signers who were discovered to be malicious during this DKG round
+        malicious_signers: HashSet<u32>,
+    },
     /// Aggregate key does not match supplied party polynomial
     #[error(
         "Aggregate key and computed key from party polynomials mismatch: got {0}, expected {1}"

--- a/src/state_machine/mod.rs
+++ b/src/state_machine/mod.rs
@@ -45,9 +45,9 @@ pub enum DkgError {
     /// DKG end timeout
     #[error("DKG end timeout, waiting for {0:?}")]
     DkgEndTimeout(Vec<u32>),
-    /// DKG end failure
+    /// DKG end failure, with a map of signer_id to reported errors and new malicious signer_ids
     #[error("DKG end failure")]
-    DkgEndFailure(HashMap<u32, DkgFailure>),
+    DkgEndFailure(HashMap<u32, DkgFailure>, HashSet<u32>),
 }
 
 /// Sign errors

--- a/src/state_machine/mod.rs
+++ b/src/state_machine/mod.rs
@@ -45,9 +45,14 @@ pub enum DkgError {
     /// DKG end timeout
     #[error("DKG end timeout, waiting for {0:?}")]
     DkgEndTimeout(Vec<u32>),
-    /// DKG end failure, with a map of signer_id to reported errors and new malicious signer_ids
+    /// DKG end failure
     #[error("DKG end failure")]
-    DkgEndFailure(HashMap<u32, DkgFailure>, HashSet<u32>),
+    DkgEndFailure {
+        /// failures reported by signers during DkgEnd
+        reported_failures: HashMap<u32, DkgFailure>,
+        /// signers who were discovered to be malicious during this DKG round
+        malicious_signers: HashSet<u32>,
+    },
 }
 
 /// Sign errors

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -1040,18 +1040,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             return Ok(vec![]);
         };
 
-        let Some(signer_key_ids) = self.public_keys.signer_key_ids.get(&src_signer_id) else {
-            warn!(%src_signer_id, "No key_ids configured");
-            return Ok(vec![]);
-        };
-
-        let Some(signer_key_id) = signer_key_ids.iter().next() else {
-            warn!(%src_signer_id, "No key_ids configured");
-            return Ok(vec![]);
-        };
-
-        let Some(kex_public_key) = self.kex_public_keys.get(signer_key_id) else {
-            warn!(%signer_key_id, "No KEX public key configured");
+        let Ok(kex_public_key) = self.get_kex_public_key(src_signer_id) else {
             return Ok(vec![]);
         };
 
@@ -1078,7 +1067,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
         let key_ids: HashSet<u32> = self.signer.get_key_ids().into_iter().collect();
 
         let shared_key = self.kex_private_key * kex_public_key;
-        let shared_secret = make_shared_secret(&self.kex_private_key, kex_public_key);
+        let shared_secret = make_shared_secret(&self.kex_private_key, &kex_public_key);
 
         for (src_id, shares) in &dkg_private_shares.shares {
             let mut decrypted_shares = HashMap::new();

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -12,10 +12,9 @@ use crate::{
         check_public_shares, validate_key_id, validate_signer_id, PolyCommitment, PublicNonce,
         TupleProof,
     },
-    compute,
     curve::{
         ecdsa,
-        point::{Compressed, Error as PointError, Point, G},
+        point::{Error as PointError, Point, G},
         scalar::Scalar,
     },
     errors::{DkgError, EncryptionError},

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -5,7 +5,7 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     fmt,
 };
-use tracing::{debug, info, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 
 use crate::{
     common::{
@@ -105,6 +105,9 @@ pub enum Error {
     #[error("A curve point error {0}")]
     /// A curve point error
     Point(#[from] PointError),
+    #[error("missing kex public key for key_id {0}")]
+    /// Missing KEX public key for a key_id
+    MissingKexPublicKey(u32),
 }
 
 /// The saved state required to reconstruct a signer
@@ -160,6 +163,10 @@ pub struct SavedState {
     pub verify_packet_sigs: bool,
     /// coordinator public key
     pub coordinator_public_key: Option<ecdsa::PublicKey>,
+    /// Ephemeral private key for key exchange
+    kex_private_key: Scalar,
+    /// Ephemeral public keys for key exchange indexed by key_id
+    kex_public_keys: HashMap<u32, Point>,
 }
 
 impl fmt::Debug for SavedState {
@@ -239,6 +246,10 @@ pub struct Signer<SignerType: SignerTrait> {
     pub verify_packet_sigs: bool,
     /// coordinator public key
     pub coordinator_public_key: Option<ecdsa::PublicKey>,
+    /// Ephemeral private key for key exchange
+    kex_private_key: Scalar,
+    /// Ephemeral public keys for key exchange indexed by key_id
+    kex_public_keys: HashMap<u32, Point>,
 }
 
 impl<SignerType: SignerTrait> fmt::Debug for Signer<SignerType> {
@@ -336,6 +347,8 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             dkg_end_begin_msg: Default::default(),
             verify_packet_sigs: true,
             coordinator_public_key: None,
+            kex_private_key: Scalar::random(rng),
+            kex_public_keys: Default::default(),
         })
     }
 
@@ -365,6 +378,8 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             dkg_end_begin_msg: state.dkg_end_begin_msg.clone(),
             verify_packet_sigs: state.verify_packet_sigs,
             coordinator_public_key: state.coordinator_public_key,
+            kex_private_key: state.kex_private_key,
+            kex_public_keys: state.kex_public_keys.clone(),
         }
     }
 
@@ -394,6 +409,8 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             dkg_end_begin_msg: self.dkg_end_begin_msg.clone(),
             verify_packet_sigs: self.verify_packet_sigs,
             coordinator_public_key: self.coordinator_public_key,
+            kex_private_key: self.kex_private_key,
+            kex_public_keys: self.kex_public_keys.clone(),
         }
     }
 
@@ -410,6 +427,8 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
         self.dkg_private_shares.clear();
         self.dkg_private_begin_msg = None;
         self.dkg_end_begin_msg = None;
+        self.kex_private_key = Scalar::random(rng);
+        self.kex_public_keys.clear();
         self.state = State::Idle;
     }
 
@@ -612,7 +631,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                                 {
                                     bad_private_shares.insert(
                                         *party_signer_id,
-                                        self.make_bad_private_share(*party_signer_id, rng),
+                                        self.make_bad_private_share(*party_signer_id, rng)?,
                                     );
                                 } else {
                                     warn!("DkgError::BadPrivateShares from party_id {party_id} but no (signer_id, shared_secret) cached");
@@ -855,6 +874,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             dkg_id: self.dkg_id,
             signer_id: self.signer_id,
             comms: Vec::new(),
+            kex_public_key: self.kex_private_key * G,
         };
 
         for poly in &comms {
@@ -904,9 +924,9 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             self.signer_id,
             &self.signer.get_shares()
         );
-        for (key_id, shares) in &self.signer.get_shares() {
+        for (party_id, shares) in &self.signer.get_shares() {
             debug!(
-                "Signer {} addding dkg private share for key_id {key_id}",
+                "Signer {} addding dkg private share for party_id {party_id}",
                 self.signer_id
             );
             // encrypt each share for the recipient
@@ -915,16 +935,18 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             for (dst_key_id, private_share) in shares {
                 if active_key_ids.contains(dst_key_id) {
                     debug!("encrypting dkg private share for key_id {dst_key_id}");
-                    let dst_public_key = compute::point(&self.public_keys.key_ids[dst_key_id])?;
-                    let shared_secret =
-                        make_shared_secret(&self.network_private_key, &dst_public_key);
+                    let Some(kex_public_key) = self.kex_public_keys.get(dst_key_id) else {
+                        error!("No KEX public key for key_id {dst_key_id}");
+                        return Err(Error::MissingKexPublicKey(*dst_key_id));
+                    };
+                    let shared_secret = make_shared_secret(&self.kex_private_key, kex_public_key);
                     let encrypted_share = encrypt(&shared_secret, &private_share.to_bytes(), rng)?;
 
                     encrypted_shares.insert(*dst_key_id, encrypted_share);
                 }
             }
 
-            private_shares.shares.push((*key_id, encrypted_shares));
+            private_shares.shares.push((*party_id, encrypted_shares));
         }
 
         let private_shares = Message::DkgPrivateShares(private_shares);
@@ -989,6 +1011,16 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             return Ok(vec![]);
         }
 
+        let Some(signer_key_ids) = self.public_keys.signer_key_ids.get(&signer_id) else {
+            warn!(%signer_id, "No key_ids configured");
+            return Ok(vec![]);
+        };
+
+        for key_id in signer_key_ids {
+            self.kex_public_keys
+                .insert(*key_id, dkg_public_shares.kex_public_key);
+        }
+
         self.dkg_public_shares
             .insert(dkg_public_shares.signer_id, dkg_public_shares.clone());
         Ok(vec![])
@@ -1006,6 +1038,21 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
         // check that the signer_id exists in the config
         let Some(_signer_public_key) = self.public_keys.signers.get(&src_signer_id) else {
             warn!(%src_signer_id, "No public key configured");
+            return Ok(vec![]);
+        };
+
+        let Some(signer_key_ids) = self.public_keys.signer_key_ids.get(&src_signer_id) else {
+            warn!(%src_signer_id, "No key_ids configured");
+            return Ok(vec![]);
+        };
+
+        let Some(signer_key_id) = signer_key_ids.iter().next() else {
+            warn!(%src_signer_id, "No key_ids configured");
+            return Ok(vec![]);
+        };
+
+        let Some(kex_public_key) = self.kex_public_keys.get(signer_key_id) else {
+            warn!(%signer_key_id, "No KEX public key configured");
             return Ok(vec![]);
         };
 
@@ -1030,11 +1077,9 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
 
         // make a HashSet of our key_ids so we can quickly query them
         let key_ids: HashSet<u32> = self.signer.get_key_ids().into_iter().collect();
-        let compressed = Compressed::from(self.public_keys.signers[&src_signer_id].to_bytes());
-        // this should not fail as long as the public key above was valid
-        let public_key = Point::try_from(&compressed).unwrap();
-        let shared_key = self.network_private_key * public_key;
-        let shared_secret = make_shared_secret(&self.network_private_key, &public_key);
+
+        let shared_key = self.kex_private_key * kex_public_key;
+        let shared_secret = make_shared_secret(&self.kex_private_key, kex_public_key);
 
         for (src_id, shares) in &dkg_private_shares.shares {
             let mut decrypted_shares = HashMap::new();
@@ -1049,7 +1094,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                                 warn!("Failed to parse Scalar for dkg private share from src_id {src_id} to dst_id {dst_key_id}: {e:?}");
                                 self.invalid_private_shares.insert(
                                     src_signer_id,
-                                    self.make_bad_private_share(src_signer_id, rng),
+                                    self.make_bad_private_share(src_signer_id, rng)?,
                                 );
                             }
                         },
@@ -1057,7 +1102,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                             warn!("Failed to decrypt dkg private share from src_id {src_id} to dst_id {dst_key_id}: {e:?}");
                             self.invalid_private_shares.insert(
                                 src_signer_id,
-                                self.make_bad_private_share(src_signer_id, rng),
+                                self.make_bad_private_share(src_signer_id, rng)?,
                             );
                         }
                     }
@@ -1076,25 +1121,41 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
         Ok(vec![])
     }
 
+    fn get_kex_public_key(&self, signer_id: u32) -> Result<Point, Error> {
+        let Some(signer_key_ids) = self.public_keys.signer_key_ids.get(&signer_id) else {
+            warn!(%signer_id, "No key_ids configured");
+            return Err(Error::Config(ConfigError::InvalidSignerId(signer_id)));
+        };
+
+        let Some(signer_key_id) = signer_key_ids.iter().next() else {
+            warn!(%signer_id, "No key_ids configured");
+            return Err(Error::Config(ConfigError::InvalidSignerId(signer_id)));
+        };
+
+        let Some(kex_public_key) = self.kex_public_keys.get(signer_key_id) else {
+            warn!(%signer_id, %signer_key_id, "No KEX public key configured");
+            return Err(Error::MissingKexPublicKey(*signer_key_id));
+        };
+
+        Ok(*kex_public_key)
+    }
+
     #[allow(non_snake_case)]
     fn make_bad_private_share<R: RngCore + CryptoRng>(
         &self,
         signer_id: u32,
         rng: &mut R,
-    ) -> BadPrivateShare {
-        let a = self.network_private_key;
+    ) -> Result<BadPrivateShare, Error> {
+        let a = self.kex_private_key;
         let A = a * G;
-        let B = Point::try_from(&Compressed::from(
-            self.public_keys.signers[&signer_id].to_bytes(),
-        ))
-        .unwrap();
+        let B = self.get_kex_public_key(signer_id)?;
         let K = a * B;
         let tuple_proof = TupleProof::new(&a, &A, &B, &K, rng);
 
-        BadPrivateShare {
+        Ok(BadPrivateShare {
             shared_key: K,
             tuple_proof,
-        }
+        })
     }
 }
 
@@ -1336,6 +1397,7 @@ pub mod test {
             dkg_id: 0,
             signer_id: 0,
             comms,
+            kex_public_key: Point::from(Scalar::random(&mut rng)),
         };
         signer.dkg_public_share(&public_share).unwrap();
         assert_eq!(1, signer.dkg_public_shares.len());
@@ -1351,6 +1413,7 @@ pub mod test {
                     poly: vec![],
                 },
             )],
+            kex_public_key: Point::from(Scalar::random(&mut rng)),
         };
         signer.dkg_public_share(&dup_public_share).unwrap();
         assert_eq!(1, signer.dkg_public_shares.len());
@@ -1414,6 +1477,8 @@ pub mod test {
         let private_key2 = Scalar::random(&mut rng);
         let public_key2 = ecdsa::PublicKey::new(&private_key2).unwrap();
         let mut public_keys: PublicKeys = Default::default();
+        let kex_private_key = Scalar::random(&mut rng);
+        let kex_public_key = Point::from(&kex_private_key);
 
         public_keys.signers.insert(0, public_key);
         public_keys.signers.insert(1, public_key2);
@@ -1431,6 +1496,15 @@ pub mod test {
         let mut signer =
             Signer::<v1::Signer>::new(1, 1, 2, 2, 0, vec![1], private_key, public_keys, &mut rng)
                 .unwrap();
+
+        let public_share = DkgPublicShares {
+            dkg_id: 0,
+            signer_id: 1,
+            comms: vec![],
+            kex_public_key,
+        };
+        signer.dkg_public_share(&public_share).unwrap();
+        assert_eq!(1, signer.dkg_public_shares.len());
 
         let private_share = DkgPrivateShares {
             dkg_id: 0,
@@ -1466,6 +1540,8 @@ pub mod test {
         let private_key2 = Scalar::random(&mut rng);
         let public_key2 = ecdsa::PublicKey::new(&private_key2).unwrap();
         let mut public_keys: PublicKeys = Default::default();
+        let kex_private_key = Scalar::random(&mut rng);
+        let kex_public_key = Point::from(&kex_private_key);
 
         public_keys.signers.insert(0, public_key);
         public_keys.signers.insert(1, public_key2);
@@ -1483,6 +1559,15 @@ pub mod test {
         let mut signer =
             Signer::<v2::Signer>::new(1, 1, 2, 2, 0, vec![1], private_key, public_keys, &mut rng)
                 .unwrap();
+
+        let public_share = DkgPublicShares {
+            dkg_id: 0,
+            signer_id: 1,
+            comms: vec![],
+            kex_public_key,
+        };
+        signer.dkg_public_share(&public_share).unwrap();
+        assert_eq!(1, signer.dkg_public_shares.len());
 
         let private_share = DkgPrivateShares {
             dkg_id: 0,


### PR DESCRIPTION
This PR uses ephemeral keys for the DH key exchange needed to encrypt `DkgPrivateShares`.  Signers will create a new `kex_private_key` for each `DKG` round, then pass the corresponding `kex_public_key` in `DkgPublicShares`.  This prevents accumulation of bits of the `ECDSA` private keys over multiple rounds of DKG, and allows exposing the `DH` shared key during the `DkgFaillure::BadPrivateShares` protocol without compromising future rounds of DKG between those participants.

Fixes #167 