### PR TITLE
[chore]: feature gate v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Cargo Test
         id: cargo_test
         run: |
-          cargo test
+          cargo test --features with_v1
 
   fmt:
     name: fmt
@@ -83,7 +83,7 @@ jobs:
       - name: Cargo Clippy
         id: cargo_clippy
         run: |
-          cargo clippy --all-targets -- -D warnings -A clippy::op-ref -A clippy::needless-range-loop
+          cargo clippy --all-targets --all-features -- -D warnings -A clippy::op-ref -A clippy::needless-range-loop
 
   doc:
     permissions:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ rand_chacha = "0.3.1"
 
 [[bench]]
 name = "v1_bench"
+required-features = ["with_v1"]
 harness = false
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["cryptography"]
 [features]
 default = ["with_p256k1_bindgen"]
 with_p256k1_bindgen = ["p256k1/with_bindgen"]
+with_v1 = []
 
 [dependencies]
 aes-gcm = "0.10"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub mod traits;
 /// Utilities for hashing and encryption
 pub mod util;
 /// Version 1 of WSTS, which encapsulates a number of parties using vanilla FROST
+#[cfg(feature = "with_v1")]
 #[allow(clippy::op_ref)]
 pub mod v1;
 /// Version 1 of WSTS, which encapsulates a number of parties using vanilla FROST

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 use std::{env, time};
 
-use wsts::{common::test_helpers::gen_signer_ids, traits::Aggregator, util::create_rng, v1, v2};
+use wsts::{common::test_helpers::gen_signer_ids, traits::Aggregator, util::create_rng, v2};
+#[cfg(feature = "with_v1")]
+use wsts::v1;
 
 #[allow(non_snake_case)]
 fn main() {
@@ -27,6 +29,7 @@ fn main() {
     println!("With N={N} T={T} K={K}:");
 
     // v1
+    #[cfg(feature = "with_v1")]
     {
         let signer_ids = gen_signer_ids(N, K);
         let mut signers: Vec<v1::Signer> = signer_ids

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 use std::{env, time};
 
-use wsts::{common::test_helpers::gen_signer_ids, traits::Aggregator, util::create_rng, v2};
 #[cfg(feature = "with_v1")]
 use wsts::v1;
+use wsts::{common::test_helpers::gen_signer_ids, traits::Aggregator, util::create_rng, v2};
 
 #[allow(non_snake_case)]
 fn main() {

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -1475,6 +1475,7 @@ pub mod test {
     }
 
     /// test basic insertion and detection of duplicates for DkgPublicShares
+    #[allow(dead_code)]
     fn dkg_public_share<Aggregator: AggregatorTrait, Signer: SignerTrait>() {
         let ctx = 0u64.to_be_bytes();
         let mut rng = create_rng();
@@ -1668,6 +1669,7 @@ pub mod test {
     }
 
     /// test basic insertion and detection of duplicates for SignatureShareResponse
+    #[allow(dead_code)]
     fn sig_share<Aggregator: AggregatorTrait, Signer: SignerTrait>() {
         let mut rng = create_rng();
         let (coordinators, _) = setup::<FireCoordinator<Aggregator>, Signer>(2, 1);

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -1386,6 +1386,8 @@ impl<Aggregator: AggregatorTrait> CoordinatorTrait for Coordinator<Aggregator> {
 /// Test module for coordinator functionality
 pub mod test {
     use super::*;
+    #[cfg(feature = "with_v1")]
+    use crate::v1;
     use crate::{
         curve::{point::Point, scalar::Scalar},
         net::{
@@ -1409,12 +1411,13 @@ pub mod test {
         },
         traits::{Aggregator as AggregatorTrait, Signer as SignerTrait},
         util::create_rng,
-        v1, v2,
+        v2,
     };
     use hashbrown::HashMap;
     use std::{thread, time::Duration};
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn new_coordinator_v1() {
         new_coordinator::<FireCoordinator<v1::Aggregator>>();
     }
@@ -1425,6 +1428,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn equal_after_save_load_v1() {
         equal_after_save_load::<FireCoordinator<v1::Aggregator>, v1::Signer>(2, 2);
     }
@@ -1435,6 +1439,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn coordinator_state_machine_v1() {
         coordinator_state_machine::<FireCoordinator<v1::Aggregator>>();
     }
@@ -1445,6 +1450,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn start_dkg_round_v1() {
         start_dkg_round::<FireCoordinator<v1::Aggregator>>(None);
         start_dkg_round::<FireCoordinator<v1::Aggregator>>(Some(12345u64));
@@ -1457,11 +1463,13 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn dkg_public_share_v1() {
         dkg_public_share::<v1::Aggregator, v1::Signer>();
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn dkg_public_share_v2() {
         dkg_public_share::<v1::Aggregator, v2::Signer>();
     }
@@ -1524,6 +1532,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn dkg_private_share_v1() {
         dkg_private_share::<v1::Aggregator, v1::Signer>();
     }
@@ -1577,6 +1586,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn nonce_response_v1() {
         nonce_response::<v1::Aggregator, v1::Signer>();
     }
@@ -1646,11 +1656,13 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn sig_share_v1() {
         sig_share::<v1::Aggregator, v1::Signer>();
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn sig_share_v2() {
         sig_share::<v2::Aggregator, v1::Signer>();
     }
@@ -1719,6 +1731,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn start_public_shares_v1() {
         start_public_shares::<v1::Aggregator>();
     }
@@ -1743,6 +1756,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn start_private_shares_v1() {
         start_private_shares::<v1::Aggregator>();
     }
@@ -1766,6 +1780,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn run_dkg_sign_v1() {
         for _ in 0..4 {
             run_dkg_sign::<FireCoordinator<v1::Aggregator>, v1::Signer>(5, 2);
@@ -1780,6 +1795,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn check_signature_shares_v1() {
         check_signature_shares::<FireCoordinator<v1::Aggregator>, v1::Signer>(
             5,
@@ -1836,6 +1852,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn all_signers_dkg_v1() {
         all_signers_dkg::<v1::Aggregator, v1::Signer>(5, 2);
     }
@@ -1902,6 +1919,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn missing_public_keys_dkg_v1() {
         missing_public_keys_dkg::<v1::Aggregator, v1::Signer>(10, 1);
     }
@@ -1987,6 +2005,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn minimum_signers_dkg_v1() {
         minimum_signers_dkg::<v1::Aggregator, v1::Signer>(10, 2);
     }
@@ -2146,6 +2165,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn insufficient_signers_dkg_v1() {
         insufficient_signers_dkg::<v1::Aggregator, v1::Signer>();
     }
@@ -2304,6 +2324,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn malicious_signers_dkg_v1() {
         malicious_signers_dkg::<v1::Aggregator, v1::Signer>(5, 2);
     }
@@ -2417,6 +2438,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn bad_poly_length_dkg_v1() {
         bad_poly_length_dkg::<v1::Aggregator, v1::Signer>(5, 2);
     }
@@ -2524,6 +2546,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn all_signers_sign_v1() {
         all_signers_sign::<v1::Aggregator, v1::Signer>();
     }
@@ -2586,6 +2609,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn minimum_signers_sign_v1() {
         minimum_signers_sign::<v1::Aggregator, v1::Signer>();
     }
@@ -2665,6 +2689,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn missing_public_keys_sign_v1() {
         missing_public_keys_sign::<v1::Aggregator, v1::Signer>();
     }
@@ -2748,6 +2773,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn insufficient_signers_sign_v1() {
         insufficient_signers_sign::<v1::Aggregator, v1::Signer>();
     }
@@ -3008,6 +3034,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn multiple_nonce_request_messages_sign_v1() {
         multiple_nonce_request_messages::<v1::Aggregator, v1::Signer>();
     }
@@ -3103,6 +3130,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn old_round_ids_are_ignored_v1() {
         old_round_ids_are_ignored::<v1::Aggregator, v1::Signer>();
     }
@@ -3182,6 +3210,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn gen_nonces_v1() {
         gen_nonces::<FireCoordinator<v1::Aggregator>, v1::Signer>(5, 1);
     }
@@ -3192,6 +3221,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn bad_signature_share_request_v1() {
         bad_signature_share_request::<FireCoordinator<v1::Aggregator>, v1::Signer>(5, 2);
     }
@@ -3202,6 +3232,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn invalid_nonce_v1() {
         invalid_nonce::<FireCoordinator<v1::Aggregator>, v1::Signer>(5, 2);
     }
@@ -3212,6 +3243,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn one_signer_bad_threshold_v1() {
         one_signer_bad_threshold::<v1::Aggregator, v1::Signer>();
     }
@@ -3314,6 +3346,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn bad_dkg_threshold_v1() {
         bad_dkg_threshold::<v1::Aggregator, v1::Signer>();
     }
@@ -3391,6 +3424,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn empty_public_shares_v1() {
         empty_public_shares::<FireCoordinator<v1::Aggregator>, v1::Signer>(5, 2);
     }
@@ -3401,6 +3435,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn empty_private_shares_v1() {
         empty_private_shares::<FireCoordinator<v1::Aggregator>, v1::Signer>(5, 2);
     }

--- a/src/state_machine/coordinator/frost.rs
+++ b/src/state_machine/coordinator/frost.rs
@@ -967,6 +967,8 @@ impl<Aggregator: AggregatorTrait> CoordinatorTrait for Coordinator<Aggregator> {
 /// Test module for coordinator functionality
 pub mod test {
     use super::*;
+    #[cfg(feature = "with_v1")]
+    use crate::v1;
     use crate::{
         curve::scalar::Scalar,
         net::{DkgBegin, Message, NonceRequest, Packet, SignatureShareResponse, SignatureType},
@@ -982,10 +984,11 @@ pub mod test {
         },
         traits::{Aggregator as AggregatorTrait, Signer as SignerTrait},
         util::create_rng,
-        v1, v2,
+        v2,
     };
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn new_coordinator_v1() {
         new_coordinator::<FrostCoordinator<v1::Aggregator>>();
     }
@@ -996,6 +999,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn equal_after_save_load_v1() {
         equal_after_save_load::<FrostCoordinator<v1::Aggregator>, v1::Signer>(2, 2);
     }
@@ -1006,6 +1010,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn coordinator_state_machine_v1() {
         coordinator_state_machine::<FrostCoordinator<v1::Aggregator>>();
     }
@@ -1016,6 +1021,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn start_dkg_round_v1() {
         start_dkg_round::<FrostCoordinator<v1::Aggregator>>(None);
         start_dkg_round::<FrostCoordinator<v1::Aggregator>>(Some(12345u64));
@@ -1028,6 +1034,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn start_public_shares_v1() {
         start_public_shares::<v1::Aggregator>();
     }
@@ -1052,6 +1059,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn start_private_shares_v1() {
         start_private_shares::<v1::Aggregator>();
     }
@@ -1075,11 +1083,13 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn dkg_public_share_v1() {
         dkg_public_share::<v1::Aggregator, v1::Signer>();
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn dkg_public_share_v2() {
         dkg_public_share::<v1::Aggregator, v2::Signer>();
     }
@@ -1142,6 +1152,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn dkg_private_share_v1() {
         dkg_private_share::<v1::Aggregator, v1::Signer>();
     }
@@ -1195,6 +1206,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn nonce_response_v1() {
         nonce_response::<v1::Aggregator, v1::Signer>();
     }
@@ -1258,11 +1270,13 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn sig_share_v1() {
         sig_share::<v1::Aggregator, v1::Signer>();
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn sig_share_v2() {
         sig_share::<v2::Aggregator, v1::Signer>();
     }
@@ -1332,6 +1346,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn run_dkg_sign_v1() {
         run_dkg_sign::<FrostCoordinator<v1::Aggregator>, v1::Signer>(5, 2);
     }
@@ -1342,6 +1357,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn check_signature_shares_v1() {
         check_signature_shares::<FrostCoordinator<v1::Aggregator>, v1::Signer>(
             5,
@@ -1398,6 +1414,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn bad_signature_share_request_v1() {
         bad_signature_share_request::<FrostCoordinator<v1::Aggregator>, v1::Signer>(5, 2);
     }
@@ -1408,6 +1425,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn invalid_nonce_v1() {
         invalid_nonce::<FrostCoordinator<v1::Aggregator>, v1::Signer>(5, 2);
     }
@@ -1423,6 +1441,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn old_round_ids_are_ignored_v1() {
         old_round_ids_are_ignored::<v1::Aggregator>();
     }
@@ -1502,6 +1521,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn empty_public_shares_v1() {
         empty_public_shares::<FrostCoordinator<v1::Aggregator>, v1::Signer>(5, 2);
     }
@@ -1512,6 +1532,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn empty_private_shares_v1() {
         empty_private_shares::<FrostCoordinator<v1::Aggregator>, v1::Signer>(5, 2);
     }

--- a/src/state_machine/coordinator/frost.rs
+++ b/src/state_machine/coordinator/frost.rs
@@ -1095,6 +1095,7 @@ pub mod test {
     }
 
     /// test basic insertion and detection of duplicates for DkgPublicShares
+    #[allow(dead_code)]
     fn dkg_public_share<Aggregator: AggregatorTrait, Signer: SignerTrait>() {
         let ctx = 0u64.to_be_bytes();
         let mut rng = create_rng();
@@ -1282,6 +1283,7 @@ pub mod test {
     }
 
     /// test basic insertion and detection of duplicates for SignatureShareResponse
+    #[allow(dead_code)]
     fn sig_share<Aggregator: AggregatorTrait, Signer: SignerTrait>() {
         let mut rng = create_rng();
         let (coordinators, _) = setup::<FrostCoordinator<Aggregator>, Signer>(2, 1);

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -1103,6 +1103,8 @@ impl<SignerType: SignerTrait> StateMachine<State, Error> for Signer<SignerType> 
 /// Test module for signer functionality
 pub mod test {
     use super::*;
+    #[cfg(feature = "with_v1")]
+    use crate::v1;
     use crate::{
         common::PolyCommitment,
         curve::{ecdsa, scalar::Scalar},
@@ -1114,17 +1116,19 @@ pub mod test {
         },
         traits::Signer as SignerTrait,
         util::create_rng,
-        v1, v2,
+        v2,
     };
 
     use hashbrown::HashSet;
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn bad_config_v1() {
         bad_config::<v1::Signer>();
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn bad_config_v2() {
         bad_config::<v1::Signer>();
     }
@@ -1264,6 +1268,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn dkg_public_share_v1() {
         dkg_public_share::<v1::Signer>();
     }
@@ -1325,6 +1330,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn public_shares_done_v1() {
         public_shares_done::<v1::Signer>();
     }
@@ -1367,6 +1373,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     /// test basic insertion and detection of duplicates for DkgPrivateShares for v1
     fn dkg_private_share_v1() {
         let mut rng = create_rng();
@@ -1471,6 +1478,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn can_dkg_end_v1() {
         can_dkg_end::<v1::Signer>();
     }
@@ -1532,6 +1540,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "with_v1")]
     fn dkg_ended_v1() {
         dkg_ended::<v1::Signer>();
     }

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -1133,6 +1133,7 @@ pub mod test {
         bad_config::<v1::Signer>();
     }
 
+    #[allow(dead_code)]
     fn bad_config<SignerType: SignerTrait>() {
         let mut rng = create_rng();
 

--- a/src/taproot.rs
+++ b/src/taproot.rs
@@ -153,7 +153,9 @@ pub mod test_helpers {
 mod test {
     use super::{test_helpers, Point, Scalar, SchnorrProof, G};
 
-    use crate::{compute, traits::Aggregator, traits::Signer, util::create_rng, v1, v2};
+    #[cfg(feature = "with_v1")]
+    use crate::v1;
+    use crate::{compute, traits::Aggregator, traits::Signer, util::create_rng, v2};
 
     #[test]
     #[allow(non_snake_case)]
@@ -285,6 +287,7 @@ mod test {
 
     #[test]
     #[allow(non_snake_case)]
+    #[cfg(feature = "with_v1")]
     fn taproot_sign_verify_v1_with_merkle_root() {
         let script = "OP_1".as_bytes();
         let merkle_root = compute::merkle_root(script);
@@ -294,11 +297,13 @@ mod test {
 
     #[test]
     #[allow(non_snake_case)]
+    #[cfg(feature = "with_v1")]
     fn taproot_sign_verify_v1_no_merkle_root() {
         taproot_sign_verify_v1(None);
     }
 
     #[allow(non_snake_case)]
+    #[cfg(feature = "with_v1")]
     fn taproot_sign_verify_v1(merkle_root: Option<[u8; 32]>) {
         let mut rng = create_rng();
 


### PR DESCRIPTION
# Description

Closes #119

This PR feature gates v1 code under "with_v1" feature.

Now some commands like benchmarking work only with enabling `with_v1` feature, like `cargo bench --features with_v1`. Maaybe some sort of `Makefile` can be useful to incapsulate this and further similar changes.