### PR TITLE
feat: zeroize nonce before drop

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -58,6 +58,13 @@ pub struct Nonce {
     pub e: Scalar,
 }
 
+impl Drop for Nonce {
+    fn drop(&mut self) {
+        self.d.set_zero();
+        self.e.set_zero();
+    }
+}
+
 impl fmt::Debug for Nonce {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Nonce").finish_non_exhaustive()


### PR DESCRIPTION
Closes #115


## Note
About zeroize crate, some of our dependencies do not use it, and thus it need some workaround to make it working. Also if I understand correctly and only this `Nonce` struct need zeroizing it is simpler to directly implement `Drop` (and as bonus avoid some unsafe code which `Zeroize` have under the hood and avoid extra dependency).


p.s. oookay, not only `Nonce` but at least `Scalar` should be zeroized and it makes everything a bit more difficult