### PR TITLE
chore: fix cargo doc warnings

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -168,7 +168,7 @@ pub trait Aggregator: Clone + Debug + PartialEq {
     ) -> Result<Signature, AggregatorError>;
 
     /// Check and aggregate the signature shares into a BIP-340 `SchnorrProof`.
-    /// https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki
+    /// <https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki>
     fn sign_schnorr(
         &mut self,
         msg: &[u8],
@@ -178,8 +178,8 @@ pub trait Aggregator: Clone + Debug + PartialEq {
     ) -> Result<SchnorrProof, AggregatorError>;
 
     /// Check and aggregate the signature shares into a BIP-340 `SchnorrProof` with BIP-341 key tweaks
-    /// https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki
-    /// https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki
+    /// <https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki>
+    /// <https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki>
     fn sign_taproot(
         &mut self,
         msg: &[u8],

--- a/src/util.rs
+++ b/src/util.rs
@@ -60,7 +60,7 @@ pub fn make_shared_secret_from_key(shared_key: &Point) -> [u8; 32] {
 }
 
 /// Derive a shared key using the ANSI-x963 standard
-/// https://www.secg.org/sec1-v2.pdf (section 3.6.1)
+/// <https://www.secg.org/sec1-v2.pdf> (section 3.6.1)
 pub fn ansi_x963_derive_key(shared_key: &[u8], shared_info: &[u8]) -> [u8; 32] {
     let mut hasher = Sha256::new();
     let counter = 1u32;

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -301,7 +301,7 @@ pub struct Aggregator {
     pub num_keys: u32,
     /// The threshold of signers needed to construct a valid signature
     pub threshold: u32,
-    /// The aggregate group polynomial; poly[0] is the group public key
+    /// The aggregate group polynomial; `poly[0]` is the group public key
     pub poly: Vec<Point>,
 }
 

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -283,7 +283,7 @@ pub struct Aggregator {
     pub num_keys: u32,
     /// The threshold of signing keys needed to construct a valid signature
     pub threshold: u32,
-    /// The aggregate group polynomial; poly[0] is the group public key
+    /// The aggregate group polynomial; `poly[0]` is the group public key
     pub poly: Vec<Point>,
 }
 


### PR DESCRIPTION
Fixes `GitHub Actions / doc` warnings appearing on every PR diff