### PR TITLE
Test `sBTC` style taproot script spends

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,6 @@ with_v1 = []
 
 [dependencies]
 aes-gcm = "0.10"
-bitcoin = { version = "0.32", default-features = false, features = ["serde", "rand-std"] }
-bitcoinconsensus = { version = "0.106.0", default-features = false }
 bs58 = "0.5"
 elliptic-curve = { version = "0.13.8", features = ["hash2curve"] }
 hashbrown = { version = "0.14", features = ["serde"] }
@@ -35,6 +33,8 @@ tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 
 [dev-dependencies]
+bitcoin = { version = "0.32", default-features = false, features = ["serde", "rand-std"] }
+bitcoinconsensus = { version = "0.106.0", default-features = false }
 criterion = "0.5.1"
 rand = "0.8.5"
 rand_chacha = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ with_v1 = []
 
 [dependencies]
 aes-gcm = "0.10"
-bitcoin = { version = "0.32.5", default-features = false, features = ["serde", "rand-std"] }
+bitcoin = { version = "0.32", default-features = false, features = ["serde", "rand-std"] }
 bitcoinconsensus = { version = "0.106.0", default-features = false }
 bs58 = "0.5"
 elliptic-curve = { version = "0.13.8", features = ["hash2curve"] }

--- a/src/btc.rs
+++ b/src/btc.rs
@@ -293,9 +293,9 @@ mod test {
         //
         //     <sbtc_payload> DROP <signers_pubkey> CHECKSIGVERIFY
         //
-        // with 160-bytes of <sbtc_payload>
+        // with a variable sized  <sbtc_payload> up to 159-bytes
 
-        let sbtc_payload = [255u8; 160];
+        let sbtc_payload = [255u8; 159];
         let mut push_bytes = PushBytesBuf::new();
         push_bytes
             .push(sbtc_payload.len().try_into().unwrap())

--- a/src/btc.rs
+++ b/src/btc.rs
@@ -286,7 +286,7 @@ mod test {
             .collect::<Vec<u32>>();
         let mut sig_agg = v2::Aggregator::new(num_keys, threshold);
         sig_agg.init(&polys).expect("aggregator init failed");
-        let wsts_public_key = sig_agg.poly[0].clone();
+        let wsts_public_key = sig_agg.poly[0];
         let wsts_public_key_bytes = wsts_public_key.x().to_bytes();
 
         // the sBTC accept script must be of the form
@@ -365,7 +365,7 @@ mod test {
 
         let schnorr_sig = secp.sign_schnorr(&message, &depositor_keypair);
         let taproot_sig = bitcoin::taproot::Signature {
-            signature: schnorr_sig.clone(),
+            signature: schnorr_sig,
             sighash_type: TapSighashType::All,
         };
 
@@ -404,7 +404,7 @@ mod test {
         let schnorr_sig = bitcoin::secp256k1::schnorr::Signature::from_slice(&proof_bytes)
             .expect("Failed to parse Signature from slice");
         let taproot_sig = bitcoin::taproot::Signature {
-            signature: schnorr_sig.clone(),
+            signature: schnorr_sig,
             sighash_type: TapSighashType::All,
         };
 

--- a/src/btc.rs
+++ b/src/btc.rs
@@ -228,7 +228,7 @@ impl UnsignedTx {
 mod test {
     use super::*;
     use crate::{
-        compute, curve,
+        compute,
         taproot::{test_helpers, SchnorrProof},
         traits::{Aggregator, Signer},
         v2,
@@ -335,10 +335,7 @@ mod test {
         let nums_x_data =
             hex::decode("50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0")
                 .unwrap();
-        let nums_x = curve::field::Element::try_from(nums_x_data.as_slice()).unwrap();
-        let nums_key_point = curve::point::Point::lift_x(&nums_x).unwrap();
-        let nums_public_key =
-            bitcoin::XOnlyPublicKey::from_slice(&nums_key_point.x().to_bytes()).unwrap();
+        let nums_public_key = bitcoin::XOnlyPublicKey::from_slice(&nums_x_data).unwrap();
 
         let spend_info = TaprootBuilder::new()
             .add_leaf(1, accept_script.clone())

--- a/src/btc.rs
+++ b/src/btc.rs
@@ -348,6 +348,8 @@ mod test {
             //.finalize(&secp, depositor_public_key)
             .expect("failed to finalize taproot_spend_info");
 
+        println!("TaprootSpendInfo {spend_info:?}");
+
         let spend_internal_key = spend_info.internal_key();
         let merkle_root = spend_info.merkle_root();
         let tweaked = depositor_keypair.tap_tweak(&secp, merkle_root);
@@ -400,6 +402,8 @@ mod test {
         let control_block = spend_info
             .control_block(&(reject_script.clone(), LeafVersion::TapScript))
             .expect("We just inserted the reject script into the tree");
+
+        println!("ControlBlock {control_block:?}");
 
         let reject_script_bytes = reject_script.to_bytes();
         let control_block_bytes = control_block.serialize();

--- a/src/btc.rs
+++ b/src/btc.rs
@@ -157,7 +157,7 @@ impl UnsignedTx {
 
     /// Tests if the provided taproot [`Signature`] is valid for spending the
     /// signers' UTXO. This function will return  [`Error::BitcoinConsensus`]
-    /// error if the signature fails verification, passing the underlying error
+    /// error if the transaction fails verification, passing the underlying error
     /// from [`bitcoinconsensus`].
     pub fn verify_signature<C: Verification>(
         &self,
@@ -169,9 +169,9 @@ impl UnsignedTx {
         self.verify_witness(secp, witness, merkle_root)
     }
 
-    /// Tests if the provided taproot [`Signature`] is valid for spending the
+    /// Tests if the provided taproot [`Witness`] is valid for spending the
     /// signers' UTXO. This function will return  [`Error::BitcoinConsensus`]
-    /// error if the signature fails verification, passing the underlying error
+    /// error if the transaction fails verification, passing the underlying error
     /// from [`bitcoinconsensus`].
     pub fn verify_witness<C: Verification>(
         &self,

--- a/src/btc.rs
+++ b/src/btc.rs
@@ -297,9 +297,6 @@ mod test {
 
         let sbtc_payload = [255u8; 159];
         let mut push_bytes = PushBytesBuf::new();
-        push_bytes
-            .push(sbtc_payload.len().try_into().unwrap())
-            .unwrap();
         push_bytes.extend_from_slice(&sbtc_payload).unwrap();
 
         let accept_script = Builder::new()

--- a/src/btc.rs
+++ b/src/btc.rs
@@ -356,7 +356,6 @@ mod test {
         let sighash = unsigned
             .compute_script_sighash(&secp, merkle_root, &reject_script)
             .expect("failed to compute taproot sighash");
-
         let message = secp256k1::Message::from_digest_slice(sighash.as_ref())
             .expect("Failed to create message");
 
@@ -385,12 +384,8 @@ mod test {
         let sighash = unsigned
             .compute_script_sighash(&secp, merkle_root, &accept_script)
             .expect("failed to compute taproot sighash");
-
-        let _raw_merkle_root = merkle_root.map(|root| {
-            let bytes: [u8; 32] = *root.to_raw_hash().as_ref();
-            bytes
-        });
         let message: &[u8] = sighash.as_ref();
+
         let (nonces, sig_shares) =
             test_helpers::sign_schnorr(message, &mut signing_set, &mut OsRng);
         let proof = match sig_agg.sign_schnorr(message, &nonces, &sig_shares, &key_ids) {

--- a/src/taproot.rs
+++ b/src/taproot.rs
@@ -147,6 +147,22 @@ pub mod test_helpers {
 
         (nonces, shares)
     }
+
+    /// Run a signing round for the passed `msg`
+    #[allow(non_snake_case)]
+    pub fn sign_schnorr<RNG: RngCore + CryptoRng, Signer: traits::Signer>(
+        msg: &[u8],
+        signers: &mut [Signer],
+        rng: &mut RNG,
+    ) -> (Vec<PublicNonce>, Vec<SignatureShare>) {
+        let (signer_ids, key_ids, nonces) = sign_params(signers, rng);
+        let shares = signers
+            .iter()
+            .flat_map(|s| s.sign_schnorr(msg, &signer_ids, &key_ids, &nonces))
+            .collect();
+
+        (nonces, shares)
+    }
 }
 
 #[cfg(test)]

--- a/src/taproot.rs
+++ b/src/taproot.rs
@@ -115,7 +115,6 @@ pub mod test_helpers {
         }
     }
 
-    #[allow(non_snake_case)]
     fn sign_params<RNG: RngCore + CryptoRng, Signer: traits::Signer>(
         signers: &mut [Signer],
         rng: &mut RNG,
@@ -132,7 +131,6 @@ pub mod test_helpers {
     }
 
     /// Run a signing round for the passed `msg`
-    #[allow(non_snake_case)]
     pub fn sign<RNG: RngCore + CryptoRng, Signer: traits::Signer>(
         msg: &[u8],
         signers: &mut [Signer],
@@ -149,7 +147,6 @@ pub mod test_helpers {
     }
 
     /// Run a signing round for the passed `msg`
-    #[allow(non_snake_case)]
     pub fn sign_schnorr<RNG: RngCore + CryptoRng, Signer: traits::Signer>(
         msg: &[u8],
         signers: &mut [Signer],


### PR DESCRIPTION
Previously we added support for testing that taproot key spends work with `WSTS`, to prevent accidental breakage via changes to the challenge hash or other taproot critical areas.  This PR adds tests for taproot script spends, which utilize the `WSTS` `sign_schnorr` functions rather than the `sign_taproot` functions.  

The scripts tested are the full `sBTC` accept and reject scripts, including the `sbtc_payload` and timelocks.

Fixes #173 