### PR TITLE
Use a single apt-get for latex deps

### DIFF
--- a/.doc/install-latex-ubuntu.sh
+++ b/.doc/install-latex-ubuntu.sh
@@ -1,6 +1,4 @@
 # Update apt
 sudo apt-get update
-# Install LaTeX
-sudo apt-get install texlive
-# Install LaTeX Extra
-sudo apt-get install texlive-latex-extra
+# Install LaTeX base and extra packages
+sudo apt-get install texlive texlive-latex-extra


### PR DESCRIPTION
The doc target takes a very long time, and part of this is due to running two `apt-get` calls to install latex and the extra packages.

Fixes #196 