### PR TITLE
Pass optional `sign_id` to `fn Coordinator::start_signing_round`

### DIFF
--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -235,8 +235,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                         // Set the current sign id to one before the current message to ensure
                         // that we start the next round at the correct id. (Do this rather
                         // than overwriting afterwards to ensure logging is accurate)
-                        self.current_dkg_id = dkg_begin.dkg_id.wrapping_sub(1);
-                        let packet = self.start_dkg_round(None)?;
+                        let packet = self.start_dkg_round(Some(dkg_begin.dkg_id))?;
                         return Ok((Some(packet), None));
                     } else if let Message::NonceRequest(nonce_request) = &packet.msg {
                         if self.current_sign_id == nonce_request.sign_id {

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -1499,7 +1499,7 @@ pub mod test {
                     empty_private_shares, empty_public_shares, equal_after_save_load,
                     feedback_messages, feedback_mutated_messages, gen_nonces, invalid_nonce,
                     new_coordinator, run_dkg_sign, setup, setup_with_timeouts, start_dkg_round,
-                    verify_packet_sigs,
+                    start_signing_round, verify_packet_sigs,
                 },
                 Config, Coordinator as CoordinatorTrait, State,
             },
@@ -1557,6 +1557,19 @@ pub mod test {
     fn start_dkg_round_v2() {
         start_dkg_round::<FireCoordinator<v2::Aggregator>>(None);
         start_dkg_round::<FireCoordinator<v2::Aggregator>>(Some(12345u64));
+    }
+
+    #[test]
+    #[cfg(feature = "with_v1")]
+    fn start_signing_round_v1() {
+        start_signing_round::<FireCoordinator<v1::Aggregator>>(None);
+        start_signing_round::<FireCoordinator<v1::Aggregator>>(Some(12345u64));
+    }
+
+    #[test]
+    fn start_signing_round_v2() {
+        start_signing_round::<FireCoordinator<v2::Aggregator>>(None);
+        start_signing_round::<FireCoordinator<v2::Aggregator>>(Some(12345u64));
     }
 
     #[test]

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -228,7 +228,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                 State::Idle => {
                     // Did we receive a coordinator message?
                     if let Message::DkgBegin(dkg_begin) = &packet.msg {
-                        if self.current_dkg_id >= dkg_begin.dkg_id {
+                        if self.current_dkg_id == dkg_begin.dkg_id {
                             // We have already processed this DKG round
                             return Ok((None, None));
                         }
@@ -239,18 +239,16 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                         let packet = self.start_dkg_round(None)?;
                         return Ok((Some(packet), None));
                     } else if let Message::NonceRequest(nonce_request) = &packet.msg {
-                        if self.current_sign_id >= nonce_request.sign_id {
+                        if self.current_sign_id == nonce_request.sign_id {
                             // We have already processed this sign round
                             return Ok((None, None));
                         }
-                        // Set the current sign id to one before the current message to ensure
-                        // that we start the next round at the correct id. (Do this rather
-                        // than overwriting afterwards to ensure logging is accurate)
-                        self.current_sign_id = nonce_request.sign_id.wrapping_sub(1);
                         self.current_sign_iter_id = nonce_request.sign_iter_id.wrapping_sub(1);
+                        // use sign_id from NonceRequest
                         let packet = self.start_signing_round(
                             nonce_request.message.as_slice(),
                             nonce_request.signature_type,
+                            Some(nonce_request.sign_id),
                         )?;
                         return Ok((Some(packet), None));
                     }
@@ -1449,13 +1447,18 @@ impl<Aggregator: AggregatorTrait> CoordinatorTrait for Coordinator<Aggregator> {
         &mut self,
         message: &[u8],
         signature_type: SignatureType,
+        sign_id: Option<u64>,
     ) -> Result<Packet, Error> {
         // We cannot sign if we haven't first set DKG (either manually or via DKG round).
         if self.aggregate_public_key.is_none() {
             return Err(Error::MissingAggregatePublicKey);
         }
         self.message = message.to_vec();
-        self.current_sign_id = self.current_sign_id.wrapping_add(1);
+        if let Some(id) = sign_id {
+            self.current_sign_id = id;
+        } else {
+            self.current_sign_id = self.current_sign_id.wrapping_add(1);
+        }
         info!("Starting signing round {}", self.current_sign_id);
         self.move_to(State::NonceRequest(signature_type))?;
         self.request_nonces(signature_type)
@@ -2685,7 +2688,7 @@ pub mod test {
         let message = coordinators
             .first_mut()
             .unwrap()
-            .start_signing_round(&msg, signature_type)
+            .start_signing_round(&msg, signature_type, None)
             .unwrap();
         assert_eq!(
             coordinators.first().unwrap().state,
@@ -2764,7 +2767,7 @@ pub mod test {
         let message = coordinators
             .first_mut()
             .unwrap()
-            .start_signing_round(&msg, signature_type)
+            .start_signing_round(&msg, signature_type, None)
             .unwrap();
         assert_eq!(
             coordinators.first().unwrap().state,
@@ -2848,7 +2851,7 @@ pub mod test {
         let message = coordinators
             .first_mut()
             .unwrap()
-            .start_signing_round(&msg, signature_type)
+            .start_signing_round(&msg, signature_type, None)
             .unwrap();
         assert_eq!(
             coordinators.first().unwrap().state,
@@ -2985,7 +2988,7 @@ pub mod test {
         let message = insufficient_coordinators
             .first_mut()
             .unwrap()
-            .start_signing_round(&msg, signature_type)
+            .start_signing_round(&msg, signature_type, None)
             .unwrap();
         assert_eq!(
             insufficient_coordinators.first().unwrap().state,
@@ -3035,7 +3038,7 @@ pub mod test {
         let message = insufficient_coordinators
             .first_mut()
             .unwrap()
-            .start_signing_round(&msg, signature_type)
+            .start_signing_round(&msg, signature_type, None)
             .unwrap();
         assert_eq!(
             insufficient_coordinators.first().unwrap().state,
@@ -3176,7 +3179,7 @@ pub mod test {
         let message = coordinators
             .first_mut()
             .unwrap()
-            .start_signing_round(&orig_msg, signature_type)
+            .start_signing_round(&orig_msg, signature_type, None)
             .unwrap();
 
         let mut alt_packet = message.clone();
@@ -3262,7 +3265,7 @@ pub mod test {
         let (mut coordinators, _) = setup::<FireCoordinator<Aggregator>, Signer>(3, 10);
         for coordinator in &mut coordinators {
             let id: u64 = 10;
-            let old_id = id.saturating_sub(1);
+            let old_id = id;
             coordinator.current_dkg_id = id;
             coordinator.current_sign_id = id;
             // Attempt to start an old DKG round

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -232,9 +232,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                             // We have already processed this DKG round
                             return Ok((None, None));
                         }
-                        // Set the current sign id to one before the current message to ensure
-                        // that we start the next round at the correct id. (Do this rather
-                        // than overwriting afterwards to ensure logging is accurate)
+                        // use dkg_id from DkgBegin
                         let packet = self.start_dkg_round(Some(dkg_begin.dkg_id))?;
                         return Ok((Some(packet), None));
                     } else if let Message::NonceRequest(nonce_request) = &packet.msg {

--- a/src/state_machine/coordinator/frost.rs
+++ b/src/state_machine/coordinator/frost.rs
@@ -1007,7 +1007,8 @@ pub mod test {
             test::{
                 bad_signature_share_request, check_signature_shares, coordinator_state_machine,
                 empty_private_shares, empty_public_shares, equal_after_save_load, invalid_nonce,
-                new_coordinator, run_dkg_sign, setup, start_dkg_round, verify_packet_sigs,
+                new_coordinator, run_dkg_sign, setup, start_dkg_round, start_signing_round,
+                verify_packet_sigs,
             },
             Config, Coordinator as CoordinatorTrait, State,
         },
@@ -1060,6 +1061,19 @@ pub mod test {
     fn start_dkg_round_v2() {
         start_dkg_round::<FrostCoordinator<v2::Aggregator>>(None);
         start_dkg_round::<FrostCoordinator<v2::Aggregator>>(Some(12345u64));
+    }
+
+    #[test]
+    #[cfg(feature = "with_v1")]
+    fn start_signing_round_v1() {
+        start_signing_round::<FrostCoordinator<v1::Aggregator>>(None);
+        start_signing_round::<FrostCoordinator<v1::Aggregator>>(Some(12345u64));
+    }
+
+    #[test]
+    fn start_signing_round_v2() {
+        start_signing_round::<FrostCoordinator<v2::Aggregator>>(None);
+        start_signing_round::<FrostCoordinator<v2::Aggregator>>(Some(12345u64));
     }
 
     #[test]

--- a/src/state_machine/coordinator/frost.rs
+++ b/src/state_machine/coordinator/frost.rs
@@ -80,8 +80,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                         // Set the current sign id to one before the current message to ensure
                         // that we start the next round at the correct id. (Do this rather
                         // then overwriting afterwards to ensure logging is accurate)
-                        self.current_dkg_id = dkg_begin.dkg_id.wrapping_sub(1);
-                        let packet = self.start_dkg_round(None)?;
+                        let packet = self.start_dkg_round(Some(dkg_begin.dkg_id))?;
                         return Ok((Some(packet), None));
                     } else if let Message::NonceRequest(nonce_request) = &packet.msg {
                         if self.current_sign_id == nonce_request.sign_id {

--- a/src/state_machine/coordinator/frost.rs
+++ b/src/state_machine/coordinator/frost.rs
@@ -77,9 +77,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                             // We have already processed this DKG round
                             return Ok((None, None));
                         }
-                        // Set the current sign id to one before the current message to ensure
-                        // that we start the next round at the correct id. (Do this rather
-                        // then overwriting afterwards to ensure logging is accurate)
+                        // use dkg_id from DkgBegin
                         let packet = self.start_dkg_round(Some(dkg_begin.dkg_id))?;
                         return Ok((Some(packet), None));
                     } else if let Message::NonceRequest(nonce_request) = &packet.msg {

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -508,6 +508,9 @@ pub mod test {
         let mut rng = create_rng();
         let config = Config::new(10, 40, 28, Scalar::random(&mut rng));
         let mut coordinator = Coordinator::new(config);
+
+        coordinator.set_aggregate_public_key(Some(Point::new()));
+
         let msg = "It was many and many a year ago, in a kingdom by the sea"
             .as_bytes()
             .to_vec();
@@ -519,9 +522,9 @@ pub mod test {
         if let Message::NonceRequest(nonce_request) = result.unwrap().msg {
             if let Some(id) = sign_id {
                 assert_eq!(
-                    nonce_request.dkg_id, id,
+                    nonce_request.sign_id, id,
                     "Bad dkg_id {} expected {id}",
-                    nonce_request.dkg_id
+                    nonce_request.sign_id
                 );
             } else {
                 assert_eq!(

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -348,6 +348,7 @@ pub trait Coordinator: Clone + Debug + PartialEq + StateMachine<State, Error> {
         &mut self,
         message: &[u8],
         signature_type: SignatureType,
+        sign_id: Option<u64>,
     ) -> Result<Packet, Error>;
 
     /// Reset internal state
@@ -501,6 +502,39 @@ pub mod test {
         };
 
         assert_eq!(coordinator.get_state(), State::DkgPublicGather);
+    }
+
+    pub fn start_signing_round<Coordinator: CoordinatorTrait>(sign_id: Option<u64>) {
+        let mut rng = create_rng();
+        let config = Config::new(10, 40, 28, Scalar::random(&mut rng));
+        let mut coordinator = Coordinator::new(config);
+        let msg = "It was many and many a year ago, in a kingdom by the sea"
+            .as_bytes()
+            .to_vec();
+        let signature_type = SignatureType::Schnorr;
+        let result = coordinator.start_signing_round(&msg, signature_type, sign_id);
+
+        assert!(result.is_ok());
+
+        if let Message::NonceRequest(nonce_request) = result.unwrap().msg {
+            if let Some(id) = sign_id {
+                assert_eq!(
+                    nonce_request.dkg_id, id,
+                    "Bad dkg_id {} expected {id}",
+                    nonce_request.dkg_id
+                );
+            } else {
+                assert_eq!(
+                    nonce_request.sign_id, 1,
+                    "Bad dkg_id {} expected 1",
+                    nonce_request.sign_id
+                );
+            }
+        } else {
+            panic!("coordinator.start_signing_round didn't return NonceRequest");
+        };
+
+        assert_eq!(coordinator.get_state(), State::NonceGather(signature_type));
     }
 
     pub fn setup<Coordinator: CoordinatorTrait, SignerType: SignerTrait>(
@@ -829,7 +863,7 @@ pub mod test {
         let message = coordinators
             .first_mut()
             .unwrap()
-            .start_signing_round(msg, signature_type)
+            .start_signing_round(msg, signature_type, None)
             .unwrap();
         assert_eq!(
             coordinators.first_mut().unwrap().get_state(),
@@ -1230,7 +1264,7 @@ pub mod test {
         let message = coordinators
             .first_mut()
             .unwrap()
-            .start_signing_round(&msg, signature_type)
+            .start_signing_round(&msg, signature_type, None)
             .unwrap();
         assert_eq!(
             coordinators.first_mut().unwrap().get_state(),
@@ -1350,7 +1384,7 @@ pub mod test {
         let message = coordinators
             .first_mut()
             .unwrap()
-            .start_signing_round(&msg, signature_type)
+            .start_signing_round(&msg, signature_type, None)
             .unwrap();
         assert_eq!(
             coordinators.first_mut().unwrap().get_state(),
@@ -1418,7 +1452,7 @@ pub mod test {
         let message = coordinators
             .first_mut()
             .unwrap()
-            .start_signing_round(&msg, signature_type)
+            .start_signing_round(&msg, signature_type, None)
             .unwrap();
         assert_eq!(
             coordinators.first_mut().unwrap().get_state(),
@@ -1517,7 +1551,7 @@ pub mod test {
         let message = coordinators
             .first_mut()
             .unwrap()
-            .start_signing_round(&msg, signature_type)
+            .start_signing_round(&msg, signature_type, None)
             .unwrap();
         assert_eq!(
             coordinators.first_mut().unwrap().get_state(),


### PR DESCRIPTION
Fixes #197 