### PR TITLE
Add state machine tests that sign/verify bitcoin taproot key and script spends

### DIFF
--- a/src/btc.rs
+++ b/src/btc.rs
@@ -240,7 +240,8 @@ mod test {
             script::{Builder, PushBytesBuf},
         },
         opcodes::all::*,
-        taproot::{LeafVersion, TaprootBuilder},
+        secp256k1::schnorr,
+        taproot::{self, LeafVersion, TaprootBuilder},
     };
     use rand_core::OsRng;
 
@@ -332,7 +333,7 @@ mod test {
         let nums_x_data =
             hex::decode("50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0")
                 .unwrap();
-        let nums_public_key = bitcoin::XOnlyPublicKey::from_slice(&nums_x_data).unwrap();
+        let nums_public_key = XOnlyPublicKey::from_slice(&nums_x_data).unwrap();
 
         let spend_info = TaprootBuilder::new()
             .add_leaf(1, accept_script.clone())
@@ -357,7 +358,7 @@ mod test {
             .expect("Failed to create message");
 
         let schnorr_sig = secp.sign_schnorr(&message, &depositor_keypair);
-        let taproot_sig = bitcoin::taproot::Signature {
+        let taproot_sig = taproot::Signature {
             signature: schnorr_sig,
             sighash_type: TapSighashType::All,
         };
@@ -390,9 +391,9 @@ mod test {
             Ok(proof) => proof,
         };
         let proof_bytes = proof.to_bytes();
-        let schnorr_sig = bitcoin::secp256k1::schnorr::Signature::from_slice(&proof_bytes)
+        let schnorr_sig = schnorr::Signature::from_slice(&proof_bytes)
             .expect("Failed to parse Signature from slice");
-        let taproot_sig = bitcoin::taproot::Signature {
+        let taproot_sig = taproot::Signature {
             signature: schnorr_sig,
             sighash_type: TapSighashType::All,
         };
@@ -448,7 +449,7 @@ mod test {
 
         // [1] Verify the correct signature, which should succeed.
         let schnorr_sig = secp.sign_schnorr(&message, &tweaked.to_keypair());
-        let taproot_sig = bitcoin::taproot::Signature {
+        let taproot_sig = taproot::Signature {
             signature: schnorr_sig,
             sighash_type: TapSighashType::All,
         };
@@ -458,7 +459,7 @@ mod test {
 
         // [2] Verify the correct signature, but with a different sighash type,
         // which should fail.
-        let taproot_sig = bitcoin::taproot::Signature {
+        let taproot_sig = taproot::Signature {
             signature: schnorr_sig,
             sighash_type: TapSighashType::None,
         };
@@ -470,7 +471,7 @@ mod test {
         // which should fail. In this case we've created the signature using
         // the untweaked keypair.
         let schnorr_sig = secp.sign_schnorr(&message, &keypair);
-        let taproot_sig = bitcoin::taproot::Signature {
+        let taproot_sig = taproot::Signature {
             signature: schnorr_sig,
             sighash_type: TapSighashType::All,
         };
@@ -483,7 +484,7 @@ mod test {
         let secret_key = secp256k1::SecretKey::new(&mut OsRng);
         let keypair = secp256k1::Keypair::from_secret_key(&secp, &secret_key);
         let schnorr_sig = secp.sign_schnorr(&message, &keypair);
-        let taproot_sig = bitcoin::taproot::Signature {
+        let taproot_sig = taproot::Signature {
             signature: schnorr_sig,
             sighash_type: TapSighashType::All,
         };
@@ -494,7 +495,7 @@ mod test {
         // [5] Same as [4], but using its tweaked key.
         let tweaked = keypair.tap_tweak(&secp, merkle_root);
         let schnorr_sig = secp.sign_schnorr(&message, &tweaked.to_keypair());
-        let taproot_sig = bitcoin::taproot::Signature {
+        let taproot_sig = taproot::Signature {
             signature: schnorr_sig,
             sighash_type: TapSighashType::All,
         };
@@ -573,9 +574,9 @@ mod test {
         assert!(proof_deser.verify(&tweaked_public_key.x(), message));
 
         // [1] Verify the correct signature, which should succeed.
-        let schnorr_sig = bitcoin::secp256k1::schnorr::Signature::from_slice(&proof_bytes)
+        let schnorr_sig = schnorr::Signature::from_slice(&proof_bytes)
             .expect("Failed to parse Signature from slice");
-        let taproot_sig = bitcoin::taproot::Signature {
+        let taproot_sig = taproot::Signature {
             signature: schnorr_sig,
             sighash_type: TapSighashType::All,
         };
@@ -585,7 +586,7 @@ mod test {
 
         // [2] Verify the correct signature, but with a different sighash type,
         // which should fail.
-        let taproot_sig = bitcoin::taproot::Signature {
+        let taproot_sig = taproot::Signature {
             signature: schnorr_sig,
             sighash_type: TapSighashType::None,
         };

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -1493,11 +1493,11 @@ pub mod test {
             coordinator::{
                 fire::Coordinator as FireCoordinator,
                 test::{
-                    bad_signature_share_request, check_signature_shares, coordinator_state_machine,
-                    empty_private_shares, empty_public_shares, equal_after_save_load,
-                    feedback_messages, feedback_mutated_messages, gen_nonces, invalid_nonce,
-                    new_coordinator, run_dkg_sign, setup, setup_with_timeouts, start_dkg_round,
-                    start_signing_round, verify_packet_sigs,
+                    bad_signature_share_request, btc_sign_verify, check_signature_shares,
+                    coordinator_state_machine, empty_private_shares, empty_public_shares,
+                    equal_after_save_load, feedback_messages, feedback_mutated_messages,
+                    gen_nonces, invalid_nonce, new_coordinator, run_dkg_sign, setup,
+                    setup_with_timeouts, start_dkg_round, start_signing_round, verify_packet_sigs,
                 },
                 Config, Coordinator as CoordinatorTrait, State,
             },
@@ -3584,5 +3584,16 @@ pub mod test {
     #[test]
     fn verify_packet_sigs_v2() {
         verify_packet_sigs::<FireCoordinator<v2::Aggregator>, v2::Signer>();
+    }
+
+    #[test]
+    #[cfg(feature = "with_v1")]
+    fn btc_sign_verify_v1() {
+        btc_sign_verify::<FireCoordinator<v1::Aggregator>, v1::Signer>(5, 2);
+    }
+
+    #[test]
+    fn btc_sign_verify_v2() {
+        btc_sign_verify::<FireCoordinator<v2::Aggregator>, v2::Signer>(5, 2);
     }
 }

--- a/src/state_machine/coordinator/frost.rs
+++ b/src/state_machine/coordinator/frost.rs
@@ -1003,10 +1003,10 @@ pub mod test {
         state_machine::coordinator::{
             frost::Coordinator as FrostCoordinator,
             test::{
-                bad_signature_share_request, check_signature_shares, coordinator_state_machine,
-                empty_private_shares, empty_public_shares, equal_after_save_load, invalid_nonce,
-                new_coordinator, run_dkg_sign, setup, start_dkg_round, start_signing_round,
-                verify_packet_sigs,
+                bad_signature_share_request, btc_sign_verify, check_signature_shares,
+                coordinator_state_machine, empty_private_shares, empty_public_shares,
+                equal_after_save_load, invalid_nonce, new_coordinator, run_dkg_sign, setup,
+                start_dkg_round, start_signing_round, verify_packet_sigs,
             },
             Config, Coordinator as CoordinatorTrait, State,
         },
@@ -1595,5 +1595,16 @@ pub mod test {
     #[test]
     fn verify_packet_sigs_v2() {
         verify_packet_sigs::<FrostCoordinator<v2::Aggregator>, v2::Signer>();
+    }
+
+    #[test]
+    #[cfg(feature = "with_v1")]
+    fn btc_sign_verify_v1() {
+        btc_sign_verify::<FrostCoordinator<v1::Aggregator>, v1::Signer>(5, 2);
+    }
+
+    #[test]
+    fn btc_sign_verify_v2() {
+        btc_sign_verify::<FrostCoordinator<v2::Aggregator>, v2::Signer>(5, 2);
     }
 }

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -1875,8 +1875,8 @@ pub mod test {
     use bitcoin::{
         blockdata::script::Builder,
         opcodes::all::*,
-        secp256k1::{Secp256k1, XOnlyPublicKey},
-        taproot::{LeafVersion, TaprootBuilder},
+        secp256k1::{schnorr, Secp256k1, XOnlyPublicKey},
+        taproot::{self, LeafVersion, TaprootBuilder},
         TapSighashType, Witness,
     };
 
@@ -1928,9 +1928,9 @@ pub mod test {
             panic!("taproot signature failed");
         };
 
-        let schnorr_sig = bitcoin::secp256k1::schnorr::Signature::from_slice(&proof.to_bytes())
+        let schnorr_sig = schnorr::Signature::from_slice(&proof.to_bytes())
             .expect("Failed to parse Signature from slice");
-        let taproot_sig = bitcoin::taproot::Signature {
+        let taproot_sig = taproot::Signature {
             signature: schnorr_sig,
             sighash_type: TapSighashType::All,
         };
@@ -1954,9 +1954,9 @@ pub mod test {
             panic!("schnorr signature failed");
         };
 
-        let schnorr_sig = bitcoin::secp256k1::schnorr::Signature::from_slice(&proof.to_bytes())
+        let schnorr_sig = schnorr::Signature::from_slice(&proof.to_bytes())
             .expect("Failed to parse Signature from slice");
-        let taproot_sig = bitcoin::taproot::Signature {
+        let taproot_sig = taproot::Signature {
             signature: schnorr_sig,
             sighash_type: TapSighashType::All,
         };

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -1922,7 +1922,7 @@ pub mod test {
         let OperationResult::SignTaproot(proof) = run_sign::<Coordinator, SignerType>(
             &mut coordinators,
             &mut signers,
-            &msg,
+            msg,
             SignatureType::Taproot(raw_merkle_root),
         ) else {
             panic!("taproot signature failed");
@@ -1948,7 +1948,7 @@ pub mod test {
         let OperationResult::SignSchnorr(proof) = run_sign::<Coordinator, SignerType>(
             &mut coordinators,
             &mut signers,
-            &msg,
+            msg,
             SignatureType::Schnorr,
         ) else {
             panic!("schnorr signature failed");

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -1869,4 +1869,111 @@ pub mod test {
             );
         }
     }
+
+    use crate::btc::UnsignedTx;
+
+    use bitcoin::{
+        blockdata::script::Builder,
+        opcodes::all::*,
+        secp256k1::{Secp256k1, XOnlyPublicKey},
+        taproot::{LeafVersion, TaprootBuilder},
+        TapSighashType, Witness,
+    };
+
+    /// Create a taproot transaction with key and script spends, then sign/verify each spend path
+    pub fn btc_sign_verify<Coordinator: CoordinatorTrait, SignerType: SignerTrait>(
+        num_signers: u32,
+        keys_per_signer: u32,
+    ) {
+        let (mut coordinators, mut signers) =
+            run_dkg::<Coordinator, SignerType>(num_signers, keys_per_signer);
+
+        let aggregate_public_key = coordinators[0]
+            .get_aggregate_public_key()
+            .expect("public key");
+        let aggregate_xonly_key = XOnlyPublicKey::from_slice(&aggregate_public_key.x().to_bytes())
+            .expect("failed to create XOnlyPublicKey");
+
+        let secp = Secp256k1::new();
+        let script = Builder::new()
+            .push_x_only_key(&aggregate_xonly_key)
+            .push_opcode(OP_CHECKSIG)
+            .into_script();
+        let spend_info = TaprootBuilder::new()
+            .add_leaf(0, script.clone())
+            .unwrap()
+            .finalize(&secp, aggregate_xonly_key)
+            .expect("failed to finalize taproot_spend_info");
+        let merkle_root = spend_info.merkle_root();
+        let internal_key = spend_info.internal_key();
+        let unsigned = UnsignedTx::new(internal_key);
+
+        // test the key spend
+        let sighash = unsigned
+            .compute_sighash(&secp, merkle_root)
+            .expect("failed to compute taproot sighash");
+        let msg: &[u8] = sighash.as_ref();
+
+        let raw_merkle_root = merkle_root.map(|root| {
+            let bytes: [u8; 32] = *root.to_raw_hash().as_ref();
+            bytes
+        });
+
+        let OperationResult::SignTaproot(proof) = run_sign::<Coordinator, SignerType>(
+            &mut coordinators,
+            &mut signers,
+            &msg,
+            SignatureType::Taproot(raw_merkle_root),
+        ) else {
+            panic!("taproot signature failed");
+        };
+
+        let schnorr_sig = bitcoin::secp256k1::schnorr::Signature::from_slice(&proof.to_bytes())
+            .expect("Failed to parse Signature from slice");
+        let taproot_sig = bitcoin::taproot::Signature {
+            signature: schnorr_sig,
+            sighash_type: TapSighashType::All,
+        };
+
+        unsigned
+            .verify_signature(&secp, &taproot_sig, merkle_root)
+            .expect("signature verification failed");
+
+        // test the script spend
+        let sighash = unsigned
+            .compute_script_sighash(&secp, merkle_root, &script)
+            .expect("failed to compute taproot sighash");
+        let msg: &[u8] = sighash.as_ref();
+
+        let OperationResult::SignSchnorr(proof) = run_sign::<Coordinator, SignerType>(
+            &mut coordinators,
+            &mut signers,
+            &msg,
+            SignatureType::Schnorr,
+        ) else {
+            panic!("schnorr signature failed");
+        };
+
+        let schnorr_sig = bitcoin::secp256k1::schnorr::Signature::from_slice(&proof.to_bytes())
+            .expect("Failed to parse Signature from slice");
+        let taproot_sig = bitcoin::taproot::Signature {
+            signature: schnorr_sig,
+            sighash_type: TapSighashType::All,
+        };
+
+        let control_block = spend_info
+            .control_block(&(script.clone(), LeafVersion::TapScript))
+            .expect("insert the accept script into the control block");
+
+        println!("ControlBlock {control_block:?}");
+
+        let mut witness = Witness::new();
+        witness.push(taproot_sig.to_vec());
+        witness.push(script.as_bytes());
+        witness.push(control_block.serialize());
+
+        unsigned
+            .verify_witness(&secp, witness, merkle_root)
+            .expect("signature verification failed");
+    }
 }


### PR DESCRIPTION
In PR #192 , we added test code for taproot key and script spends.  Here we add a similar test that uses the state machines.

Fixes #24
