### PR TITLE
Add testing feature to enable exporting test code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsts"
-version = "14.0.2"
+version = "15.0.1"
 edition = "2021"
 authors = ["Joey Yandle <xoloki@gmail.com>"]
 license = "Apache-2.0"
@@ -14,6 +14,7 @@ categories = ["cryptography"]
 default = ["with_p256k1_bindgen"]
 with_p256k1_bindgen = ["p256k1/with_bindgen"]
 with_v1 = []
+testing = []
 
 [dependencies]
 aes-gcm = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsts"
-version = "15.0.1"
+version = "15.0.0"
 edition = "2021"
 authors = ["Joey Yandle <xoloki@gmail.com>"]
 license = "Apache-2.0"

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -1370,7 +1370,7 @@ impl<Aggregator: AggregatorTrait> CoordinatorTrait for Coordinator<Aggregator> {
         self.config.clone()
     }
 
-    #[cfg(test)]
+    #[cfg(any(test, feature = "testing"))]
     fn get_config_mut(&mut self) -> &mut Config {
         &mut self.config
     }

--- a/src/state_machine/coordinator/frost.rs
+++ b/src/state_machine/coordinator/frost.rs
@@ -890,7 +890,7 @@ impl<Aggregator: AggregatorTrait> CoordinatorTrait for Coordinator<Aggregator> {
         self.config.clone()
     }
 
-    #[cfg(test)]
+    #[cfg(any(test, feature = "testing"))]
     fn get_config_mut(&mut self) -> &mut Config {
         &mut self.config
     }

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -312,7 +312,7 @@ pub trait Coordinator: Clone + Debug + PartialEq + StateMachine<State, Error> {
     fn get_config(&self) -> Config;
 
     /// Retrieve a mutable reference to the config
-    #[cfg(test)]
+    #[cfg(any(test, feature = "testing"))]
     fn get_config_mut(&mut self) -> &mut Config;
 
     /// Set the coordinator public key
@@ -367,7 +367,7 @@ pub mod frost;
 pub mod fire;
 
 #[allow(missing_docs)]
-#[cfg(test)]
+#[cfg(any(test, feature = "testing"))]
 pub mod test {
     use hashbrown::{HashMap, HashSet};
     use rand_core::OsRng;

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -28,7 +28,7 @@ use crate::{
     util::{decrypt, encrypt, make_shared_secret},
 };
 
-#[cfg(test)]
+#[cfg(any(test, feature = "testing"))]
 use crate::net::Signable;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -432,7 +432,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
     }
 
     /// Process the slice of packets
-    #[cfg(test)]
+    #[cfg(any(test, feature = "testing"))]
     pub fn process_inbound_messages<R: RngCore + CryptoRng>(
         &mut self,
         packets: &[Packet],


### PR DESCRIPTION
This PR increments the major semver, since previous PRs made breaking API changes without doing so.  It also adds a `testing` feature which allows us to export the coordinator test module in a way that dependent applications (like `sBTC`) can use.  This is the same pattern used by `stacks-core` and other projects, as a result of the never-fixed https://github.com/rust-lang/cargo/issues/8379