### PR TITLE
Add ExpansionType to control how binding values are computed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsts"
-version = "15.0.0"
+version = "16.0.0"
 edition = "2021"
 authors = ["Joey Yandle <xoloki@gmail.com>"]
 license = "Apache-2.0"

--- a/benches/v1_bench.rs
+++ b/benches/v1_bench.rs
@@ -1,4 +1,5 @@
 use wsts::common::test_helpers::gen_signer_ids;
+use wsts::compute::ExpansionType;
 use wsts::traits::Aggregator;
 use wsts::v1;
 use wsts::v1::test_helpers::{dkg, sign};
@@ -75,7 +76,7 @@ pub fn bench_aggregator_sign(c: &mut Criterion) {
 
     let s = format!("v1 group sign N={N} T={T} K={K}");
     c.bench_function(&s, |b| {
-        b.iter(|| aggregator.sign(msg, &nonces, &sig_shares, &[]))
+        b.iter(|| aggregator.sign(msg, &nonces, &sig_shares, &[], ExpansionType::Default))
     });
 }
 

--- a/benches/v2_bench.rs
+++ b/benches/v2_bench.rs
@@ -1,4 +1,5 @@
 use wsts::common::test_helpers::gen_signer_ids;
+use wsts::compute::ExpansionType;
 use wsts::traits::Aggregator;
 use wsts::v2;
 use wsts::v2::test_helpers::{dkg, sign};
@@ -102,7 +103,7 @@ pub fn bench_aggregator_sign(c: &mut Criterion) {
 
     let s = format!("v2 group sign N={N} T={T} K={K}");
     c.bench_function(&s, |b| {
-        b.iter(|| aggregator.sign(msg, &nonces, &sig_shares, &key_ids))
+        b.iter(|| aggregator.sign(msg, &nonces, &sig_shares, &key_ids, ExpansionType::Default))
     });
 }
 

--- a/src/btc.rs
+++ b/src/btc.rs
@@ -228,7 +228,7 @@ impl UnsignedTx {
 mod test {
     use super::*;
     use crate::{
-        compute,
+        compute::{self, ExpansionType},
         taproot::{test_helpers, SchnorrProof},
         traits::{Aggregator, Signer},
         v2,
@@ -385,7 +385,13 @@ mod test {
 
         let (nonces, sig_shares) =
             test_helpers::sign_schnorr(message, &mut signing_set, &mut OsRng);
-        let proof = match sig_agg.sign_schnorr(message, &nonces, &sig_shares, &key_ids) {
+        let proof = match sig_agg.sign_schnorr(
+            message,
+            &nonces,
+            &sig_shares,
+            &key_ids,
+            ExpansionType::Default,
+        ) {
             Err(e) => panic!("Aggregator sign failed: {e:?}"),
             Ok(proof) => proof,
         };
@@ -560,11 +566,17 @@ mod test {
         let message: &[u8] = sighash.as_ref();
         let (nonces, sig_shares) =
             test_helpers::sign(message, &mut signing_set, &mut OsRng, raw_merkle_root);
-        let proof =
-            match sig_agg.sign_taproot(message, &nonces, &sig_shares, &key_ids, raw_merkle_root) {
-                Err(e) => panic!("Aggregator sign failed: {e:?}"),
-                Ok(proof) => proof,
-            };
+        let proof = match sig_agg.sign_taproot(
+            message,
+            &nonces,
+            &sig_shares,
+            &key_ids,
+            raw_merkle_root,
+            ExpansionType::Default,
+        ) {
+            Err(e) => panic!("Aggregator sign failed: {e:?}"),
+            Ok(proof) => proof,
+        };
         // now ser/de the proof
         let proof_bytes = proof.to_bytes();
         let proof_deser = SchnorrProof::from(proof_bytes);

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -22,7 +22,7 @@ pub enum ExpansionType {
     Xmd,
 }
 
-/// Compute a binding value from the party ID, public nonces, and signed message using XMD-based expansion.
+/// Compute a binding value from the party ID, public nonces, and signed message using the passed expansion type.
 pub fn binding(
     id: &Scalar,
     public_nonces: &[PublicNonce],
@@ -34,7 +34,7 @@ pub fn binding(
         ExpansionType::Xmd => binding_xmd(id, public_nonces, msg),
     }
 }
-/// Compute a binding value from the party ID, public nonces, and signed message using XMD-based expansion.
+/// Compute a binding value from the party ID, public nonces, and signed message using the passed expansion type.
 pub fn binding_compressed(
     id: &Scalar,
     public_nonces: &[(Compressed, Compressed)],

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -12,18 +12,52 @@ use crate::{
     util::{expand_to_scalar, hash_to_scalar},
 };
 
-#[allow(non_snake_case)]
+/// What type of message expansion to use
+#[derive(Default, Clone, Copy, Debug, PartialEq)]
+pub enum ExpansionType {
+    /// Expand hash directly from bytes
+    #[default]
+    Default,
+    /// Expand hash using XMD
+    Xmd,
+}
+
 /// Compute a binding value from the party ID, public nonces, and signed message using XMD-based expansion.
-pub fn binding_xmd(id: &Scalar, B: &[PublicNonce], msg: &[u8]) -> Scalar {
+pub fn binding(
+    id: &Scalar,
+    public_nonces: &[PublicNonce],
+    msg: &[u8],
+    expansion_type: ExpansionType,
+) -> Scalar {
+    match expansion_type {
+        ExpansionType::Default => binding_default(id, public_nonces, msg),
+        ExpansionType::Xmd => binding_xmd(id, public_nonces, msg),
+    }
+}
+/// Compute a binding value from the party ID, public nonces, and signed message using XMD-based expansion.
+pub fn binding_compressed(
+    id: &Scalar,
+    public_nonces: &[(Compressed, Compressed)],
+    msg: &[u8],
+    expansion_type: ExpansionType,
+) -> Scalar {
+    match expansion_type {
+        ExpansionType::Default => binding_compressed_default(id, public_nonces, msg),
+        ExpansionType::Xmd => binding_compressed_xmd(id, public_nonces, msg),
+    }
+}
+
+/// Compute a binding value from the party ID, public nonces, and signed message using XMD-based expansion.
+pub fn binding_xmd(id: &Scalar, public_nonces: &[PublicNonce], msg: &[u8]) -> Scalar {
     let prefix = b"WSTS/binding";
 
     // Serialize all input into a buffer
     let mut buf = Vec::new();
     buf.extend_from_slice(&id.to_bytes());
 
-    for b in B {
-        buf.extend_from_slice(b.D.compress().as_bytes());
-        buf.extend_from_slice(b.E.compress().as_bytes());
+    for public_nonce in public_nonces {
+        buf.extend_from_slice(public_nonce.D.compress().as_bytes());
+        buf.extend_from_slice(public_nonce.E.compress().as_bytes());
     }
 
     buf.extend_from_slice(msg);
@@ -32,18 +66,21 @@ pub fn binding_xmd(id: &Scalar, B: &[PublicNonce], msg: &[u8]) -> Scalar {
         .expect("FATAL: DST is less than 256 bytes so operation should not fail")
 }
 
-#[allow(non_snake_case)]
 /// Compute a binding value from the party ID, public nonces, and signed message using XMD-based expansion.
-pub fn binding_compressed_xmd(id: &Scalar, B: &[(Compressed, Compressed)], msg: &[u8]) -> Scalar {
+pub fn binding_compressed_xmd(
+    id: &Scalar,
+    public_nonces: &[(Compressed, Compressed)],
+    msg: &[u8],
+) -> Scalar {
     let prefix = b"WSTS/binding";
 
     // Serialize all input into a buffer
     let mut buf = Vec::new();
     buf.extend_from_slice(&id.to_bytes());
 
-    for (D, E) in B {
-        buf.extend_from_slice(D.as_bytes());
-        buf.extend_from_slice(E.as_bytes());
+    for (binding, hiding) in public_nonces {
+        buf.extend_from_slice(binding.as_bytes());
+        buf.extend_from_slice(hiding.as_bytes());
     }
 
     buf.extend_from_slice(msg);
@@ -52,34 +89,36 @@ pub fn binding_compressed_xmd(id: &Scalar, B: &[(Compressed, Compressed)], msg: 
         .expect("FATAL: DST is less than 256 bytes so operation should not fail")
 }
 
-#[allow(non_snake_case)]
-/// Compute a binding value from the party ID, public nonces, and signed message using XMD-based expansion.
-pub fn binding(id: &Scalar, B: &[PublicNonce], msg: &[u8]) -> Scalar {
+/// Compute a binding value from the party ID, public nonces, and signed message using default expansion.
+pub fn binding_default(id: &Scalar, public_nonces: &[PublicNonce], msg: &[u8]) -> Scalar {
     let mut hasher = Sha256::new();
     let prefix = "WSTS/binding";
 
     hasher.update(prefix.as_bytes());
     hasher.update(id.to_bytes());
-    for b in B {
-        hasher.update(b.D.compress().as_bytes());
-        hasher.update(b.E.compress().as_bytes());
+    for public_nonce in public_nonces {
+        hasher.update(public_nonce.D.compress().as_bytes());
+        hasher.update(public_nonce.E.compress().as_bytes());
     }
     hasher.update(msg);
 
     hash_to_scalar(&mut hasher)
 }
 
-#[allow(non_snake_case)]
-/// Compute a binding value from the party ID, public nonces, and signed message using XMD-based expansion.
-pub fn binding_compressed(id: &Scalar, B: &[(Compressed, Compressed)], msg: &[u8]) -> Scalar {
+/// Compute a binding value from the party ID, public nonces, and signed message using default expansion.
+pub fn binding_compressed_default(
+    id: &Scalar,
+    public_nonces: &[(Compressed, Compressed)],
+    msg: &[u8],
+) -> Scalar {
     let mut hasher = Sha256::new();
     let prefix = "WSTS/binding";
 
     hasher.update(prefix.as_bytes());
     hasher.update(&id.to_bytes());
-    for (D, E) in B {
-        hasher.update(D.as_bytes());
-        hasher.update(E.as_bytes());
+    for (binding, hiding) in public_nonces {
+        hasher.update(binding.as_bytes());
+        hasher.update(hiding.as_bytes());
     }
     hasher.update(msg);
 
@@ -116,10 +155,15 @@ pub fn lambda(i: u32, key_ids: &[u32]) -> Scalar {
 // Is this the best way to return these values?
 #[allow(non_snake_case)]
 /// Compute the intermediate values used in both the parties and the aggregator
-pub fn intermediate(msg: &[u8], party_ids: &[u32], nonces: &[PublicNonce]) -> (Vec<Point>, Point) {
+pub fn intermediate(
+    msg: &[u8],
+    party_ids: &[u32],
+    nonces: &[PublicNonce],
+    expansion_type: ExpansionType,
+) -> (Vec<Point>, Point) {
     let rhos: Vec<Scalar> = party_ids
         .iter()
-        .map(|&i| binding(&id(i), nonces, msg))
+        .map(|&i| binding(&id(i), nonces, msg, expansion_type))
         .collect();
     let R_vec: Vec<Point> = zip(nonces, rhos)
         .map(|(nonce, rho)| nonce.D + rho * nonce.E)
@@ -135,6 +179,7 @@ pub fn aggregate_nonce(
     msg: &[u8],
     party_ids: &[u32],
     nonces: &[PublicNonce],
+    expansion_type: ExpansionType,
 ) -> Result<Point, PointError> {
     let compressed_nonces: Vec<(Compressed, Compressed)> = nonces
         .iter()
@@ -145,7 +190,7 @@ pub fn aggregate_nonce(
         .flat_map(|&i| {
             [
                 Scalar::from(1),
-                binding_compressed(&id(i), &compressed_nonces, msg),
+                binding_compressed(&id(i), &compressed_nonces, msg, expansion_type),
             ]
         })
         .collect();

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -57,6 +57,7 @@ pub fn binding_compressed(
 }
 
 /// Compute a binding value from the party ID, public nonces, and signed message using XMD-based expansion.
+/// XMD RFC: https://datatracker.ietf.org/doc/rfc9380/
 pub fn binding_xmd(id: &Scalar, public_nonces: &[PublicNonce], msg: &[u8]) -> Scalar {
     let prefix = b"WSTS/binding";
 
@@ -76,6 +77,7 @@ pub fn binding_xmd(id: &Scalar, public_nonces: &[PublicNonce], msg: &[u8]) -> Sc
 }
 
 /// Compute a binding value from the party ID, public nonces, and signed message using XMD-based expansion.
+/// XMD RFC: https://datatracker.ietf.org/doc/rfc9380/
 pub fn binding_compressed_xmd(
     id: &Scalar,
     public_nonces: &[(Compressed, Compressed)],

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -12,7 +12,11 @@ use crate::{
     util::{expand_to_scalar, hash_to_scalar},
 };
 
-/// What type of message expansion to use
+/// What type of message expansion to use, i.e. how do we take a stream of bytes and turn it into
+/// a digest.  The original FROST paper simply says to use "a hash function whose outputs are in
+/// $Z_q^*$".  The IETF FROST RFC, however, uses XMD message expansion, which is used when hashing
+/// to curves and their scalars/field elements in order to get a more even distribution than a raw
+/// hash would provide.
 #[derive(Default, Clone, Copy, Debug, PartialEq)]
 pub enum ExpansionType {
     /// Expand hash directly from bytes
@@ -34,6 +38,7 @@ pub fn binding(
         ExpansionType::Xmd => binding_xmd(id, public_nonces, msg),
     }
 }
+
 /// Compute a binding value from the party ID, public nonces, and signed message using the passed expansion type.
 pub fn binding_compressed(
     id: &Scalar,

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -115,7 +115,7 @@ pub fn binding_compressed_default(
     let prefix = "WSTS/binding";
 
     hasher.update(prefix.as_bytes());
-    hasher.update(&id.to_bytes());
+    hasher.update(id.to_bytes());
     for (binding, hiding) in public_nonces {
         hasher.update(binding.as_bytes());
         hasher.update(hiding.as_bytes());

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -18,8 +18,9 @@ use crate::{
 /// to curves and their scalars/field elements in order to get a more even distribution than a raw
 /// hash would provide.
 ///
-/// IETF FROST RFC: https://datatracker.ietf.org/doc/rfc9591/
-/// Hash to curve RFC: https://datatracker.ietf.org/doc/rfc9380/
+/// FROST paper: https://eprint.iacr.org/2020/852.pdf
+/// FROST RFC: https://datatracker.ietf.org/doc/rfc9591/
+/// XMD RFC: https://datatracker.ietf.org/doc/rfc9380/
 #[derive(Default, Clone, Copy, Debug, PartialEq)]
 pub enum ExpansionType {
     /// Expand hash directly from bytes

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -17,6 +17,9 @@ use crate::{
 /// $Z_q^*$".  The IETF FROST RFC, however, uses XMD message expansion, which is used when hashing
 /// to curves and their scalars/field elements in order to get a more even distribution than a raw
 /// hash would provide.
+///
+/// IETF FROST RFC: https://datatracker.ietf.org/doc/rfc9591/
+/// Hash to curve RFC: https://datatracker.ietf.org/doc/rfc9380/
 #[derive(Default, Clone, Copy, Debug, PartialEq)]
 pub enum ExpansionType {
     /// Expand hash directly from bytes

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,10 @@ use std::{env, time};
 
 #[cfg(feature = "with_v1")]
 use wsts::v1;
-use wsts::{common::test_helpers::gen_signer_ids, traits::Aggregator, util::create_rng, v2};
+use wsts::{
+    common::test_helpers::gen_signer_ids, compute::ExpansionType, traits::Aggregator,
+    util::create_rng, v2,
+};
 
 #[allow(non_snake_case)]
 fn main() {
@@ -88,7 +91,7 @@ fn main() {
 
         let group_sign_start = time::Instant::now();
         let _sig = aggregator
-            .sign(msg, &nonces, &sig_shares, &key_ids)
+            .sign(msg, &nonces, &sig_shares, &key_ids, ExpansionType::Default)
             .expect("v2 group sign failed");
         let group_sign_time = group_sign_start.elapsed();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ fn main() {
 
         let group_sign_start = time::Instant::now();
         let _sig = aggregator
-            .sign(msg, &nonces, &sig_shares, &[])
+            .sign(msg, &nonces, &sig_shares, &[], ExpansionType::Default)
             .expect("v1 group sign failed");
         let group_sign_time = group_sign_start.elapsed();
 

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -1511,6 +1511,7 @@ pub mod test {
     #[cfg(feature = "with_v1")]
     use crate::v1;
     use crate::{
+        compute::ExpansionType,
         curve::{point::Point, scalar::Scalar},
         net::{
             DkgBegin, DkgFailure, DkgPrivateShares, DkgPublicShares, Message, NonceRequest, Packet,
@@ -1614,7 +1615,8 @@ pub mod test {
     fn dkg_public_share<Aggregator: AggregatorTrait, Signer: SignerTrait>() {
         let ctx = 0u64.to_be_bytes();
         let mut rng = create_rng();
-        let (coordinators, _) = setup::<FireCoordinator<Aggregator>, Signer>(2, 1);
+        let (coordinators, _) =
+            setup::<FireCoordinator<Aggregator>, Signer>(2, 1, ExpansionType::Default);
         let mut coordinator: FireCoordinator<Aggregator> = coordinators[0].clone();
 
         coordinator.state = State::DkgPublicGather;
@@ -1682,7 +1684,8 @@ pub mod test {
 
     /// test basic insertion and detection of duplicates for DkgPrivateShares
     fn dkg_private_share<Aggregator: AggregatorTrait, Signer: SignerTrait>() {
-        let (coordinators, _) = setup::<FireCoordinator<Aggregator>, Signer>(2, 1);
+        let (coordinators, _) =
+            setup::<FireCoordinator<Aggregator>, Signer>(2, 1, ExpansionType::Default);
         let mut coordinator: FireCoordinator<Aggregator> = coordinators[0].clone();
 
         coordinator.state = State::DkgPrivateGather;
@@ -1737,7 +1740,8 @@ pub mod test {
     /// test basic insertion and detection of duplicates for NonceResponse
     fn nonce_response<Aggregator: AggregatorTrait, Signer: SignerTrait>() {
         let mut rng = create_rng();
-        let (coordinators, _) = setup::<FireCoordinator<Aggregator>, Signer>(2, 1);
+        let (coordinators, _) =
+            setup::<FireCoordinator<Aggregator>, Signer>(2, 1, ExpansionType::Default);
         let mut coordinator: FireCoordinator<Aggregator> = coordinators[0].clone();
         let signature_type = SignatureType::Frost;
         let message = vec![0u8];
@@ -1808,7 +1812,8 @@ pub mod test {
     #[allow(dead_code)]
     fn sig_share<Aggregator: AggregatorTrait, Signer: SignerTrait>() {
         let mut rng = create_rng();
-        let (coordinators, _) = setup::<FireCoordinator<Aggregator>, Signer>(2, 1);
+        let (coordinators, _) =
+            setup::<FireCoordinator<Aggregator>, Signer>(2, 1, ExpansionType::Default);
         let mut coordinator = coordinators[0].clone();
         let signature_type = SignatureType::Frost;
 
@@ -1942,14 +1947,37 @@ pub mod test {
     #[cfg(feature = "with_v1")]
     fn run_dkg_sign_v1() {
         for _ in 0..4 {
-            run_dkg_sign::<FireCoordinator<v1::Aggregator>, v1::Signer>(5, 2);
+            run_dkg_sign::<FireCoordinator<v1::Aggregator>, v1::Signer>(
+                5,
+                2,
+                ExpansionType::Default,
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "with_v1")]
+    fn run_dkg_sign_v1_xmd() {
+        for _ in 0..4 {
+            run_dkg_sign::<FireCoordinator<v1::Aggregator>, v1::Signer>(5, 2, ExpansionType::Xmd);
         }
     }
 
     #[test]
     fn run_dkg_sign_v2() {
         for _ in 0..4 {
-            run_dkg_sign::<FireCoordinator<v2::Aggregator>, v2::Signer>(5, 2);
+            run_dkg_sign::<FireCoordinator<v2::Aggregator>, v2::Signer>(
+                5,
+                2,
+                ExpansionType::Default,
+            );
+        }
+    }
+
+    #[test]
+    fn run_dkg_sign_v2_xmd() {
+        for _ in 0..4 {
+            run_dkg_sign::<FireCoordinator<v2::Aggregator>, v2::Signer>(5, 2, ExpansionType::Xmd);
         }
     }
 
@@ -2025,8 +2053,11 @@ pub mod test {
         num_signers: u32,
         keys_per_signer: u32,
     ) -> (Vec<FireCoordinator<Aggregator>>, Vec<Signer<SignerType>>) {
-        let (mut coordinators, mut signers) =
-            setup::<FireCoordinator<Aggregator>, SignerType>(num_signers, keys_per_signer);
+        let (mut coordinators, mut signers) = setup::<FireCoordinator<Aggregator>, SignerType>(
+            num_signers,
+            keys_per_signer,
+            ExpansionType::Default,
+        );
 
         // We have started a dkg round
         let message = coordinators
@@ -2103,6 +2134,7 @@ pub mod test {
                 Some(timeout),
                 Some(timeout),
                 Some(timeout),
+                ExpansionType::Default,
             );
 
         // Start a DKG round where we will not allow all signers to recv DkgBegin, so they will not respond with DkgPublicShares
@@ -2188,6 +2220,7 @@ pub mod test {
             Some(timeout),
             Some(timeout),
             Some(timeout),
+            ExpansionType::Default,
         );
 
         // Start a DKG round where we will not allow all signers to recv DkgBegin, so they will not respond with DkgPublicShares
@@ -2347,6 +2380,7 @@ pub mod test {
             Some(timeout),
             Some(timeout),
             Some(timeout),
+            ExpansionType::Default,
         );
 
         // Start a DKG round where we will not allow all signers to recv DkgBegin, so they will not respond with DkgPublicShares
@@ -2497,8 +2531,11 @@ pub mod test {
         num_signers: u32,
         keys_per_signer: u32,
     ) -> (Vec<FireCoordinator<Aggregator>>, Vec<Signer<SignerType>>) {
-        let (mut coordinators, mut signers) =
-            setup::<FireCoordinator<Aggregator>, SignerType>(num_signers, keys_per_signer);
+        let (mut coordinators, mut signers) = setup::<FireCoordinator<Aggregator>, SignerType>(
+            num_signers,
+            keys_per_signer,
+            ExpansionType::Default,
+        );
 
         // We have started a dkg round
         let message = coordinators
@@ -2613,8 +2650,11 @@ pub mod test {
         num_signers: u32,
         keys_per_signer: u32,
     ) -> (Vec<FireCoordinator<Aggregator>>, Vec<Signer<SignerType>>) {
-        let (mut coordinators, mut signers) =
-            setup::<FireCoordinator<Aggregator>, SignerType>(num_signers, keys_per_signer);
+        let (mut coordinators, mut signers) = setup::<FireCoordinator<Aggregator>, SignerType>(
+            num_signers,
+            keys_per_signer,
+            ExpansionType::Default,
+        );
 
         // We have started a dkg round
         let message = coordinators
@@ -2939,15 +2979,28 @@ pub mod test {
     #[test]
     #[cfg(feature = "with_v1")]
     fn insufficient_signers_sign_v1() {
-        insufficient_signers_sign::<v1::Aggregator, v1::Signer>();
+        insufficient_signers_sign::<v1::Aggregator, v1::Signer>(ExpansionType::Default);
+    }
+
+    #[test]
+    #[cfg(feature = "with_v1")]
+    fn insufficient_signers_sign_v1_xmd() {
+        insufficient_signers_sign::<v1::Aggregator, v1::Signer>(ExpansionType::Xmd);
     }
 
     #[test]
     fn insufficient_signers_sign_v2() {
-        insufficient_signers_sign::<v2::Aggregator, v2::Signer>();
+        insufficient_signers_sign::<v2::Aggregator, v2::Signer>(ExpansionType::Default);
     }
 
-    fn insufficient_signers_sign<Aggregator: AggregatorTrait, Signer: SignerTrait>() {
+    #[test]
+    fn insufficient_signers_sign_v2_xmd() {
+        insufficient_signers_sign::<v2::Aggregator, v2::Signer>(ExpansionType::Xmd);
+    }
+
+    fn insufficient_signers_sign<Aggregator: AggregatorTrait, Signer: SignerTrait>(
+        expansion_type: ExpansionType,
+    ) {
         let num_signers = 5;
         let keys_per_signer = 2;
         let (mut coordinators, mut signers) =
@@ -2959,6 +3012,7 @@ pub mod test {
                 None,
                 Some(Duration::from_millis(128)),
                 Some(Duration::from_millis(128)),
+                expansion_type,
             );
         let config = coordinators.first().unwrap().get_config();
 
@@ -3305,7 +3359,8 @@ pub mod test {
     }
 
     fn old_round_ids_are_ignored<Aggregator: AggregatorTrait, Signer: SignerTrait>() {
-        let (mut coordinators, _) = setup::<FireCoordinator<Aggregator>, Signer>(3, 10);
+        let (mut coordinators, _) =
+            setup::<FireCoordinator<Aggregator>, Signer>(3, 10, ExpansionType::Default);
         for coordinator in &mut coordinators {
             let id: u64 = 10;
             let old_id = id;
@@ -3420,7 +3475,7 @@ pub mod test {
     fn one_signer_bad_threshold<Aggregator: AggregatorTrait, SignerType: SignerTrait>() {
         let mut rng = create_rng();
         let (mut coordinators, mut signers) =
-            setup::<FireCoordinator<Aggregator>, SignerType>(10, 1);
+            setup::<FireCoordinator<Aggregator>, SignerType>(10, 1, ExpansionType::Default);
 
         // persist one signer, change the threshold, reset polys
         let mut state = signers[0].save();
@@ -3543,7 +3598,7 @@ pub mod test {
 
     fn bad_dkg_threshold<Aggregator: AggregatorTrait, SignerType: SignerTrait>() {
         let (mut coordinators, mut signers) =
-            setup::<FireCoordinator<Aggregator>, SignerType>(10, 1);
+            setup::<FireCoordinator<Aggregator>, SignerType>(10, 1, ExpansionType::Default);
 
         // We have started a dkg round
         let message = coordinators

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -1151,19 +1151,28 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                     &shares,
                     &key_ids,
                     merkle_root,
+                    self.config.expansion_type,
                 )?;
                 debug!("SchnorrProof ({}, {})", schnorr_proof.r, schnorr_proof.s);
                 self.schnorr_proof = Some(schnorr_proof);
             } else if let SignatureType::Schnorr = signature_type {
-                let schnorr_proof =
-                    self.aggregator
-                        .sign_schnorr(&self.message, &nonces, &shares, &key_ids)?;
+                let schnorr_proof = self.aggregator.sign_schnorr(
+                    &self.message,
+                    &nonces,
+                    &shares,
+                    &key_ids,
+                    self.config.expansion_type,
+                )?;
                 debug!("SchnorrProof ({}, {})", schnorr_proof.r, schnorr_proof.s);
                 self.schnorr_proof = Some(schnorr_proof);
             } else {
-                let signature = self
-                    .aggregator
-                    .sign(&self.message, &nonces, &shares, &key_ids)?;
+                let signature = self.aggregator.sign(
+                    &self.message,
+                    &nonces,
+                    &shares,
+                    &key_ids,
+                    self.config.expansion_type,
+                )?;
                 debug!("Signature ({}, {})", signature.R, signature.z);
                 self.signature = Some(signature);
             }
@@ -1192,7 +1201,12 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
             .cloned()
             .flat_map(|pn| pn.nonces)
             .collect::<Vec<PublicNonce>>();
-        let (_, R) = compute::intermediate(&self.message, &party_ids, &nonces);
+        let (_, R) = compute::intermediate(
+            &self.message,
+            &party_ids,
+            &nonces,
+            self.config.expansion_type,
+        );
 
         R
     }

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -2138,7 +2138,7 @@ pub mod test {
         let (outbound_messages, operation_results) = feedback_messages(
             &mut minimum_coordinators,
             &mut minimum_signers,
-            &[message.clone()],
+            std::slice::from_ref(&message),
         );
 
         assert!(outbound_messages.is_empty());
@@ -2219,7 +2219,7 @@ pub mod test {
         let (outbound_messages, operation_results) = feedback_messages(
             &mut minimum_coordinators,
             &mut minimum_signers,
-            &[message.clone()],
+            std::slice::from_ref(&message),
         );
 
         assert!(outbound_messages.is_empty());
@@ -2382,7 +2382,7 @@ pub mod test {
         let (outbound_messages, operation_results) = feedback_messages(
             &mut insufficient_coordinators,
             &mut insufficient_signers,
-            &[message.clone()],
+            std::slice::from_ref(&message),
         );
 
         // Failed to get an aggregate public key

--- a/src/state_machine/coordinator/frost.rs
+++ b/src/state_machine/coordinator/frost.rs
@@ -698,6 +698,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                     shares,
                     &key_ids,
                     merkle_root,
+                    self.config.expansion_type,
                 )?;
                 debug!(
                     r = %schnorr_proof.r,
@@ -706,9 +707,13 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                 );
                 self.schnorr_proof = Some(schnorr_proof);
             } else if let SignatureType::Schnorr = signature_type {
-                let schnorr_proof =
-                    self.aggregator
-                        .sign_schnorr(&self.message, &nonces, shares, &key_ids)?;
+                let schnorr_proof = self.aggregator.sign_schnorr(
+                    &self.message,
+                    &nonces,
+                    shares,
+                    &key_ids,
+                    self.config.expansion_type,
+                )?;
                 debug!(
                     r = %schnorr_proof.r,
                     s = %schnorr_proof.s,
@@ -716,9 +721,13 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                 );
                 self.schnorr_proof = Some(schnorr_proof);
             } else {
-                let signature = self
-                    .aggregator
-                    .sign(&self.message, &nonces, shares, &key_ids)?;
+                let signature = self.aggregator.sign(
+                    &self.message,
+                    &nonces,
+                    shares,
+                    &key_ids,
+                    self.config.expansion_type,
+                )?;
                 debug!(
                     R = %signature.R,
                     z = %signature.z,
@@ -745,7 +754,12 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
             .values()
             .flat_map(|pn| pn.nonces.clone())
             .collect::<Vec<PublicNonce>>();
-        let (_, R) = compute::intermediate(&self.message, &party_ids, &nonces);
+        let (_, R) = compute::intermediate(
+            &self.message,
+            &party_ids,
+            &nonces,
+            self.config.expansion_type,
+        );
 
         R
     }

--- a/src/state_machine/coordinator/frost.rs
+++ b/src/state_machine/coordinator/frost.rs
@@ -1019,6 +1019,7 @@ pub mod test {
     #[cfg(feature = "with_v1")]
     use crate::v1;
     use crate::{
+        compute::ExpansionType,
         curve::scalar::Scalar,
         net::{DkgBegin, Message, NonceRequest, Packet, SignatureShareResponse, SignatureType},
         schnorr::ID,
@@ -1162,7 +1163,8 @@ pub mod test {
     fn dkg_public_share<Aggregator: AggregatorTrait, Signer: SignerTrait>() {
         let ctx = 0u64.to_be_bytes();
         let mut rng = create_rng();
-        let (coordinators, _) = setup::<FrostCoordinator<Aggregator>, Signer>(2, 1);
+        let (coordinators, _) =
+            setup::<FrostCoordinator<Aggregator>, Signer>(2, 1, ExpansionType::Default);
         let mut coordinator: FrostCoordinator<Aggregator> = coordinators[0].clone();
 
         coordinator.start_dkg_round(None).unwrap(); // = State::DkgPublicGather;
@@ -1230,7 +1232,8 @@ pub mod test {
 
     /// test basic insertion and detection of duplicates for DkgPrivateShares
     fn dkg_private_share<Aggregator: AggregatorTrait, Signer: SignerTrait>() {
-        let (coordinators, _) = setup::<FrostCoordinator<Aggregator>, Signer>(2, 1);
+        let (coordinators, _) =
+            setup::<FrostCoordinator<Aggregator>, Signer>(2, 1, ExpansionType::Default);
         let mut coordinator: FrostCoordinator<Aggregator> = coordinators[0].clone();
 
         coordinator.state = State::DkgPrivateGather;
@@ -1285,7 +1288,8 @@ pub mod test {
     /// test basic insertion and detection of duplicates for NonceResponse
     fn nonce_response<Aggregator: AggregatorTrait, Signer: SignerTrait>() {
         let mut rng = create_rng();
-        let (coordinators, _) = setup::<FrostCoordinator<Aggregator>, Signer>(2, 1);
+        let (coordinators, _) =
+            setup::<FrostCoordinator<Aggregator>, Signer>(2, 1, ExpansionType::Default);
         let mut coordinator: FrostCoordinator<Aggregator> = coordinators[0].clone();
         let signature_type = SignatureType::Frost;
         let message = vec![0u8];
@@ -1351,7 +1355,8 @@ pub mod test {
     #[allow(dead_code)]
     fn sig_share<Aggregator: AggregatorTrait, Signer: SignerTrait>() {
         let mut rng = create_rng();
-        let (coordinators, _) = setup::<FrostCoordinator<Aggregator>, Signer>(2, 1);
+        let (coordinators, _) =
+            setup::<FrostCoordinator<Aggregator>, Signer>(2, 1, ExpansionType::Default);
         let mut coordinator = coordinators[0].clone();
         let signature_type = SignatureType::Frost;
 
@@ -1415,12 +1420,23 @@ pub mod test {
     #[test]
     #[cfg(feature = "with_v1")]
     fn run_dkg_sign_v1() {
-        run_dkg_sign::<FrostCoordinator<v1::Aggregator>, v1::Signer>(5, 2);
+        run_dkg_sign::<FrostCoordinator<v1::Aggregator>, v1::Signer>(5, 2, ExpansionType::Default);
+    }
+
+    #[test]
+    #[cfg(feature = "with_v1")]
+    fn run_dkg_sign_v1_xmd() {
+        run_dkg_sign::<FrostCoordinator<v1::Aggregator>, v1::Signer>(5, 2, ExpansionType::Xmd);
     }
 
     #[test]
     fn run_dkg_sign_v2() {
-        run_dkg_sign::<FrostCoordinator<v2::Aggregator>, v2::Signer>(5, 2);
+        run_dkg_sign::<FrostCoordinator<v2::Aggregator>, v2::Signer>(5, 2, ExpansionType::Default);
+    }
+
+    #[test]
+    fn run_dkg_sign_v2_xmd() {
+        run_dkg_sign::<FrostCoordinator<v2::Aggregator>, v2::Signer>(5, 2, ExpansionType::Xmd);
     }
 
     #[test]
@@ -1504,7 +1520,7 @@ pub mod test {
 
     #[test]
     fn process_inbound_messages_v2() {
-        run_dkg_sign::<FrostCoordinator<v2::Aggregator>, v2::Signer>(5, 2);
+        run_dkg_sign::<FrostCoordinator<v2::Aggregator>, v2::Signer>(5, 2, ExpansionType::Default);
     }
 
     #[test]

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -567,6 +567,7 @@ pub mod test {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn setup_with_timeouts<Coordinator: CoordinatorTrait, SignerType: SignerTrait>(
         num_signers: u32,
         keys_per_signer: u32,

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -1,5 +1,6 @@
 use crate::{
     common::{PolyCommitment, Signature, SignatureShare},
+    compute::ExpansionType,
     curve::{
         ecdsa,
         point::{Error as PointError, Point},
@@ -155,6 +156,8 @@ pub struct Config {
     pub public_keys: PublicKeys,
     /// whether to verify the signature on Packets
     pub verify_packet_sigs: bool,
+    /// How to expand the binding value when hashing
+    pub expansion_type: ExpansionType,
 }
 
 impl fmt::Debug for Config {
@@ -196,6 +199,7 @@ impl Config {
             sign_timeout: None,
             public_keys: Default::default(),
             verify_packet_sigs: true,
+            expansion_type: ExpansionType::Default,
         }
     }
 
@@ -227,6 +231,7 @@ impl Config {
             sign_timeout,
             public_keys,
             verify_packet_sigs: true,
+            expansion_type: ExpansionType::Default,
         }
     }
 }
@@ -376,7 +381,7 @@ pub mod test {
 
     use crate::{
         common::SignatureShare,
-        compute,
+        compute::{self, ExpansionType},
         curve::{ecdsa, point::Point, point::G, scalar::Scalar},
         errors::AggregatorError,
         net::{DkgFailure, Message, Packet, SignatureShareResponse, SignatureType},
@@ -627,6 +632,7 @@ pub mod test {
                     *private_key,
                     public_keys.clone(),
                     &mut rng,
+                    ExpansionType::Default,
                 )
                 .unwrap();
                 signer.verify_packet_sigs = false;

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -553,6 +553,7 @@ pub mod test {
     pub fn setup<Coordinator: CoordinatorTrait, SignerType: SignerTrait>(
         num_signers: u32,
         keys_per_signer: u32,
+        expansion_type: ExpansionType,
     ) -> (Vec<Coordinator>, Vec<Signer<SignerType>>) {
         setup_with_timeouts::<Coordinator, SignerType>(
             num_signers,
@@ -562,6 +563,7 @@ pub mod test {
             None,
             None,
             None,
+            expansion_type,
         )
     }
 
@@ -573,6 +575,7 @@ pub mod test {
         dkg_end_timeout: Option<Duration>,
         nonce_timeout: Option<Duration>,
         sign_timeout: Option<Duration>,
+        expansion_type: ExpansionType,
     ) -> (Vec<Coordinator>, Vec<Signer<SignerType>>) {
         INIT.call_once(|| {
             tracing_subscriber::registry()
@@ -632,7 +635,7 @@ pub mod test {
                     *private_key,
                     public_keys.clone(),
                     &mut rng,
-                    ExpansionType::Default,
+                    expansion_type,
                 )
                 .unwrap();
                 signer.verify_packet_sigs = false;
@@ -656,6 +659,7 @@ pub mod test {
                     public_keys.clone(),
                 );
                 config.verify_packet_sigs = false;
+                config.expansion_type = expansion_type;
                 Coordinator::new(config)
             })
             .collect::<Vec<Coordinator>>();
@@ -744,9 +748,10 @@ pub mod test {
     pub fn run_dkg<Coordinator: CoordinatorTrait, SignerType: SignerTrait>(
         num_signers: u32,
         keys_per_signer: u32,
+        expansion_type: ExpansionType,
     ) -> (Vec<Coordinator>, Vec<Signer<SignerType>>) {
         let (mut coordinators, mut signers) =
-            setup::<Coordinator, SignerType>(num_signers, keys_per_signer);
+            setup::<Coordinator, SignerType>(num_signers, keys_per_signer, expansion_type);
 
         // We have started a dkg round
         let message = coordinators
@@ -972,9 +977,10 @@ pub mod test {
     pub fn run_dkg_sign<Coordinator: CoordinatorTrait, SignerType: SignerTrait>(
         num_signers: u32,
         keys_per_signer: u32,
+        expansion_type: ExpansionType,
     ) {
         let (mut coordinators, mut signers) =
-            run_dkg::<Coordinator, SignerType>(num_signers, keys_per_signer);
+            run_dkg::<Coordinator, SignerType>(num_signers, keys_per_signer, expansion_type);
 
         let msg = "It was many and many a year ago, in a kingdom by the sea"
             .as_bytes()
@@ -1017,7 +1023,8 @@ pub mod test {
         Coordinator: CoordinatorTrait,
         SignerType: SignerTrait,
     >() {
-        let (coordinators, mut signers) = setup::<Coordinator, SignerType>(5, 1);
+        let (coordinators, mut signers) =
+            setup::<Coordinator, SignerType>(5, 1, ExpansionType::Default);
         let mut coordinators = vec![coordinators[0].clone()];
 
         for coordinator in coordinators.iter_mut() {
@@ -1140,7 +1147,8 @@ pub mod test {
         Coordinator: CoordinatorTrait,
         SignerType: SignerTrait,
     >() {
-        let (coordinators, mut signers) = setup::<Coordinator, SignerType>(5, 1);
+        let (coordinators, mut signers) =
+            setup::<Coordinator, SignerType>(5, 1, ExpansionType::Default);
         let mut coordinators = vec![coordinators[0].clone()];
 
         for coordinator in coordinators.iter_mut() {
@@ -1181,7 +1189,8 @@ pub mod test {
         Coordinator: CoordinatorTrait,
         SignerType: SignerTrait,
     >() {
-        let (coordinators, mut signers) = setup::<Coordinator, SignerType>(5, 1);
+        let (coordinators, mut signers) =
+            setup::<Coordinator, SignerType>(5, 1, ExpansionType::Default);
         let mut coordinators = vec![coordinators[0].clone()];
 
         for coordinator in coordinators.iter_mut() {
@@ -1223,7 +1232,8 @@ pub mod test {
         Coordinator: CoordinatorTrait,
         SignerType: SignerTrait,
     >() {
-        let (coordinators, mut signers) = setup::<Coordinator, SignerType>(5, 1);
+        let (coordinators, mut signers) =
+            setup::<Coordinator, SignerType>(5, 1, ExpansionType::Default);
         let mut coordinators = vec![coordinators[0].clone()];
 
         for coordinator in coordinators.iter_mut() {
@@ -1268,8 +1278,11 @@ pub mod test {
         signature_type: SignatureType,
         bad_parties: Vec<u32>,
     ) {
-        let (mut coordinators, mut signers) =
-            run_dkg::<Coordinator, SignerType>(num_signers, keys_per_signer);
+        let (mut coordinators, mut signers) = run_dkg::<Coordinator, SignerType>(
+            num_signers,
+            keys_per_signer,
+            ExpansionType::Default,
+        );
 
         let msg = "It was many and many a year ago, in a kingdom by the sea"
             .as_bytes()
@@ -1359,7 +1372,7 @@ pub mod test {
         keys_per_signer: u32,
     ) {
         let (coordinators, signers) =
-            setup::<Coordinator, SignerType>(num_signers, keys_per_signer);
+            setup::<Coordinator, SignerType>(num_signers, keys_per_signer, ExpansionType::Default);
 
         let loaded_coordinators = coordinators
             .iter()
@@ -1385,8 +1398,11 @@ pub mod test {
     ) {
         let mut rng = OsRng;
 
-        let (mut coordinators, mut signers) =
-            run_dkg::<Coordinator, SignerType>(num_signers, keys_per_signer);
+        let (mut coordinators, mut signers) = run_dkg::<Coordinator, SignerType>(
+            num_signers,
+            keys_per_signer,
+            ExpansionType::Default,
+        );
 
         let msg = "It was many and many a year ago, in a kingdom by the sea"
             .as_bytes()
@@ -1454,8 +1470,11 @@ pub mod test {
         num_signers: u32,
         keys_per_signer: u32,
     ) {
-        let (mut coordinators, mut signers) =
-            run_dkg::<Coordinator, SignerType>(num_signers, keys_per_signer);
+        let (mut coordinators, mut signers) = run_dkg::<Coordinator, SignerType>(
+            num_signers,
+            keys_per_signer,
+            ExpansionType::Default,
+        );
 
         let msg = "It was many and many a year ago, in a kingdom by the sea"
             .as_bytes()
@@ -1553,8 +1572,11 @@ pub mod test {
         num_signers: u32,
         keys_per_signer: u32,
     ) {
-        let (mut coordinators, mut signers) =
-            run_dkg::<Coordinator, SignerType>(num_signers, keys_per_signer);
+        let (mut coordinators, mut signers) = run_dkg::<Coordinator, SignerType>(
+            num_signers,
+            keys_per_signer,
+            ExpansionType::Default,
+        );
 
         let msg = "It was many and many a year ago, in a kingdom by the sea"
             .as_bytes()
@@ -1681,7 +1703,7 @@ pub mod test {
         keys_per_signer: u32,
     ) {
         let (mut coordinators, mut signers) =
-            setup::<Coordinator, SignerType>(num_signers, keys_per_signer);
+            setup::<Coordinator, SignerType>(num_signers, keys_per_signer, ExpansionType::Default);
 
         // We have started a dkg round
         let message = coordinators
@@ -1785,7 +1807,7 @@ pub mod test {
         keys_per_signer: u32,
     ) {
         let (mut coordinators, mut signers) =
-            setup::<Coordinator, SignerType>(num_signers, keys_per_signer);
+            setup::<Coordinator, SignerType>(num_signers, keys_per_signer, ExpansionType::Default);
 
         // We have started a dkg round
         let message = coordinators

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -1519,9 +1519,19 @@ pub mod test {
         key_ids2.insert(2);
         public_keys.signer_key_ids.insert(1, key_ids2);
 
-        let mut signer =
-            Signer::<v1::Signer>::new(1, 1, 2, 2, 0, vec![1], private_key, public_keys, &mut rng)
-                .unwrap();
+        let mut signer = Signer::<v1::Signer>::new(
+            1,
+            1,
+            2,
+            2,
+            0,
+            vec![1],
+            private_key,
+            public_keys,
+            &mut rng,
+            ExpansionType::Default,
+        )
+        .unwrap();
 
         let public_share = DkgPublicShares {
             dkg_id: 0,

--- a/src/taproot.rs
+++ b/src/taproot.rs
@@ -377,7 +377,14 @@ mod test {
         );
         println!("sign_verify: tweaked_key.x  {}", &tweaked_public_key.x());
         let (nonces, sig_shares) = test_helpers::sign(msg, &mut S, &mut rng, merkle_root);
-        let proof = match sig_agg.sign_taproot(msg, &nonces, &sig_shares, &[], merkle_root) {
+        let proof = match sig_agg.sign_taproot(
+            msg,
+            &nonces,
+            &sig_shares,
+            &[],
+            merkle_root,
+            ExpansionType::Default,
+        ) {
             Err(e) => panic!("Aggregator sign failed: {e:?}"),
             Ok(proof) => proof,
         };

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -7,6 +7,7 @@ use std::fmt;
 
 use crate::{
     common::{MerkleRoot, Nonce, PolyCommitment, PublicNonce, Signature, SignatureShare},
+    compute::ExpansionType,
     curve::{point::Point, scalar::Scalar},
     errors::{AggregatorError, DkgError},
     taproot::SchnorrProof,
@@ -112,6 +113,7 @@ pub trait Signer: Clone + Debug + PartialEq {
         signer_ids: &[u32],
         key_ids: &[u32],
         nonces: &[PublicNonce],
+        expansion_type: ExpansionType,
     ) -> (Vec<Point>, Point);
 
     /// Validate that signer_id owns party_id
@@ -128,6 +130,7 @@ pub trait Signer: Clone + Debug + PartialEq {
         signer_ids: &[u32],
         key_ids: &[u32],
         nonces: &[PublicNonce],
+        expansion_type: ExpansionType,
     ) -> Vec<SignatureShare>;
 
     /// Sign `msg` using all this signer's keys
@@ -137,6 +140,7 @@ pub trait Signer: Clone + Debug + PartialEq {
         signer_ids: &[u32],
         key_ids: &[u32],
         nonces: &[PublicNonce],
+        expansion_type: ExpansionType,
     ) -> Vec<SignatureShare>;
 
     /// Sign `msg` using all this signer's keys and a tweaked public key
@@ -147,6 +151,7 @@ pub trait Signer: Clone + Debug + PartialEq {
         key_ids: &[u32],
         nonces: &[PublicNonce],
         merkle_root: Option<MerkleRoot>,
+        expansion_type: ExpansionType,
     ) -> Vec<SignatureShare>;
 }
 
@@ -165,6 +170,7 @@ pub trait Aggregator: Clone + Debug + PartialEq {
         nonces: &[PublicNonce],
         sig_shares: &[SignatureShare],
         key_ids: &[u32],
+        expansion_type: ExpansionType,
     ) -> Result<Signature, AggregatorError>;
 
     /// Check and aggregate the signature shares into a BIP-340 `SchnorrProof`.
@@ -175,6 +181,7 @@ pub trait Aggregator: Clone + Debug + PartialEq {
         nonces: &[PublicNonce],
         sig_shares: &[SignatureShare],
         key_ids: &[u32],
+        expansion_type: ExpansionType,
     ) -> Result<SchnorrProof, AggregatorError>;
 
     /// Check and aggregate the signature shares into a BIP-340 `SchnorrProof` with BIP-341 key tweaks
@@ -187,6 +194,7 @@ pub trait Aggregator: Clone + Debug + PartialEq {
         sig_shares: &[SignatureShare],
         key_ids: &[u32],
         merkle_root: Option<MerkleRoot>,
+        expansion_type: ExpansionType,
     ) -> Result<SchnorrProof, AggregatorError>;
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -17,6 +17,14 @@ pub const AES_GCM_NONCE_SIZE: usize = 12;
 /// Expands a message using the XMD (eXpandable Message Digest) method with SHA-256, and reduces
 /// the result modulo the curve order to produce a `Scalar`.
 ///
+/// The goal of XMD is to produce a uniform random byte string using a cryptographic hash function.
+/// Rather than simply using the hash function to produce output, it prefixes the output with one
+/// byte formed from hashing various parameters, a second byte from hashing the first byte with
+/// some of the same parameters, then each successive byte hashes an XOR of the two previous with
+/// similar parameters to the second.
+///
+/// RFC: https://datatracker.ietf.org/doc/rfc9380/ (section 5.3.1)
+///
 /// # Arguments
 /// - `msg`: The input message to be expanded.
 /// - `dst`: A domain separation tag (DST). Must be 255 bytes or fewer, as required by the

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -8,7 +8,7 @@ use tracing::warn;
 
 use crate::{
     common::{check_public_shares, Nonce, PolyCommitment, PublicNonce, Signature, SignatureShare},
-    compute,
+    compute::{self, ExpansionType},
     curve::{
         point::{Point, G},
         scalar::Scalar,

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -221,7 +221,7 @@ impl Party {
         nonces: &[PublicNonce],
         expansion_type: ExpansionType,
     ) -> SignatureShare {
-        let (_, aggregate_nonce) = compute::intermediate(msg, signers, nonces);
+        let (_, aggregate_nonce) = compute::intermediate(msg, signers, nonces, expansion_type);
         let mut z = &self.nonce.d + &self.nonce.e * compute::binding(&self.id(), nonces, msg);
         z += compute::challenge(&self.group_key, &aggregate_nonce, msg)
             * &self.private_key


### PR DESCRIPTION
This PR adds the `ExpansionType` enum to the `compute` module, and uses it to control how the binding values are generated.  Config fields are added to the state machines, then passed down to the lower level traits and compute functions.