### PR TITLE
Remove unchecked access and only accept packets from signers in the wait list

### DIFF
--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -1162,7 +1162,14 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
             let shares = message_nonce
                 .public_nonces
                 .iter()
-                .flat_map(|(i, _)| self.signature_shares[i].clone())
+                .flat_map(|(i, _)| {
+                    if let Some(shares) = self.signature_shares.get(i) {
+                        shares.clone()
+                    } else {
+                        warn!(sign_id = %self.current_sign_id, signer_id = %i, "Have nonces but no signature shares from signer");
+                        vec![]
+                    }
+                })
                 .collect::<Vec<SignatureShare>>();
 
             debug!(

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -499,16 +499,25 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                 return Ok(());
             }
 
-            self.dkg_wait_signer_ids
+            let waiting = self
+                .dkg_wait_signer_ids
                 .remove(&dkg_public_shares.signer_id);
 
-            self.dkg_public_shares
-                .insert(dkg_public_shares.signer_id, dkg_public_shares.clone());
-            debug!(
-                dkg_id = %dkg_public_shares.dkg_id,
-                signer_id = %dkg_public_shares.signer_id,
-                "DkgPublicShares received"
-            );
+            if waiting {
+                self.dkg_public_shares
+                    .insert(dkg_public_shares.signer_id, dkg_public_shares.clone());
+                debug!(
+                    dkg_id = %dkg_public_shares.dkg_id,
+                    signer_id = %dkg_public_shares.signer_id,
+                    "DkgPublicShares received"
+                );
+            } else {
+                warn!(
+                    dkg_id = %dkg_public_shares.dkg_id,
+                    signer_id = %dkg_public_shares.signer_id,
+                    "Got DkgPublicShares from signer who we weren't waiting on"
+                );
+            }
         }
 
         if self.dkg_wait_signer_ids.is_empty() {
@@ -546,16 +555,25 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                 return Ok(());
             }
 
-            self.dkg_wait_signer_ids
+            let waiting = self
+                .dkg_wait_signer_ids
                 .remove(&dkg_private_shares.signer_id);
 
-            self.dkg_private_shares
-                .insert(dkg_private_shares.signer_id, dkg_private_shares.clone());
-            info!(
-                dkg_id = %dkg_private_shares.dkg_id,
-                signer_id = %dkg_private_shares.signer_id,
-                "DkgPrivateShares received"
-            );
+            if waiting {
+                self.dkg_private_shares
+                    .insert(dkg_private_shares.signer_id, dkg_private_shares.clone());
+                info!(
+                    dkg_id = %dkg_private_shares.dkg_id,
+                    signer_id = %dkg_private_shares.signer_id,
+                    "DkgPrivateShares received"
+                );
+            } else {
+                warn!(
+                    dkg_id = %dkg_private_shares.dkg_id,
+                    signer_id = %dkg_private_shares.signer_id,
+                    "Got DkgPrivateShares from signer who we weren't waiting on"
+                );
+            }
         }
 
         if self.dkg_wait_signer_ids.is_empty() {
@@ -794,8 +812,15 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
     fn dkg_end_gathered(&mut self) -> Result<(), Error> {
         // Cache the polynomials used in DKG for the aggregator
         for signer_id in self.dkg_private_shares.keys() {
-            for (party_id, comm) in &self.dkg_public_shares[signer_id].comms {
-                self.party_polynomials.insert(*party_id, comm.clone());
+            if let Some(dkg_public_shares) = &self.dkg_public_shares.get(signer_id) {
+                for (party_id, comm) in &dkg_public_shares.comms {
+                    self.party_polynomials.insert(*party_id, comm.clone());
+                }
+            } else {
+                warn!(
+                    signer_id = %signer_id,
+                    "No DkgPublicShares from signer who sent DkgPrivateShares"
+                );
             }
         }
 
@@ -803,7 +828,13 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
         let key = self
             .dkg_end_messages
             .keys()
-            .flat_map(|signer_id| self.dkg_public_shares[signer_id].comms.clone())
+            .flat_map(|signer_id| {
+                if let Some(dkg_public_shares) = self.dkg_public_shares.get(signer_id) {
+                    dkg_public_shares.comms.clone()
+                } else {
+                    vec![]
+                }
+            })
             .fold(Point::default(), |s, (_, comm)| s + comm.poly[0]);
 
         info!("Aggregate public key: {key}");
@@ -1620,10 +1651,17 @@ pub mod test {
             msg: Message::DkgPublicShares(public_shares.clone()),
             sig: Default::default(),
         };
+
+        // check that shares are ignored if not waiting on that signer
+        coordinator.dkg_wait_signer_ids.insert(1);
+        coordinator.gather_public_shares(&packet).unwrap();
+        assert_eq!(0, coordinator.dkg_public_shares.len());
+
+        coordinator.dkg_wait_signer_ids.insert(0);
         coordinator.gather_public_shares(&packet).unwrap();
         assert_eq!(1, coordinator.dkg_public_shares.len());
 
-        // check that a duplicate public share is ignored
+        // check that a duplicate public share is ignored even if the state machine is tricked into waiting on it
         let dup_public_shares = DkgPublicShares {
             dkg_id: 0,
             signer_id: 0,
@@ -1641,6 +1679,7 @@ pub mod test {
             sig: Default::default(),
         };
 
+        coordinator.dkg_wait_signer_ids.insert(0);
         coordinator.gather_public_shares(&dup_packet).unwrap();
         assert_eq!(1, coordinator.dkg_public_shares.len());
         assert_eq!(
@@ -1682,10 +1721,17 @@ pub mod test {
             msg: Message::DkgPrivateShares(private_share.clone()),
             sig: Default::default(),
         };
+
+        // check that shares are ignored if not waiting on that signer
+        coordinator.dkg_wait_signer_ids.insert(1);
+        coordinator.gather_private_shares(&packet).unwrap();
+        assert_eq!(0, coordinator.dkg_private_shares.len());
+
+        coordinator.dkg_wait_signer_ids.insert(0);
         coordinator.gather_private_shares(&packet).unwrap();
         assert_eq!(1, coordinator.dkg_private_shares.len());
 
-        // check that a duplicate private share is ignored
+        // check that a duplicate private share is ignored even if the state machine is tricked into waiting for it
         let dup_private_share = DkgPrivateShares {
             dkg_id: 0,
             signer_id: 0,
@@ -1695,6 +1741,7 @@ pub mod test {
             msg: Message::DkgPrivateShares(dup_private_share.clone()),
             sig: Default::default(),
         };
+        coordinator.dkg_wait_signer_ids.insert(0);
         coordinator.gather_private_shares(&packet).unwrap();
         assert_eq!(1, coordinator.dkg_private_shares.len());
         assert_eq!(

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -10,6 +10,7 @@ use crate::{
         point::{Point, G},
         scalar::Scalar,
     },
+    errors::AggregatorError,
     net::{
         DkgBegin, DkgEnd, DkgEndBegin, DkgFailure, DkgPrivateBegin, DkgPrivateShares,
         DkgPublicShares, DkgStatus, Message, NonceRequest, NonceResponse, Packet, Signable,
@@ -619,7 +620,11 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
         // this will be used to report signers who were malicious in this DKG round, as opposed to
         // self.malicious_dkg_signer_ids which contains all DKG signers who were ever malicious
         let mut malicious_signers = HashSet::new();
-        let threshold: usize = self.config.threshold.try_into().unwrap();
+        let threshold: usize = self
+            .config
+            .threshold
+            .try_into()
+            .map_err(Error::TryFromInt)?;
         if self.dkg_wait_signer_ids.is_empty() {
             // if there are any errors, mark signers malicious and retry
             for (signer_id, dkg_end) in &self.dkg_end_messages {
@@ -817,11 +822,31 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                     self.party_polynomials.insert(*party_id, comm.clone());
                 }
             } else {
-                warn!(
+                error!(
                     signer_id = %signer_id,
                     "No DkgPublicShares from signer who sent DkgPrivateShares"
                 );
+                return Err(Error::NoPublicSharesForSigner(*signer_id));
             }
+        }
+
+        // Final sanity check on PolyComitments
+        let threshold: usize = self
+            .config
+            .threshold
+            .try_into()
+            .map_err(Error::TryFromInt)?;
+        let mut bad_ids = Vec::new();
+        for (party_id, comm) in &self.party_polynomials {
+            if !check_public_shares(comm, threshold, &self.current_dkg_id.to_be_bytes()) {
+                bad_ids.push(compute::id(*party_id));
+            }
+        }
+
+        if !bad_ids.is_empty() {
+            return Err(Error::Aggregator(AggregatorError::BadPolyCommitments(
+                bad_ids,
+            )));
         }
 
         // Calculate the aggregate public key
@@ -832,10 +857,21 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                 if let Some(dkg_public_shares) = self.dkg_public_shares.get(signer_id) {
                     dkg_public_shares.comms.clone()
                 } else {
+                    warn!(
+                        signer_id = %signer_id,
+                        "No DkgPublicShares from signer who sent DkgEnd"
+                    );
                     vec![]
                 }
             })
-            .fold(Point::default(), |s, (_, comm)| s + comm.poly[0]);
+            .fold(Point::default(), |s, (_, comm)| {
+                if let Some(p) = comm.poly.get(0) {
+                    s + p
+                } else {
+                    warn!("Empty polynomial when computing aggregate public key");
+                    s
+                }
+            });
 
         info!("Aggregate public key: {key}");
         self.aggregate_public_key = Some(key);

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -114,6 +114,9 @@ pub enum Error {
     #[error("A packet had an invalid signature")]
     /// A packet had an invalid signature
     InvalidPacketSignature,
+    #[error("No public shares for signer {0}")]
+    /// No public shares for the signer who sent private shares
+    NoPublicSharesForSigner(u32),
     #[error("A curve point error {0}")]
     /// A curve point error
     Point(#[from] PointError),


### PR DESCRIPTION
This PR addresses a reported DOS during DKG that was a result of accepting packets from signers who had been excluded from the active participant list, which combined with an unchecked access pattern could lead to a panic during DKG completion.

To fix this, we only accept packets from signers in the wait list, and also remove all unchecked access in this and other code paths in the FIRE coordinator.  

Fixes #206 