### PR TITLE
Initialize nonces

### DIFF
--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -313,7 +313,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
 
         public_keys.validate(total_signers, total_keys)?;
 
-        let signer = SignerType::new(
+        let mut signer = SignerType::new(
             signer_id,
             &key_ids,
             total_signers,
@@ -321,6 +321,10 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             threshold,
             rng,
         );
+
+        // immediately generate nonces with good entropy to avoid protocol attacks
+        signer.gen_nonces(&network_private_key, rng);
+
         debug!("new Signer for signer_id {signer_id} with key_ids {key_ids:?}");
         Ok(Self {
             dkg_id: 0,

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -52,6 +52,10 @@ impl fmt::Debug for Party {
 impl Party {
     /// Construct a random Party with the passed ID and parameters
     pub fn new<RNG: RngCore + CryptoRng>(id: u32, n: u32, t: u32, rng: &mut RNG) -> Self {
+        // create a nonce using just the passed RNG to avoid having a zero nonce used against us
+        let secret_key = Scalar::random(rng);
+        let nonce = Nonce::random(&secret_key, rng);
+
         Self {
             id,
             num_keys: n,
@@ -60,7 +64,7 @@ impl Party {
             private_key: Scalar::zero(),
             public_key: Point::zero(),
             group_key: Point::zero(),
-            nonce: Nonce::zero(),
+            nonce,
         }
     }
 

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -866,7 +866,8 @@ mod tests {
         let mut signer = v1::Signer::new(id, &key_ids, n, t, &mut rng);
 
         for party in &signer.parties {
-            assert!(party.nonce.is_zero());
+            assert!(!party.nonce.is_zero());
+            assert!(party.nonce.is_valid());
         }
 
         let nonces = signer.gen_nonces(&secret_key, &mut rng);
@@ -875,6 +876,7 @@ mod tests {
 
         for party in &signer.parties {
             assert!(!party.nonce.is_zero());
+            assert!(party.nonce.is_valid());
         }
     }
 

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -771,14 +771,39 @@ pub mod test_helpers {
 #[cfg(test)]
 mod tests {
     use hashbrown::{HashMap, HashSet};
+    use num_traits::Zero;
 
     use crate::util::create_rng;
     use crate::{
+        curve::scalar::Scalar,
         traits::{
             self, test_helpers::run_compute_secrets_missing_private_shares, Aggregator, Signer,
         },
         v2,
     };
+
+    #[test]
+    fn signer_gen_nonces() {
+        let mut rng = create_rng();
+        let secret_key = Scalar::random(&mut rng);
+        let id = 1;
+        let key_ids = [1, 2, 3];
+        let n: u32 = 10;
+        let p: u32 = 3;
+        let t: u32 = 7;
+
+        let mut signer = v2::Signer::new(id, &key_ids, p, n, t, &mut rng);
+
+        assert!(!signer.nonce.is_zero());
+        assert!(signer.nonce.is_valid());
+
+        let nonces = signer.gen_nonces(&secret_key, &mut rng);
+
+        assert_eq!(nonces.len(), 1);
+
+        assert!(!signer.nonce.is_zero());
+        assert!(signer.nonce.is_valid());
+    }
 
     #[test]
     fn party_save_load() {

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -60,6 +60,10 @@ impl Party {
         threshold: u32,
         rng: &mut RNG,
     ) -> Self {
+        // create a nonce using just the passed RNG to avoid having a zero nonce used against us
+        let secret_key = Scalar::random(rng);
+        let nonce = Nonce::random(&secret_key, rng);
+
         Self {
             party_id,
             key_ids: key_ids.to_vec(),
@@ -69,7 +73,7 @@ impl Party {
             f: Some(VSS::random_poly(threshold - 1, rng)),
             private_keys: Default::default(),
             group_key: Point::zero(),
-            nonce: Nonce::zero(),
+            nonce,
         }
     }
 


### PR DESCRIPTION
This PR fixes https://github.com/xoloki/wsts/issues/207 by initializing Signer nonces both in the low level objects (using only the passed RNG) and also in the Signer state machine (mixing in the network_private_key).