### PR TITLE
Add DKG Ack states and fix signer state machine

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -103,6 +103,10 @@ pub enum Message {
     DkgPrivateBegin(DkgPrivateBegin),
     /// Send DKG private shares
     DkgPrivateShares(DkgPrivateShares),
+    /// Tell signers the coordinator has received all expected private shares
+    DkgPrivateSharesDone(DkgPrivateSharesDone),
+    /// Acknowledge receipt of DkgPrivateSharesDone
+    DkgPrivateSharesDoneAck(DkgPrivateSharesDoneAck),
     /// Tell signers to compute shares and send DKG end
     DkgEndBegin(DkgEndBegin),
     /// Tell coordinator that DKG is complete
@@ -126,6 +130,8 @@ impl Signable for Message {
             Message::DkgPublicSharesDoneAck(msg) => msg.hash(hasher),
             Message::DkgPrivateBegin(msg) => msg.hash(hasher),
             Message::DkgPrivateShares(msg) => msg.hash(hasher),
+            Message::DkgPrivateSharesDone(msg) => msg.hash(hasher),
+            Message::DkgPrivateSharesDoneAck(msg) => msg.hash(hasher),
             Message::DkgEndBegin(msg) => msg.hash(hasher),
             Message::DkgEnd(msg) => msg.hash(hasher),
             Message::NonceRequest(msg) => msg.hash(hasher),
@@ -326,6 +332,42 @@ impl Signable for DkgPrivateShares {
                 hasher.update(&share[dst_id]);
             }
         }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+/// DKG private shares done message from coordinator to signers
+pub struct DkgPrivateSharesDone {
+    /// DKG round ID
+    pub dkg_id: u64,
+    /// Signer IDs that the coordinator received private shares from
+    pub signer_ids: Vec<u32>,
+}
+
+impl Signable for DkgPrivateSharesDone {
+    fn hash(&self, hasher: &mut Sha256) {
+        hasher.update("DKG_PRIVATE_SHARES_DONE".as_bytes());
+        hasher.update(self.dkg_id.to_be_bytes());
+        for signer_id in &self.signer_ids {
+            hasher.update(signer_id.to_be_bytes());
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+/// DKG private shares done acknowledgment from signer to coordinator
+pub struct DkgPrivateSharesDoneAck {
+    /// DKG round ID
+    pub dkg_id: u64,
+    /// Signer ID
+    pub signer_id: u32,
+}
+
+impl Signable for DkgPrivateSharesDoneAck {
+    fn hash(&self, hasher: &mut Sha256) {
+        hasher.update("DKG_PRIVATE_SHARES_DONE_ACK".as_bytes());
+        hasher.update(self.dkg_id.to_be_bytes());
+        hasher.update(self.signer_id.to_be_bytes());
     }
 }
 
@@ -684,6 +726,28 @@ impl Packet {
                 } else {
                     warn!(
                         "Received a DkgPrivateShares message with an unknown id: {}",
+                        msg.signer_id
+                    );
+                    return false;
+                }
+            }
+            Message::DkgPrivateSharesDone(msg) => {
+                if !msg.verify(&self.sig, coordinator_public_key) {
+                    warn!("Received a DkgPrivateSharesDone message with an invalid signature.");
+                    return false;
+                }
+            }
+            Message::DkgPrivateSharesDoneAck(msg) => {
+                if let Some(public_key) = signers_public_keys.signers.get(&msg.signer_id) {
+                    if !msg.verify(&self.sig, public_key) {
+                        warn!(
+                            "Received a DkgPrivateSharesDoneAck message with an invalid signature."
+                        );
+                        return false;
+                    }
+                } else {
+                    warn!(
+                        "Received a DkgPrivateSharesDoneAck message with an unknown id: {}",
                         msg.signer_id
                     );
                     return false;

--- a/src/net.rs
+++ b/src/net.rs
@@ -95,6 +95,10 @@ pub enum Message {
     DkgBegin(DkgBegin),
     /// Send DKG public shares
     DkgPublicShares(DkgPublicShares),
+    /// Tell signers the coordinator has received all expected public shares
+    DkgPublicSharesDone(DkgPublicSharesDone),
+    /// Acknowledge receipt of DkgPublicSharesDone
+    DkgPublicSharesDoneAck(DkgPublicSharesDoneAck),
     /// Tell signers to send DKG private shares
     DkgPrivateBegin(DkgPrivateBegin),
     /// Send DKG private shares
@@ -118,6 +122,8 @@ impl Signable for Message {
         match self {
             Message::DkgBegin(msg) => msg.hash(hasher),
             Message::DkgPublicShares(msg) => msg.hash(hasher),
+            Message::DkgPublicSharesDone(msg) => msg.hash(hasher),
+            Message::DkgPublicSharesDoneAck(msg) => msg.hash(hasher),
             Message::DkgPrivateBegin(msg) => msg.hash(hasher),
             Message::DkgPrivateShares(msg) => msg.hash(hasher),
             Message::DkgEndBegin(msg) => msg.hash(hasher),
@@ -231,6 +237,42 @@ impl Signable for DkgPublicShares {
                 hasher.update(a.compress().as_bytes());
             }
         }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+/// DKG public shares done message from coordinator to signers
+pub struct DkgPublicSharesDone {
+    /// DKG round ID
+    pub dkg_id: u64,
+    /// Signer IDs that the coordinator received public shares from
+    pub signer_ids: Vec<u32>,
+}
+
+impl Signable for DkgPublicSharesDone {
+    fn hash(&self, hasher: &mut Sha256) {
+        hasher.update("DKG_PUBLIC_SHARES_DONE".as_bytes());
+        hasher.update(self.dkg_id.to_be_bytes());
+        for signer_id in &self.signer_ids {
+            hasher.update(signer_id.to_be_bytes());
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+/// DKG public shares done acknowledgment from signer to coordinator
+pub struct DkgPublicSharesDoneAck {
+    /// DKG round ID
+    pub dkg_id: u64,
+    /// Signer ID
+    pub signer_id: u32,
+}
+
+impl Signable for DkgPublicSharesDoneAck {
+    fn hash(&self, hasher: &mut Sha256) {
+        hasher.update("DKG_PUBLIC_SHARES_DONE_ACK".as_bytes());
+        hasher.update(self.dkg_id.to_be_bytes());
+        hasher.update(self.signer_id.to_be_bytes());
     }
 }
 
@@ -603,6 +645,28 @@ impl Packet {
                 } else {
                     warn!(
                         "Received a DkgPublicShares message with an unknown id: {}",
+                        msg.signer_id
+                    );
+                    return false;
+                }
+            }
+            Message::DkgPublicSharesDone(msg) => {
+                if !msg.verify(&self.sig, coordinator_public_key) {
+                    warn!("Received a DkgPublicSharesDone message with an invalid signature.");
+                    return false;
+                }
+            }
+            Message::DkgPublicSharesDoneAck(msg) => {
+                if let Some(public_key) = signers_public_keys.signers.get(&msg.signer_id) {
+                    if !msg.verify(&self.sig, public_key) {
+                        warn!(
+                            "Received a DkgPublicSharesDoneAck message with an invalid signature."
+                        );
+                        return false;
+                    }
+                } else {
+                    warn!(
+                        "Received a DkgPublicSharesDoneAck message with an unknown id: {}",
                         msg.signer_id
                     );
                     return false;

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -13,8 +13,8 @@ use crate::{
     errors::AggregatorError,
     net::{
         DkgBegin, DkgEnd, DkgEndBegin, DkgFailure, DkgPrivateBegin, DkgPrivateShares,
-        DkgPublicShares, DkgStatus, Message, NonceRequest, NonceResponse, Packet, Signable,
-        SignatureShareRequest, SignatureType,
+        DkgPublicShares, DkgPublicSharesDone, DkgStatus, Message, NonceRequest, NonceResponse,
+        Packet, Signable, SignatureShareRequest, SignatureType,
     },
     state_machine::{
         coordinator::{
@@ -95,9 +95,24 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                                 // we hit the timeout but met the threshold, continue
                                 warn!("Timeout gathering DkgPublicShares for dkg round {} signing round {} iteration {}, dkg_threshold was met ({dkg_size}/{}), ", self.current_dkg_id, self.current_sign_id, self.current_sign_iter_id, self.config.dkg_threshold);
                                 self.public_shares_gathered()?;
-                                let packet = self.start_private_shares()?;
+                                let packet = self.send_public_shares_done()?;
                                 return Ok((Some(packet), None));
                             }
+                        }
+                    }
+                }
+            }
+            State::DkgPublicSharesDoneDistribute => {}
+            State::DkgPublicSharesDoneGather => {
+                if let Some(start) = self.dkg_public_start {
+                    if let Some(timeout) = self.config.dkg_public_timeout {
+                        if now.duration_since(start) > timeout {
+                            error!("Timeout gathering DkgPublicSharesDoneAck for dkg round {}, not all signers responded", self.current_dkg_id);
+                            let wait = self.dkg_wait_signer_ids.iter().copied().collect();
+                            return Ok((
+                                None,
+                                Some(OperationResult::DkgError(DkgError::DkgPublicTimeout(wait))),
+                            ));
                         }
                     }
                 }
@@ -259,6 +274,17 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                 State::DkgPublicGather => {
                     self.gather_public_shares(packet)?;
                     if self.state == State::DkgPublicGather {
+                        // We need more data
+                        return Ok((None, None));
+                    }
+                }
+                State::DkgPublicSharesDoneDistribute => {
+                    let packet = self.send_public_shares_done()?;
+                    return Ok((Some(packet), None));
+                }
+                State::DkgPublicSharesDoneGather => {
+                    self.gather_public_shares_done_ack(packet)?;
+                    if self.state == State::DkgPublicSharesDoneGather {
                         // We need more data
                         return Ok((None, None));
                     }
@@ -528,7 +554,49 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
     }
 
     fn public_shares_gathered(&mut self) -> Result<(), Error> {
-        self.move_to(State::DkgPrivateDistribute)?;
+        self.move_to(State::DkgPublicSharesDoneDistribute)?;
+        Ok(())
+    }
+
+    /// Notify signers that all public shares have been received
+    pub fn send_public_shares_done(&mut self) -> Result<Packet, Error> {
+        let signer_ids: Vec<u32> = self.dkg_public_shares.keys().cloned().collect();
+        self.dkg_wait_signer_ids = signer_ids.iter().cloned().collect();
+        info!(dkg_id = %self.current_dkg_id, "Sending DkgPublicSharesDone");
+        let msg = DkgPublicSharesDone {
+            dkg_id: self.current_dkg_id,
+            signer_ids,
+        };
+        let packet = Packet {
+            sig: msg
+                .sign(&self.config.message_private_key)
+                .expect("Failed to sign DkgPublicSharesDone"),
+            msg: Message::DkgPublicSharesDone(msg),
+        };
+        self.move_to(State::DkgPublicSharesDoneGather)?;
+        self.dkg_public_start = Some(Instant::now());
+        Ok(packet)
+    }
+
+    fn gather_public_shares_done_ack(&mut self, packet: &Packet) -> Result<(), Error> {
+        if let Message::DkgPublicSharesDoneAck(ack) = &packet.msg {
+            if ack.dkg_id != self.current_dkg_id {
+                return Err(Error::BadDkgId(ack.dkg_id, self.current_dkg_id));
+            }
+            if !self.config.public_keys.signers.contains_key(&ack.signer_id) {
+                warn!(signer_id = %ack.signer_id, "No public key in config");
+                return Ok(());
+            }
+            self.dkg_wait_signer_ids.remove(&ack.signer_id);
+            debug!(
+                dkg_id = %ack.dkg_id,
+                signer_id = %ack.signer_id,
+                "DkgPublicSharesDoneAck received"
+            );
+        }
+        if self.dkg_wait_signer_ids.is_empty() {
+            self.move_to(State::DkgPrivateDistribute)?;
+        }
         Ok(())
     }
 
@@ -1319,7 +1387,12 @@ impl<Aggregator: AggregatorTrait> StateMachine<State, Error> for Coordinator<Agg
             State::DkgPublicGather => {
                 prev_state == &State::DkgPublicDistribute || prev_state == &State::DkgPublicGather
             }
-            State::DkgPrivateDistribute => prev_state == &State::DkgPublicGather,
+            State::DkgPublicSharesDoneDistribute => prev_state == &State::DkgPublicGather,
+            State::DkgPublicSharesDoneGather => {
+                prev_state == &State::DkgPublicSharesDoneDistribute
+                    || prev_state == &State::DkgPublicSharesDoneGather
+            }
+            State::DkgPrivateDistribute => prev_state == &State::DkgPublicSharesDoneGather,
             State::DkgPrivateGather => {
                 prev_state == &State::DkgPrivateDistribute || prev_state == &State::DkgPrivateGather
             }
@@ -2134,6 +2207,20 @@ pub mod test {
             feedback_messages(&mut coordinators, &mut signers, &[message]);
         assert!(operation_results.is_empty());
         for coordinator in &coordinators {
+            assert_eq!(coordinator.state, State::DkgPublicSharesDoneGather);
+        }
+
+        assert_eq!(outbound_messages.len(), 1);
+        assert!(
+            matches!(&outbound_messages[0].msg, Message::DkgPublicSharesDone(_)),
+            "Expected DkgPublicSharesDone message"
+        );
+
+        // Send DkgPublicSharesDone to signers and collect their acks back to the coordinator
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
+        assert!(operation_results.is_empty());
+        for coordinator in &coordinators {
             assert_eq!(coordinator.state, State::DkgPrivateGather);
         }
 
@@ -2141,7 +2228,7 @@ pub mod test {
         assert_eq!(outbound_messages.len(), 1);
         assert!(
             matches!(&outbound_messages[0].msg, Message::DkgPrivateBegin(_)),
-            "Expected DkgPrviateBegin message"
+            "Expected DkgPrivateBegin message"
         );
         // Send the DKG Private Begin message to all signers and share their responses with the coordinators and signers
         let (outbound_messages, operation_results) =
@@ -2250,7 +2337,24 @@ pub mod test {
         assert!(operation_results.is_none());
         assert_eq!(
             minimum_coordinators.first().unwrap().state,
+            State::DkgPublicSharesDoneGather,
+        );
+
+        // Feed DkgPublicSharesDone to signers, get acks back to coordinator
+        let (outbound_messages, operation_results) = feedback_messages(
+            &mut minimum_coordinators,
+            &mut minimum_signers,
+            &[outbound_messages.unwrap()],
+        );
+        assert!(operation_results.is_empty());
+        assert_eq!(
+            minimum_coordinators.first().unwrap().state,
             State::DkgPrivateGather,
+        );
+        assert_eq!(outbound_messages.len(), 1);
+        assert!(
+            matches!(&outbound_messages[0].msg, Message::DkgPrivateBegin(_)),
+            "Expected DkgPrivateBegin message"
         );
         (minimum_coordinators, minimum_signers)
     }
@@ -2334,6 +2438,18 @@ pub mod test {
         assert!(operation_results.is_none());
         assert_eq!(
             minimum_coordinators.first().unwrap().state,
+            State::DkgPublicSharesDoneGather,
+        );
+
+        // Feed DkgPublicSharesDone to signers, get acks back to coordinator
+        let (_outbound_messages, operation_results) = feedback_messages(
+            &mut minimum_coordinators,
+            &mut minimum_signers,
+            &[outbound_messages.unwrap()],
+        );
+        assert!(operation_results.is_empty());
+        assert_eq!(
+            minimum_coordinators.first().unwrap().state,
             State::DkgPrivateGather,
         );
 
@@ -2344,6 +2460,24 @@ pub mod test {
         // Send the DKG Begin message to all signers and gather responses by sharing with all other signers and coordinator
         let (outbound_messages, operation_results) =
             feedback_messages(&mut minimum_coordinators, &mut minimum_signers, &[message]);
+        assert!(operation_results.is_empty());
+        assert_eq!(
+            minimum_coordinators.first().unwrap().state,
+            State::DkgPublicSharesDoneGather
+        );
+
+        assert_eq!(outbound_messages.len(), 1);
+        assert!(
+            matches!(&outbound_messages[0].msg, Message::DkgPublicSharesDone(_)),
+            "Expected DkgPublicSharesDone message"
+        );
+
+        // Send DkgPublicSharesDone to signers and collect their acks back to the coordinator
+        let (outbound_messages, operation_results) = feedback_messages(
+            &mut minimum_coordinators,
+            &mut minimum_signers,
+            &outbound_messages,
+        );
         assert!(operation_results.is_empty());
         assert_eq!(
             minimum_coordinators.first().unwrap().state,
@@ -2520,6 +2654,24 @@ pub mod test {
         assert!(operation_results.is_empty());
         assert_eq!(
             insufficient_coordinator.first().unwrap().state,
+            State::DkgPublicSharesDoneGather
+        );
+
+        assert_eq!(outbound_messages.len(), 1);
+        assert!(
+            matches!(&outbound_messages[0].msg, Message::DkgPublicSharesDone(_)),
+            "Expected DkgPublicSharesDone message"
+        );
+
+        // Send DkgPublicSharesDone to signers and collect their acks back to the coordinator
+        let (outbound_messages, operation_results) = feedback_messages(
+            &mut insufficient_coordinator,
+            &mut insufficient_signers,
+            &outbound_messages,
+        );
+        assert!(operation_results.is_empty());
+        assert_eq!(
+            insufficient_coordinator.first().unwrap().state,
             State::DkgPrivateGather
         );
 
@@ -2604,6 +2756,20 @@ pub mod test {
         // Send the DKG Begin message to all signers and gather responses by sharing with all other signers and coordinators
         let (outbound_messages, operation_results) =
             feedback_messages(&mut coordinators, &mut signers, &[message]);
+        assert!(operation_results.is_empty());
+        for coordinator in &coordinators {
+            assert_eq!(coordinator.state, State::DkgPublicSharesDoneGather);
+        }
+
+        assert_eq!(outbound_messages.len(), 1);
+        assert!(
+            matches!(&outbound_messages[0].msg, Message::DkgPublicSharesDone(_)),
+            "Expected DkgPublicSharesDone message"
+        );
+
+        // Send DkgPublicSharesDone to signers and collect their acks back to the coordinator
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
         assert!(operation_results.is_empty());
         for coordinator in &coordinators {
             assert_eq!(coordinator.state, State::DkgPrivateGather);
@@ -2762,6 +2928,20 @@ pub mod test {
             },
         );
 
+        assert!(operation_results.is_empty());
+        for coordinator in &coordinators {
+            assert_eq!(coordinator.state, State::DkgPublicSharesDoneGather);
+        }
+
+        assert_eq!(outbound_messages.len(), 1);
+        assert!(
+            matches!(&outbound_messages[0].msg, Message::DkgPublicSharesDone(_)),
+            "Expected DkgPublicSharesDone message"
+        );
+
+        // Send DkgPublicSharesDone to signers and collect their acks back to the coordinator
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
         assert!(operation_results.is_empty());
         for coordinator in &coordinators {
             assert_eq!(coordinator.state, State::DkgPrivateGather);
@@ -3070,6 +3250,20 @@ pub mod test {
         // Send the DKG Begin message to all signers and gather responses by sharing with all other signers and coordinator
         let (outbound_messages, operation_results) =
             feedback_messages(&mut coordinators, &mut signers, &[message]);
+        assert!(operation_results.is_empty());
+        for coordinator in &coordinators {
+            assert_eq!(coordinator.state, State::DkgPublicSharesDoneGather);
+        }
+
+        assert_eq!(outbound_messages.len(), 1);
+        assert!(
+            matches!(&outbound_messages[0].msg, Message::DkgPublicSharesDone(_)),
+            "Expected DkgPublicSharesDone message"
+        );
+
+        // Send DkgPublicSharesDone to signers and collect their acks back to the coordinator
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
         assert!(operation_results.is_empty());
         for coordinator in &coordinators {
             assert_eq!(coordinator.state, State::DkgPrivateGather);
@@ -3549,6 +3743,20 @@ pub mod test {
             feedback_messages(&mut coordinators, &mut signers, &[message]);
         assert!(operation_results.is_empty());
         for coordinator in coordinators.iter() {
+            assert_eq!(coordinator.get_state(), State::DkgPublicSharesDoneGather);
+        }
+
+        assert_eq!(outbound_messages.len(), 1);
+        assert!(
+            matches!(&outbound_messages[0].msg, Message::DkgPublicSharesDone(_)),
+            "Expected DkgPublicSharesDone message"
+        );
+
+        // Send DkgPublicSharesDone to signers and collect their acks back to the coordinator
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
+        assert!(operation_results.is_empty());
+        for coordinator in coordinators.iter() {
             assert_eq!(coordinator.get_state(), State::DkgPrivateGather);
         }
 
@@ -3660,6 +3868,20 @@ pub mod test {
         // Send the DKG Begin message to all signers and gather responses by sharing with all other signers and coordinator
         let (outbound_messages, operation_results) =
             feedback_messages(&mut coordinators, &mut signers, &[message]);
+        assert!(operation_results.is_empty());
+        for coordinator in coordinators.iter() {
+            assert_eq!(coordinator.get_state(), State::DkgPublicSharesDoneGather);
+        }
+
+        assert_eq!(outbound_messages.len(), 1);
+        assert!(
+            matches!(&outbound_messages[0].msg, Message::DkgPublicSharesDone(_)),
+            "Expected DkgPublicSharesDone message"
+        );
+
+        // Send DkgPublicSharesDone to signers and collect their acks back to the coordinator
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
         assert!(operation_results.is_empty());
         for coordinator in coordinators.iter() {
             assert_eq!(coordinator.get_state(), State::DkgPrivateGather);

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -1077,6 +1077,15 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                 return Ok(());
             };
 
+            // check that the signer participated in the current DKG round
+            if !self
+                .dkg_end_messages
+                .contains_key(&nonce_response.signer_id)
+            {
+                warn!(signer_id = %nonce_response.signer_id, "NonceResponse rejected: signer not a DKG participant");
+                return Ok(());
+            }
+
             // check that the key_ids match the config
             let Some(signer_key_ids) = self
                 .config
@@ -1261,6 +1270,15 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                 sig_share_response.signer_id,
             ));
         };
+
+        // check that the signer participated in the current DKG round
+        if !self
+            .dkg_end_messages
+            .contains_key(&sig_share_response.signer_id)
+        {
+            warn!(signer_id = %sig_share_response.signer_id, "SignatureShareResponse rejected: signer not a DKG participant");
+            return Ok(());
+        }
 
         // check that the key_ids match the config
         let Some(signer_key_ids) = self
@@ -1987,6 +2005,17 @@ pub mod test {
         let message = vec![0u8];
         coordinator.state = State::NonceGather(signature_type);
         coordinator.aggregate_public_key = Some(Point::from(Scalar::random(&mut rng)));
+        // Populate dkg_end_messages so the DKG participation check passes
+        for signer_id in 0..coordinator.config.num_signers {
+            coordinator.dkg_end_messages.insert(
+                signer_id,
+                DkgEnd {
+                    dkg_id: 0,
+                    signer_id,
+                    status: DkgStatus::Success,
+                },
+            );
+        }
 
         let nonce_response = NonceResponse {
             dkg_id: 0,
@@ -2058,6 +2087,17 @@ pub mod test {
         let signature_type = SignatureType::Frost;
 
         coordinator.state = State::SigShareGather(signature_type);
+        // Populate dkg_end_messages so the DKG participation check passes
+        for signer_id in 0..coordinator.config.num_signers {
+            coordinator.dkg_end_messages.insert(
+                signer_id,
+                DkgEnd {
+                    dkg_id: 0,
+                    signer_id,
+                    status: DkgStatus::Success,
+                },
+            );
+        }
 
         let signature_share = SignatureShare {
             id: 1,

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -78,12 +78,13 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
             State::DkgPublicGather => {
                 if let Some(start) = self.dkg_public_start {
                     if let Some(timeout) = self.config.dkg_public_timeout {
-                        if now.duration_since(start) > timeout {
+                        let elapsed = now.duration_since(start);
+                        if elapsed > timeout {
                             // check dkg_threshold to determine if we can continue
                             let dkg_size = self.compute_dkg_public_size()?;
 
                             if self.config.dkg_threshold > dkg_size {
-                                error!("Timeout gathering DkgPublicShares for dkg round {} signing round {} iteration {}, dkg_threshold not met ({dkg_size}/{}), unable to continue", self.current_dkg_id, self.current_sign_id, self.current_sign_iter_id, self.config.dkg_threshold);
+                                error!("Timeout gathering DkgPublicShares for dkg round {} signing round {} iteration {}, dkg_threshold not met ({dkg_size}/{}), unable to continue ({:?} > {:?})", self.current_dkg_id, self.current_sign_id, self.current_sign_iter_id, self.config.dkg_threshold, elapsed, timeout);
                                 let wait = self.dkg_wait_signer_ids.iter().copied().collect();
                                 return Ok((
                                     None,
@@ -93,7 +94,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                                 ));
                             } else {
                                 // we hit the timeout but met the threshold, continue
-                                warn!("Timeout gathering DkgPublicShares for dkg round {} signing round {} iteration {}, dkg_threshold was met ({dkg_size}/{}), ", self.current_dkg_id, self.current_sign_id, self.current_sign_iter_id, self.config.dkg_threshold);
+                                warn!("Timeout gathering DkgPublicShares for dkg round {} signing round {} iteration {}, dkg_threshold was met ({dkg_size}/{}), continue ({:?} > {:?})", self.current_dkg_id, self.current_sign_id, self.current_sign_iter_id, self.config.dkg_threshold, elapsed, timeout);
                                 self.public_shares_gathered()?;
                                 let packet = self.send_public_shares_done()?;
                                 return Ok((Some(packet), None));
@@ -106,8 +107,9 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
             State::DkgPublicSharesDoneGather => {
                 if let Some(start) = self.dkg_public_start {
                     if let Some(timeout) = self.config.dkg_public_timeout {
-                        if now.duration_since(start) > timeout {
-                            error!("Timeout gathering DkgPublicSharesDoneAck for dkg round {}, not all signers responded", self.current_dkg_id);
+                        let elapsed = now.duration_since(start);
+                        if elapsed > timeout {
+                            error!("Timeout gathering DkgPublicSharesDoneAck for dkg round {}, not all signers responded  ({:?} > {:?})", self.current_dkg_id, elapsed, timeout);
                             let wait = self.dkg_wait_signer_ids.iter().copied().collect();
                             return Ok((
                                 None,
@@ -121,12 +123,13 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
             State::DkgPrivateGather => {
                 if let Some(start) = self.dkg_private_start {
                     if let Some(timeout) = self.config.dkg_private_timeout {
-                        if now.duration_since(start) > timeout {
+                        let elapsed = now.duration_since(start);
+                        if elapsed > timeout {
                             // check dkg_threshold to determine if we can continue
                             let dkg_size = self.compute_dkg_private_size()?;
 
                             if self.config.dkg_threshold > dkg_size {
-                                error!("Timeout gathering DkgPrivateShares for dkg round {} signing round {} iteration {}, dkg_threshold not met ({dkg_size}/{}), unable to continue", self.current_dkg_id, self.current_sign_id, self.current_sign_iter_id, self.config.dkg_threshold);
+                                error!("Timeout gathering DkgPrivateShares for dkg round {} signing round {} iteration {}, dkg_threshold not met ({dkg_size}/{}), unable to continue ({:?} > {:?})", self.current_dkg_id, self.current_sign_id, self.current_sign_iter_id, self.config.dkg_threshold, elapsed, timeout);
                                 let wait = self.dkg_wait_signer_ids.iter().copied().collect();
                                 return Ok((
                                     None,
@@ -136,7 +139,7 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                                 ));
                             } else {
                                 // we hit the timeout but met the threshold, continue
-                                warn!("Timeout gathering DkgPrivateShares for dkg round {} signing round {} iteration {}, dkg_threshold was met ({dkg_size}/{}), ", self.current_dkg_id, self.current_sign_id, self.current_sign_iter_id, self.config.dkg_threshold);
+                                warn!("Timeout gathering DkgPrivateShares for dkg round {} signing round {} iteration {}, dkg_threshold was met ({dkg_size}/{}), continue ({:?} > {:?})", self.current_dkg_id, self.current_sign_id, self.current_sign_iter_id, self.config.dkg_threshold, elapsed, timeout);
                                 self.private_shares_gathered()?;
                                 let packet = self.send_private_shares_done()?;
                                 return Ok((Some(packet), None));
@@ -149,8 +152,9 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
             State::DkgPrivateSharesDoneGather => {
                 if let Some(start) = self.dkg_private_start {
                     if let Some(timeout) = self.config.dkg_private_timeout {
-                        if now.duration_since(start) > timeout {
-                            error!("Timeout gathering DkgPrivateSharesDoneAck for dkg round {}, not all signers responded", self.current_dkg_id);
+                        let elapsed = now.duration_since(start);
+                        if elapsed > timeout {
+                            error!("Timeout gathering DkgPrivateSharesDoneAck for dkg round {}, not all signers responded ({:?} > {:?})", self.current_dkg_id, elapsed, timeout);
                             let wait = self.dkg_wait_signer_ids.iter().copied().collect();
                             return Ok((
                                 None,
@@ -164,8 +168,9 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
             State::DkgEndGather => {
                 if let Some(start) = self.dkg_end_start {
                     if let Some(timeout) = self.config.dkg_end_timeout {
-                        if now.duration_since(start) > timeout {
-                            error!("Timeout gathering DkgEnd for dkg round {} signing round {} iteration {}, unable to continue", self.current_dkg_id, self.current_sign_id, self.current_sign_iter_id);
+                        let elapsed = now.duration_since(start);
+                        if elapsed > timeout {
+                            error!("Timeout gathering DkgEnd for dkg round {} signing round {} iteration {}, unable to continue ({:?} > {:?})", self.current_dkg_id, self.current_sign_id, self.current_sign_iter_id, elapsed, timeout);
                             let wait = self.dkg_wait_signer_ids.iter().copied().collect();
                             return Ok((
                                 None,
@@ -180,8 +185,9 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
             State::NonceGather(_signature_type) => {
                 if let Some(start) = self.nonce_start {
                     if let Some(timeout) = self.config.nonce_timeout {
-                        if now.duration_since(start) > timeout {
-                            error!("Timeout gathering nonces for signing round {} iteration {}, unable to continue", self.current_sign_id, self.current_sign_iter_id);
+                        let elapsed = now.duration_since(start);
+                        if elapsed > timeout {
+                            error!("Timeout gathering nonces for signing round {} iteration {}, unable to continue ({:?} > {:?})", self.current_sign_id, self.current_sign_iter_id, elapsed, timeout);
                             let recv = self
                                 .message_nonces
                                 .get(&self.message)
@@ -204,8 +210,9 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
             State::SigShareGather(signature_type) => {
                 if let Some(start) = self.sign_start {
                     if let Some(timeout) = self.config.sign_timeout {
-                        if now.duration_since(start) > timeout {
-                            warn!("Timeout gathering signature shares for signing round {} iteration {}", self.current_sign_id, self.current_sign_iter_id);
+                        let elapsed = now.duration_since(start);
+                        if elapsed > timeout {
+                            warn!("Timeout gathering signature shares for signing round {} iteration {} ({:?} > {:?})", self.current_sign_id, self.current_sign_iter_id, elapsed, timeout);
                             for signer_id in &self
                                 .message_nonces
                                 .get(&self.message)
@@ -2354,8 +2361,8 @@ pub mod test {
         num_signers: u32,
         keys_per_signer: u32,
     ) -> (Vec<FireCoordinator<Aggregator>>, Vec<Signer<SignerType>>) {
-        let timeout = Duration::from_millis(1024);
-        let expire = Duration::from_millis(1280);
+        let timeout = Duration::from_millis(2048);
+        let expire = Duration::from_millis(2222);
         let (mut coordinators, signers) =
             setup_with_timeouts::<FireCoordinator<Aggregator>, SignerType>(
                 num_signers,
@@ -2457,8 +2464,8 @@ pub mod test {
         num_signers: u32,
         keys_per_signer: u32,
     ) -> (Vec<FireCoordinator<Aggregator>>, Vec<Signer<SignerType>>) {
-        let timeout = Duration::from_millis(1024);
-        let expire = Duration::from_millis(1280);
+        let timeout = Duration::from_millis(2048);
+        let expire = Duration::from_millis(2222);
         let (coordinators, signers) = setup_with_timeouts::<FireCoordinator<Aggregator>, SignerType>(
             num_signers,
             keys_per_signer,
@@ -2661,8 +2668,8 @@ pub mod test {
     }
 
     fn insufficient_signers_dkg<Aggregator: AggregatorTrait, Signer: SignerTrait>() {
-        let timeout = Duration::from_millis(1024);
-        let expire = Duration::from_millis(1280);
+        let timeout = Duration::from_millis(2048);
+        let expire = Duration::from_millis(2222);
         let num_signers = 10;
         let keys_per_signer = 2;
         let (coordinators, signers) = setup_with_timeouts::<FireCoordinator<Aggregator>, Signer>(

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -13,8 +13,8 @@ use crate::{
     errors::AggregatorError,
     net::{
         DkgBegin, DkgEnd, DkgEndBegin, DkgFailure, DkgPrivateBegin, DkgPrivateShares,
-        DkgPublicShares, DkgPublicSharesDone, DkgStatus, Message, NonceRequest, NonceResponse,
-        Packet, Signable, SignatureShareRequest, SignatureType,
+        DkgPrivateSharesDone, DkgPublicShares, DkgPublicSharesDone, DkgStatus, Message,
+        NonceRequest, NonceResponse, Packet, Signable, SignatureShareRequest, SignatureType,
     },
     state_machine::{
         coordinator::{
@@ -138,9 +138,24 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                                 // we hit the timeout but met the threshold, continue
                                 warn!("Timeout gathering DkgPrivateShares for dkg round {} signing round {} iteration {}, dkg_threshold was met ({dkg_size}/{}), ", self.current_dkg_id, self.current_sign_id, self.current_sign_iter_id, self.config.dkg_threshold);
                                 self.private_shares_gathered()?;
-                                let packet = self.start_dkg_end()?;
+                                let packet = self.send_private_shares_done()?;
                                 return Ok((Some(packet), None));
                             }
+                        }
+                    }
+                }
+            }
+            State::DkgPrivateSharesDoneDistribute => {}
+            State::DkgPrivateSharesDoneGather => {
+                if let Some(start) = self.dkg_private_start {
+                    if let Some(timeout) = self.config.dkg_private_timeout {
+                        if now.duration_since(start) > timeout {
+                            error!("Timeout gathering DkgPrivateSharesDoneAck for dkg round {}, not all signers responded", self.current_dkg_id);
+                            let wait = self.dkg_wait_signer_ids.iter().copied().collect();
+                            return Ok((
+                                None,
+                                Some(OperationResult::DkgError(DkgError::DkgPrivateTimeout(wait))),
+                            ));
                         }
                     }
                 }
@@ -296,6 +311,17 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                 State::DkgPrivateGather => {
                     self.gather_private_shares(packet)?;
                     if self.state == State::DkgPrivateGather {
+                        // We need more data
+                        return Ok((None, None));
+                    }
+                }
+                State::DkgPrivateSharesDoneDistribute => {
+                    let packet = self.send_private_shares_done()?;
+                    return Ok((Some(packet), None));
+                }
+                State::DkgPrivateSharesDoneGather => {
+                    self.gather_private_shares_done_ack(packet)?;
+                    if self.state == State::DkgPrivateSharesDoneGather {
                         // We need more data
                         return Ok((None, None));
                     }
@@ -652,7 +678,49 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
     }
 
     fn private_shares_gathered(&mut self) -> Result<(), Error> {
-        self.move_to(State::DkgEndDistribute)?;
+        self.move_to(State::DkgPrivateSharesDoneDistribute)?;
+        Ok(())
+    }
+
+    /// Notify signers that all private shares have been received
+    pub fn send_private_shares_done(&mut self) -> Result<Packet, Error> {
+        let signer_ids: Vec<u32> = self.dkg_private_shares.keys().cloned().collect();
+        self.dkg_wait_signer_ids = signer_ids.iter().cloned().collect();
+        info!(dkg_id = %self.current_dkg_id, "Sending DkgPrivateSharesDone");
+        let msg = DkgPrivateSharesDone {
+            dkg_id: self.current_dkg_id,
+            signer_ids,
+        };
+        let packet = Packet {
+            sig: msg
+                .sign(&self.config.message_private_key)
+                .expect("Failed to sign DkgPrivateSharesDone"),
+            msg: Message::DkgPrivateSharesDone(msg),
+        };
+        self.move_to(State::DkgPrivateSharesDoneGather)?;
+        self.dkg_private_start = Some(Instant::now());
+        Ok(packet)
+    }
+
+    fn gather_private_shares_done_ack(&mut self, packet: &Packet) -> Result<(), Error> {
+        if let Message::DkgPrivateSharesDoneAck(ack) = &packet.msg {
+            if ack.dkg_id != self.current_dkg_id {
+                return Err(Error::BadDkgId(ack.dkg_id, self.current_dkg_id));
+            }
+            if !self.config.public_keys.signers.contains_key(&ack.signer_id) {
+                warn!(signer_id = %ack.signer_id, "No public key in config");
+                return Ok(());
+            }
+            self.dkg_wait_signer_ids.remove(&ack.signer_id);
+            debug!(
+                dkg_id = %ack.dkg_id,
+                signer_id = %ack.signer_id,
+                "DkgPrivateSharesDoneAck received"
+            );
+        }
+        if self.dkg_wait_signer_ids.is_empty() {
+            self.move_to(State::DkgEndDistribute)?;
+        }
         Ok(())
     }
 
@@ -1396,7 +1464,12 @@ impl<Aggregator: AggregatorTrait> StateMachine<State, Error> for Coordinator<Agg
             State::DkgPrivateGather => {
                 prev_state == &State::DkgPrivateDistribute || prev_state == &State::DkgPrivateGather
             }
-            State::DkgEndDistribute => prev_state == &State::DkgPrivateGather,
+            State::DkgPrivateSharesDoneDistribute => prev_state == &State::DkgPrivateGather,
+            State::DkgPrivateSharesDoneGather => {
+                prev_state == &State::DkgPrivateSharesDoneDistribute
+                    || prev_state == &State::DkgPrivateSharesDoneGather
+            }
+            State::DkgEndDistribute => prev_state == &State::DkgPrivateSharesDoneGather,
             State::DkgEndGather => prev_state == &State::DkgEndDistribute,
             State::NonceRequest(signature_type) => {
                 prev_state == &State::Idle
@@ -2236,6 +2309,16 @@ pub mod test {
         assert!(operation_results.is_empty());
         assert_eq!(outbound_messages.len(), 1);
         assert!(
+            matches!(outbound_messages[0].msg, Message::DkgPrivateSharesDone(_)),
+            "Expected DkgPrivateSharesDone message"
+        );
+
+        // Send DkgPrivateSharesDone to signers and collect their acks back to the coordinator
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
+        assert!(operation_results.is_empty());
+        assert_eq!(outbound_messages.len(), 1);
+        assert!(
             matches!(outbound_messages[0].msg, Message::DkgEndBegin(_)),
             "Expected DkgEndBegin message"
         );
@@ -2520,8 +2603,25 @@ pub mod test {
         assert!(
             matches!(
                 outbound_message.clone().unwrap().msg,
-                Message::DkgEndBegin(_)
+                Message::DkgPrivateSharesDone(_)
             ),
+            "Expected DkgPrivateSharesDone message"
+        );
+        assert_eq!(
+            minimum_coordinators.first().unwrap().state,
+            State::DkgPrivateSharesDoneGather,
+        );
+
+        // Send DkgPrivateSharesDone to signers and collect their acks back to the coordinator
+        let (outbound_messages, operation_results) = feedback_messages(
+            &mut minimum_coordinators,
+            &mut minimum_signers,
+            &[outbound_message.unwrap()],
+        );
+        assert!(operation_results.is_empty());
+        assert_eq!(outbound_messages.len(), 1);
+        assert!(
+            matches!(outbound_messages[0].msg, Message::DkgEndBegin(_)),
             "Expected DkgEndBegin message"
         );
         assert_eq!(
@@ -2533,7 +2633,7 @@ pub mod test {
         let (outbound_messages, operation_results) = feedback_messages(
             &mut minimum_coordinators,
             &mut minimum_signers,
-            &[outbound_message.unwrap()],
+            &outbound_messages,
         );
         assert!(outbound_messages.is_empty());
         assert_eq!(operation_results.len(), 1);
@@ -2829,6 +2929,16 @@ pub mod test {
         assert!(operation_results.is_empty());
         assert_eq!(outbound_messages.len(), 1);
         assert!(
+            matches!(outbound_messages[0].msg, Message::DkgPrivateSharesDone(_)),
+            "Expected DkgPrivateSharesDone message"
+        );
+
+        // Send DkgPrivateSharesDone to signers and collect their acks back to the coordinator
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
+        assert!(operation_results.is_empty());
+        assert_eq!(outbound_messages.len(), 1);
+        assert!(
             matches!(outbound_messages[0].msg, Message::DkgEndBegin(_)),
             "Expected DkgEndBegin message"
         );
@@ -2953,6 +3063,16 @@ pub mod test {
             "Expected DkgPrivateBegin message"
         );
 
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
+        assert!(operation_results.is_empty());
+        assert_eq!(outbound_messages.len(), 1);
+        assert!(
+            matches!(outbound_messages[0].msg, Message::DkgPrivateSharesDone(_)),
+            "Expected DkgPrivateSharesDone message"
+        );
+
+        // Send DkgPrivateSharesDone to signers and collect their acks back to the coordinator
         let (outbound_messages, operation_results) =
             feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
         assert!(operation_results.is_empty());
@@ -3276,6 +3396,16 @@ pub mod test {
         );
 
         // Send the DKG Private Begin message to all signers and share their responses with the coordinators and signers
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
+        assert!(operation_results.is_empty());
+        assert_eq!(outbound_messages.len(), 1);
+        assert!(
+            matches!(&outbound_messages[0].msg, Message::DkgPrivateSharesDone(_)),
+            "Expected DkgPrivateSharesDone message"
+        );
+
+        // Send DkgPrivateSharesDone to signers and collect their acks back to the coordinator
         let (outbound_messages, operation_results) =
             feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
         assert!(operation_results.is_empty());
@@ -3772,6 +3902,16 @@ pub mod test {
         assert!(operation_results.is_empty());
         assert_eq!(outbound_messages.len(), 1);
         assert!(
+            matches!(outbound_messages[0].msg, Message::DkgPrivateSharesDone(_)),
+            "Expected DkgPrivateSharesDone message"
+        );
+
+        // Send DkgPrivateSharesDone to signers and collect their acks back to the coordinator
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
+        assert!(operation_results.is_empty());
+        assert_eq!(outbound_messages.len(), 1);
+        assert!(
             matches!(outbound_messages[0].msg, Message::DkgEndBegin(_)),
             "Expected DkgEndBegin message"
         );
@@ -3894,6 +4034,16 @@ pub mod test {
         );
 
         // Send the DKG Private Begin message to all signers and share their responses with the coordinator and signers
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
+        assert!(operation_results.is_empty());
+        assert_eq!(outbound_messages.len(), 1);
+        assert!(
+            matches!(&outbound_messages[0].msg, Message::DkgPrivateSharesDone(_)),
+            "Expected DkgPrivateSharesDone message"
+        );
+
+        // Send DkgPrivateSharesDone to signers and collect their acks back to the coordinator
         let (outbound_messages, operation_results) =
             feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
         assert!(operation_results.is_empty());

--- a/src/state_machine/coordinator/fire.rs
+++ b/src/state_machine/coordinator/fire.rs
@@ -1358,8 +1358,8 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
 
             let shares = message_nonce
                 .public_nonces
-                .iter()
-                .flat_map(|(i, _)| {
+                .keys()
+                .flat_map(|i| {
                     if let Some(shares) = self.signature_shares.get(i) {
                         shares.clone()
                     } else {

--- a/src/state_machine/coordinator/frost.rs
+++ b/src/state_machine/coordinator/frost.rs
@@ -8,8 +8,8 @@ use crate::{
     curve::{ecdsa, point::Point},
     net::{
         DkgBegin, DkgEnd, DkgEndBegin, DkgPrivateBegin, DkgPrivateShares, DkgPublicShares,
-        DkgStatus, Message, NonceRequest, NonceResponse, Packet, Signable, SignatureShareRequest,
-        SignatureType,
+        DkgPublicSharesDone, DkgStatus, Message, NonceRequest, NonceResponse, Packet, Signable,
+        SignatureShareRequest, SignatureType,
     },
     state_machine::{
         coordinator::{
@@ -103,6 +103,17 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                 State::DkgPublicGather => {
                     self.gather_public_shares(packet)?;
                     if self.state == State::DkgPublicGather {
+                        // We need more data
+                        return Ok((None, None));
+                    }
+                }
+                State::DkgPublicSharesDoneDistribute => {
+                    let packet = self.send_public_shares_done()?;
+                    return Ok((Some(packet), None));
+                }
+                State::DkgPublicSharesDoneGather => {
+                    self.gather_public_shares_done_ack(packet)?;
+                    if self.state == State::DkgPublicSharesDoneGather {
                         // We need more data
                         return Ok((None, None));
                     }
@@ -327,6 +338,47 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
             );
         }
 
+        if self.ids_to_await.is_empty() {
+            self.move_to(State::DkgPublicSharesDoneDistribute)?;
+        }
+        Ok(())
+    }
+
+    /// Notify signers that all public shares have been received
+    pub fn send_public_shares_done(&mut self) -> Result<Packet, Error> {
+        let signer_ids: Vec<u32> = self.dkg_public_shares.keys().cloned().collect();
+        self.ids_to_await = signer_ids.iter().cloned().collect();
+        info!(dkg_id = %self.current_dkg_id, "Sending DkgPublicSharesDone");
+        let msg = DkgPublicSharesDone {
+            dkg_id: self.current_dkg_id,
+            signer_ids,
+        };
+        let packet = Packet {
+            sig: msg
+                .sign(&self.config.message_private_key)
+                .expect("Failed to sign DkgPublicSharesDone"),
+            msg: Message::DkgPublicSharesDone(msg),
+        };
+        self.move_to(State::DkgPublicSharesDoneGather)?;
+        Ok(packet)
+    }
+
+    fn gather_public_shares_done_ack(&mut self, packet: &Packet) -> Result<(), Error> {
+        if let Message::DkgPublicSharesDoneAck(ack) = &packet.msg {
+            if ack.dkg_id != self.current_dkg_id {
+                return Err(Error::BadDkgId(ack.dkg_id, self.current_dkg_id));
+            }
+            if !self.config.public_keys.signers.contains_key(&ack.signer_id) {
+                warn!(signer_id = %ack.signer_id, "No public key in config");
+                return Ok(());
+            }
+            self.ids_to_await.remove(&ack.signer_id);
+            debug!(
+                dkg_id = %ack.dkg_id,
+                signer_id = %ack.signer_id,
+                "DkgPublicSharesDoneAck received"
+            );
+        }
         if self.ids_to_await.is_empty() {
             self.move_to(State::DkgPrivateDistribute)?;
         }
@@ -770,7 +822,12 @@ impl<Aggregator: AggregatorTrait> StateMachine<State, Error> for Coordinator<Agg
             State::DkgPublicGather => {
                 prev_state == &State::DkgPublicDistribute || prev_state == &State::DkgPublicGather
             }
-            State::DkgPrivateDistribute => prev_state == &State::DkgPublicGather,
+            State::DkgPublicSharesDoneDistribute => prev_state == &State::DkgPublicGather,
+            State::DkgPublicSharesDoneGather => {
+                prev_state == &State::DkgPublicSharesDoneDistribute
+                    || prev_state == &State::DkgPublicSharesDoneGather
+            }
+            State::DkgPrivateDistribute => prev_state == &State::DkgPublicSharesDoneGather,
             State::DkgPrivateGather => {
                 prev_state == &State::DkgPrivateDistribute || prev_state == &State::DkgPrivateGather
             }

--- a/src/state_machine/coordinator/frost.rs
+++ b/src/state_machine/coordinator/frost.rs
@@ -801,8 +801,8 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
 
             let shares = &self
                 .public_nonces
-                .iter()
-                .flat_map(|(i, _)| self.signature_shares[i].clone())
+                .keys()
+                .flat_map(|i| self.signature_shares[i].clone())
                 .collect::<Vec<SignatureShare>>();
 
             debug!(

--- a/src/state_machine/coordinator/frost.rs
+++ b/src/state_machine/coordinator/frost.rs
@@ -603,6 +603,15 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                 return Ok(());
             };
 
+            // check that the signer participated in the current DKG round
+            if !self
+                .dkg_end_messages
+                .contains_key(&nonce_response.signer_id)
+            {
+                warn!(signer_id = %nonce_response.signer_id, "NonceResponse rejected: signer not a DKG participant");
+                return Ok(());
+            }
+
             // check that the key_ids match the config
             let Some(signer_key_ids) = self
                 .config
@@ -720,6 +729,15 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                 warn!(signer_id = %sig_share_response.signer_id, "No public key in config");
                 return Ok(());
             };
+
+            // check that the signer participated in the current DKG round
+            if !self
+                .dkg_end_messages
+                .contains_key(&sig_share_response.signer_id)
+            {
+                warn!(signer_id = %sig_share_response.signer_id, "SignatureShareResponse rejected: signer not a DKG participant");
+                return Ok(());
+            }
 
             // check that the key_ids match the config
             let Some(signer_key_ids) = self
@@ -1403,6 +1421,17 @@ pub mod test {
         let message = vec![0u8];
         coordinator.state = State::NonceGather(signature_type);
         coordinator.aggregate_public_key = Some(Point::from(Scalar::random(&mut rng)));
+        // Populate dkg_end_messages so the DKG participation check passes
+        for signer_id in 0..coordinator.config.num_signers {
+            coordinator.dkg_end_messages.insert(
+                signer_id,
+                DkgEnd {
+                    dkg_id: 0,
+                    signer_id,
+                    status: DkgStatus::Success,
+                },
+            );
+        }
 
         let nonce_response = NonceResponse {
             dkg_id: 0,
@@ -1470,6 +1499,17 @@ pub mod test {
 
         coordinator.ids_to_await = (0..coordinator.config.num_signers).collect();
         coordinator.state = State::SigShareGather(signature_type);
+        // Populate dkg_end_messages so the DKG participation check passes
+        for signer_id in 0..coordinator.config.num_signers {
+            coordinator.dkg_end_messages.insert(
+                signer_id,
+                DkgEnd {
+                    dkg_id: 0,
+                    signer_id,
+                    status: DkgStatus::Success,
+                },
+            );
+        }
 
         let signature_share = SignatureShare {
             id: 1,

--- a/src/state_machine/coordinator/frost.rs
+++ b/src/state_machine/coordinator/frost.rs
@@ -7,9 +7,9 @@ use crate::{
     compute,
     curve::{ecdsa, point::Point},
     net::{
-        DkgBegin, DkgEnd, DkgEndBegin, DkgPrivateBegin, DkgPrivateShares, DkgPublicShares,
-        DkgPublicSharesDone, DkgStatus, Message, NonceRequest, NonceResponse, Packet, Signable,
-        SignatureShareRequest, SignatureType,
+        DkgBegin, DkgEnd, DkgEndBegin, DkgPrivateBegin, DkgPrivateShares, DkgPrivateSharesDone,
+        DkgPublicShares, DkgPublicSharesDone, DkgStatus, Message, NonceRequest, NonceResponse,
+        Packet, Signable, SignatureShareRequest, SignatureType,
     },
     state_machine::{
         coordinator::{
@@ -125,6 +125,17 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
                 State::DkgPrivateGather => {
                     self.gather_private_shares(packet)?;
                     if self.state == State::DkgPrivateGather {
+                        // We need more data
+                        return Ok((None, None));
+                    }
+                }
+                State::DkgPrivateSharesDoneDistribute => {
+                    let packet = self.send_private_shares_done()?;
+                    return Ok((Some(packet), None));
+                }
+                State::DkgPrivateSharesDoneGather => {
+                    self.gather_private_shares_done_ack(packet)?;
+                    if self.state == State::DkgPrivateSharesDoneGather {
                         // We need more data
                         return Ok((None, None));
                     }
@@ -420,6 +431,47 @@ impl<Aggregator: AggregatorTrait> Coordinator<Aggregator> {
             );
         }
 
+        if self.ids_to_await.is_empty() {
+            self.move_to(State::DkgPrivateSharesDoneDistribute)?;
+        }
+        Ok(())
+    }
+
+    /// Notify signers that all private shares have been received
+    pub fn send_private_shares_done(&mut self) -> Result<Packet, Error> {
+        let signer_ids: Vec<u32> = self.dkg_private_shares.keys().cloned().collect();
+        self.ids_to_await = signer_ids.iter().cloned().collect();
+        info!(dkg_id = %self.current_dkg_id, "Sending DkgPrivateSharesDone");
+        let msg = DkgPrivateSharesDone {
+            dkg_id: self.current_dkg_id,
+            signer_ids,
+        };
+        let packet = Packet {
+            sig: msg
+                .sign(&self.config.message_private_key)
+                .expect("Failed to sign DkgPrivateSharesDone"),
+            msg: Message::DkgPrivateSharesDone(msg),
+        };
+        self.move_to(State::DkgPrivateSharesDoneGather)?;
+        Ok(packet)
+    }
+
+    fn gather_private_shares_done_ack(&mut self, packet: &Packet) -> Result<(), Error> {
+        if let Message::DkgPrivateSharesDoneAck(ack) = &packet.msg {
+            if ack.dkg_id != self.current_dkg_id {
+                return Err(Error::BadDkgId(ack.dkg_id, self.current_dkg_id));
+            }
+            if !self.config.public_keys.signers.contains_key(&ack.signer_id) {
+                warn!(signer_id = %ack.signer_id, "No public key in config");
+                return Ok(());
+            }
+            self.ids_to_await.remove(&ack.signer_id);
+            debug!(
+                dkg_id = %ack.dkg_id,
+                signer_id = %ack.signer_id,
+                "DkgPrivateSharesDoneAck received"
+            );
+        }
         if self.ids_to_await.is_empty() {
             self.move_to(State::DkgEndDistribute)?;
         }
@@ -831,7 +883,12 @@ impl<Aggregator: AggregatorTrait> StateMachine<State, Error> for Coordinator<Agg
             State::DkgPrivateGather => {
                 prev_state == &State::DkgPrivateDistribute || prev_state == &State::DkgPrivateGather
             }
-            State::DkgEndDistribute => prev_state == &State::DkgPrivateGather,
+            State::DkgPrivateSharesDoneDistribute => prev_state == &State::DkgPrivateGather,
+            State::DkgPrivateSharesDoneGather => {
+                prev_state == &State::DkgPrivateSharesDoneDistribute
+                    || prev_state == &State::DkgPrivateSharesDoneGather
+            }
+            State::DkgEndDistribute => prev_state == &State::DkgPrivateSharesDoneGather,
             State::DkgEndGather => prev_state == &State::DkgEndDistribute,
             State::NonceRequest(_) => {
                 prev_state == &State::Idle || prev_state == &State::DkgEndGather

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -1586,11 +1586,7 @@ pub mod test {
             "Expected SignatureShareRequest message"
         );
 
-        let messages = outbound_messages.clone();
-        let result = feedback_messages_with_errors(&mut coordinators, &mut signers, &messages);
-        assert!(result.is_ok());
-
-        // test request with no NonceResponses
+        // test request with no NonceResponses — signers are in SignGather, errors before state change
         let mut packet = outbound_messages[0].clone();
         let Message::SignatureShareRequest(ref mut request) = packet.msg else {
             panic!("failed to match message");
@@ -1645,6 +1641,11 @@ pub mod test {
             ),
             "Should have received signer invalid nonce response error, got {result:?}"
         );
+
+        // send valid SSR last — signers are still in SignGather after all error cases
+        let messages = outbound_messages.clone();
+        let result = feedback_messages_with_errors(&mut coordinators, &mut signers, &messages);
+        assert!(result.is_ok());
     }
 
     pub fn invalid_nonce<Coordinator: CoordinatorTrait, SignerType: SignerTrait>(
@@ -1685,11 +1686,7 @@ pub mod test {
             "Expected SignatureShareRequest message"
         );
 
-        let messages = outbound_messages.clone();
-        let result = feedback_messages_with_errors(&mut coordinators, &mut signers, &messages);
-        assert!(result.is_ok());
-
-        // test request with NonceResponse having zero nonce
+        // test request with NonceResponse having zero nonce — signers are in SignGather, errors before state change
         let mut packet = outbound_messages[0].clone();
         let Message::SignatureShareRequest(ref mut request) = packet.msg else {
             panic!("failed to match message");
@@ -1772,6 +1769,11 @@ pub mod test {
             ),
             "Should have received signer invalid nonce response error, got {result:?}"
         );
+
+        // send valid SSR last — signers are still in SignGather after all error cases
+        let messages = outbound_messages.clone();
+        let result = feedback_messages_with_errors(&mut coordinators, &mut signers, &messages);
+        assert!(result.is_ok());
     }
 
     pub fn empty_public_shares<Coordinator: CoordinatorTrait, SignerType: SignerTrait>(

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -28,6 +28,10 @@ pub enum State {
     DkgPublicDistribute,
     /// The coordinator is gathering public shares
     DkgPublicGather,
+    /// The coordinator is notifying signers that all public shares are done
+    DkgPublicSharesDoneDistribute,
+    /// The coordinator is gathering acknowledgments of DkgPublicSharesDone
+    DkgPublicSharesDoneGather,
     /// The coordinator is asking signers to send private shares
     DkgPrivateDistribute,
     /// The coordinator is gathering private shares
@@ -444,12 +448,35 @@ pub mod test {
             .is_err());
         assert!(coordinator.can_move_to(&State::DkgPublicGather).is_ok());
         assert!(coordinator
-            .can_move_to(&State::DkgPrivateDistribute)
+            .can_move_to(&State::DkgPublicSharesDoneDistribute)
             .is_ok());
+        assert!(coordinator
+            .can_move_to(&State::DkgPrivateDistribute)
+            .is_err());
         assert!(coordinator.can_move_to(&State::DkgPrivateGather).is_err());
         assert!(coordinator.can_move_to(&State::DkgEndDistribute).is_err());
         assert!(coordinator.can_move_to(&State::DkgEndGather).is_err());
         assert!(coordinator.can_move_to(&State::Idle).is_ok());
+
+        coordinator
+            .move_to(State::DkgPublicSharesDoneDistribute)
+            .unwrap();
+        assert!(coordinator
+            .can_move_to(&State::DkgPublicSharesDoneGather)
+            .is_ok());
+        assert!(coordinator
+            .can_move_to(&State::DkgPrivateDistribute)
+            .is_err());
+
+        coordinator
+            .move_to(State::DkgPublicSharesDoneGather)
+            .unwrap();
+        assert!(coordinator
+            .can_move_to(&State::DkgPublicSharesDoneGather)
+            .is_ok());
+        assert!(coordinator
+            .can_move_to(&State::DkgPrivateDistribute)
+            .is_ok());
 
         coordinator.move_to(State::DkgPrivateDistribute).unwrap();
         assert!(coordinator
@@ -767,6 +794,20 @@ pub mod test {
             feedback_messages(&mut coordinators, &mut signers, &[message]);
         assert!(operation_results.is_empty());
         for coordinator in coordinators.iter() {
+            assert_eq!(coordinator.get_state(), State::DkgPublicSharesDoneGather);
+        }
+
+        assert_eq!(outbound_messages.len(), 1);
+        assert!(
+            matches!(&outbound_messages[0].msg, Message::DkgPublicSharesDone(_)),
+            "Expected DkgPublicSharesDone message"
+        );
+
+        // Send DkgPublicSharesDone to signers and collect their acks back to the coordinator
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
+        assert!(operation_results.is_empty());
+        for coordinator in coordinators.iter() {
             assert_eq!(coordinator.get_state(), State::DkgPrivateGather);
         }
 
@@ -1052,6 +1093,20 @@ pub mod test {
         // Send the DKG Begin message to all signers and gather responses by sharing with all other signers and coordinator
         let (outbound_messages, operation_results) =
             feedback_messages(&mut coordinators, &mut signers, &[message]);
+        assert!(operation_results.is_empty());
+        for coordinator in coordinators.iter() {
+            assert_eq!(coordinator.get_state(), State::DkgPublicSharesDoneGather);
+        }
+
+        assert_eq!(outbound_messages.len(), 1);
+        assert!(
+            matches!(&outbound_messages[0].msg, Message::DkgPublicSharesDone(_)),
+            "Expected DkgPublicSharesDone message"
+        );
+
+        // Send DkgPublicSharesDone to signers and collect their acks back to the coordinator
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
         assert!(operation_results.is_empty());
         for coordinator in coordinators.iter() {
             assert_eq!(coordinator.get_state(), State::DkgPrivateGather);
@@ -1732,6 +1787,20 @@ pub mod test {
         );
         assert!(operation_results.is_empty());
         for coordinator in coordinators.iter() {
+            assert_eq!(coordinator.get_state(), State::DkgPublicSharesDoneGather);
+        }
+
+        assert_eq!(outbound_messages.len(), 1);
+        assert!(
+            matches!(&outbound_messages[0].msg, Message::DkgPublicSharesDone(_)),
+            "Expected DkgPublicSharesDone message"
+        );
+
+        // Send DkgPublicSharesDone to signers and collect their acks back to the coordinator
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
+        assert!(operation_results.is_empty());
+        for coordinator in coordinators.iter() {
             assert_eq!(coordinator.get_state(), State::DkgPrivateGather);
         }
 
@@ -1808,6 +1877,20 @@ pub mod test {
         // Send the DKG Begin message to all signers and gather responses by sharing with all other signers and coordinator
         let (outbound_messages, operation_results) =
             feedback_messages(&mut coordinators, &mut signers, &[message]);
+        assert!(operation_results.is_empty());
+        for coordinator in coordinators.iter() {
+            assert_eq!(coordinator.get_state(), State::DkgPublicSharesDoneGather);
+        }
+
+        assert_eq!(outbound_messages.len(), 1);
+        assert!(
+            matches!(&outbound_messages[0].msg, Message::DkgPublicSharesDone(_)),
+            "Expected DkgPublicSharesDone message"
+        );
+
+        // Send DkgPublicSharesDone to signers and collect their acks back to the coordinator
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
         assert!(operation_results.is_empty());
         for coordinator in coordinators.iter() {
             assert_eq!(coordinator.get_state(), State::DkgPrivateGather);

--- a/src/state_machine/coordinator/mod.rs
+++ b/src/state_machine/coordinator/mod.rs
@@ -36,6 +36,10 @@ pub enum State {
     DkgPrivateDistribute,
     /// The coordinator is gathering private shares
     DkgPrivateGather,
+    /// The coordinator is notifying signers that all private shares are done
+    DkgPrivateSharesDoneDistribute,
+    /// The coordinator is gathering acknowledgments of DkgPrivateSharesDone
+    DkgPrivateSharesDoneGather,
     /// The coordinator is asking signers to compute shares and send end
     DkgEndDistribute,
     /// The coordinator is gathering DKG End messages
@@ -500,9 +504,28 @@ pub mod test {
             .can_move_to(&State::DkgPrivateDistribute)
             .is_err());
         assert!(coordinator.can_move_to(&State::DkgPrivateGather).is_ok());
-        assert!(coordinator.can_move_to(&State::DkgEndDistribute).is_ok());
+        assert!(coordinator
+            .can_move_to(&State::DkgPrivateSharesDoneDistribute)
+            .is_ok());
+        assert!(coordinator.can_move_to(&State::DkgEndDistribute).is_err());
         assert!(coordinator.can_move_to(&State::DkgEndGather).is_err());
         assert!(coordinator.can_move_to(&State::Idle).is_ok());
+
+        coordinator
+            .move_to(State::DkgPrivateSharesDoneDistribute)
+            .unwrap();
+        assert!(coordinator
+            .can_move_to(&State::DkgPrivateSharesDoneGather)
+            .is_ok());
+        assert!(coordinator.can_move_to(&State::DkgEndDistribute).is_err());
+
+        coordinator
+            .move_to(State::DkgPrivateSharesDoneGather)
+            .unwrap();
+        assert!(coordinator
+            .can_move_to(&State::DkgPrivateSharesDoneGather)
+            .is_ok());
+        assert!(coordinator.can_move_to(&State::DkgEndDistribute).is_ok());
 
         coordinator.move_to(State::DkgEndDistribute).unwrap();
         assert!(coordinator.can_move_to(&State::DkgEndGather).is_ok());
@@ -842,6 +865,16 @@ pub mod test {
         assert_eq!(operation_results.len(), 0);
         assert_eq!(outbound_messages.len(), 1);
         assert!(
+            matches!(outbound_messages[0].msg, Message::DkgPrivateSharesDone(_)),
+            "Expected DkgPrivateSharesDone message"
+        );
+
+        // Send DkgPrivateSharesDone to signers and collect their acks back to the coordinator
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
+        assert_eq!(operation_results.len(), 0);
+        assert_eq!(outbound_messages.len(), 1);
+        assert!(
             matches!(outbound_messages[0].msg, Message::DkgEndBegin(_)),
             "Expected DkgEndBegin message"
         );
@@ -1121,6 +1154,18 @@ pub mod test {
         }
 
         // Send the DKG Private Begin message to all signers and share their responses with the coordinator and signers
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
+        assert_eq!(operation_results.len(), 0);
+        assert_eq!(outbound_messages.len(), 1);
+        match &outbound_messages[0].msg {
+            Message::DkgPrivateSharesDone(_) => {}
+            _ => {
+                panic!("Expected DkgPrivateSharesDone message");
+            }
+        }
+
+        // Send DkgPrivateSharesDone to signers and collect their acks back to the coordinator
         let (outbound_messages, operation_results) =
             feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
         assert_eq!(operation_results.len(), 0);
@@ -1815,6 +1860,16 @@ pub mod test {
         assert_eq!(operation_results.len(), 0);
         assert_eq!(outbound_messages.len(), 1);
         assert!(
+            matches!(outbound_messages[0].msg, Message::DkgPrivateSharesDone(_)),
+            "Expected DkgPrivateSharesDone message"
+        );
+
+        // Send DkgPrivateSharesDone to signers and collect their acks back to the coordinator
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
+        assert_eq!(operation_results.len(), 0);
+        assert_eq!(outbound_messages.len(), 1);
+        assert!(
             matches!(outbound_messages[0].msg, Message::DkgEndBegin(_)),
             "Expected DkgEndBegin message"
         );
@@ -1930,6 +1985,16 @@ pub mod test {
                     .collect()
             },
         );
+        assert_eq!(operation_results.len(), 0);
+        assert_eq!(outbound_messages.len(), 1);
+        assert!(
+            matches!(&outbound_messages[0].msg, Message::DkgPrivateSharesDone(_)),
+            "Expected DkgPrivateSharesDone message"
+        );
+
+        // Send DkgPrivateSharesDone to signers and collect their acks back to the coordinator
+        let (outbound_messages, operation_results) =
+            feedback_messages(&mut coordinators, &mut signers, &outbound_messages);
         assert_eq!(operation_results.len(), 0);
         assert_eq!(outbound_messages.len(), 1);
         assert!(

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -41,11 +41,15 @@ pub enum State {
     DkgPublicDistribute,
     /// The signer is gathering DKG public shares
     DkgPublicGather,
+    /// The signer has acknowledged DkgPublicSharesDone and is waiting for DkgPrivateBegin
+    DkgPublicSharesDoneAck,
     /// The signer is distributing DKG private shares
     DkgPrivateDistribute,
     /// The signer is gathering DKG private shares
     DkgPrivateGather,
-    /// The signer is distributing signature shares
+    /// The signer has acknowledged DkgPrivateSharesDone and is waiting for DkgEndBegin
+    DkgPrivateSharesDoneAck,
+    /// The signer has sent a nonce and is waiting for a signature share request
     SignGather,
 }
 
@@ -473,27 +477,60 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                 return Err(Error::InvalidPacketSignature);
             }
         }
-        let out_msgs = match &packet.msg {
-            Message::DkgBegin(dkg_begin) => self.dkg_begin(dkg_begin, rng),
-            Message::DkgPrivateBegin(dkg_private_begin) => {
-                self.dkg_private_begin(dkg_private_begin, rng)
+        let out_msgs = match (&self.state, &packet.msg) {
+            // DkgBegin restarts DKG from any state
+            (_, Message::DkgBegin(msg)) => self.dkg_begin(msg, rng),
+            // DKG public phase
+            (State::DkgPublicGather, Message::DkgPublicShares(msg)) => self.dkg_public_share(msg),
+            // Late-arriving public shares are still stored even after we've acked done
+            (State::DkgPublicSharesDoneAck, Message::DkgPublicShares(msg)) => {
+                self.dkg_public_share(msg)
             }
-            Message::DkgEndBegin(dkg_end_begin) => self.dkg_end_begin(dkg_end_begin),
-            Message::DkgPublicShares(dkg_public_shares) => self.dkg_public_share(dkg_public_shares),
-            Message::DkgPublicSharesDone(msg) => self.dkg_public_shares_done(msg),
-            Message::DkgPrivateShares(dkg_private_shares) => {
-                self.dkg_private_shares(dkg_private_shares, rng)
+            (State::DkgPublicGather, Message::DkgPublicSharesDone(msg)) => {
+                self.dkg_public_shares_done(msg)
             }
-            Message::DkgPrivateSharesDone(msg) => self.dkg_private_shares_done(msg),
-            Message::SignatureShareRequest(sign_share_request) => {
-                self.sign_share_request(sign_share_request, rng)
+            // DKG private phase
+            (State::DkgPublicSharesDoneAck, Message::DkgPrivateBegin(msg)) => {
+                self.dkg_private_begin(msg, rng)
             }
-            Message::NonceRequest(nonce_request) => self.nonce_request(nonce_request, rng),
-            Message::DkgEnd(_)
-            | Message::DkgPublicSharesDoneAck(_)
-            | Message::DkgPrivateSharesDoneAck(_)
-            | Message::NonceResponse(_)
-            | Message::SignatureShareResponse(_) => Ok(vec![]), // TODO
+            (State::DkgPrivateGather, Message::DkgPrivateShares(msg)) => {
+                self.dkg_private_shares(msg, rng)
+            }
+            // Late-arriving private shares are still stored even after we've acked done
+            (State::DkgPrivateSharesDoneAck, Message::DkgPrivateShares(msg)) => {
+                self.dkg_private_shares(msg, rng)
+            }
+            (State::DkgPrivateGather, Message::DkgPrivateSharesDone(msg)) => {
+                self.dkg_private_shares_done(msg)
+            }
+            // DKG end phase
+            (State::DkgPrivateSharesDoneAck, Message::DkgEndBegin(msg)) => self.dkg_end_begin(msg),
+            // Signing phase: NonceRequest accepted from Idle or SignGather (coordinator retry)
+            (State::Idle | State::SignGather, Message::NonceRequest(msg)) => {
+                self.nonce_request(msg, rng)
+            }
+            (State::SignGather, Message::SignatureShareRequest(msg)) => {
+                self.sign_share_request(msg, rng)
+            }
+            // Messages signers never process
+            (
+                _,
+                Message::DkgEnd(_)
+                | Message::DkgPublicSharesDoneAck(_)
+                | Message::DkgPrivateSharesDoneAck(_)
+                | Message::NonceResponse(_)
+                | Message::SignatureShareResponse(_),
+            ) => Ok(vec![]),
+            // Unexpected state+message combination
+            (state, msg) => {
+                warn!(
+                    signer_id = %self.signer_id,
+                    ?state,
+                    msg_type = ?std::mem::discriminant(msg),
+                    "unexpected message in state, dropping"
+                );
+                Ok(vec![])
+            }
         };
 
         match out_msgs {
@@ -699,7 +736,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             self.dkg_end_begin_msg.is_some(),
         );
 
-        if self.state == State::DkgPrivateGather {
+        if self.state == State::DkgPrivateGather || self.state == State::DkgPrivateSharesDoneAck {
             if let Some(dkg_private_begin) = &self.dkg_private_begin_msg {
                 // need public shares from active signers
                 for signer_id in &dkg_private_begin.signer_ids {
@@ -759,6 +796,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             "sending NonceResponse"
         );
         msgs.push(response);
+        self.move_to(State::SignGather)?;
 
         Ok(msgs)
     }
@@ -843,9 +881,11 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                 "sending SignatureShareResponse"
             );
 
+            self.move_to(State::Idle)?;
             Ok(vec![Message::SignatureShareResponse(response)])
         } else {
             debug!(signer_id = %self.signer_id, "signer not included in SignatureShareRequest");
+            self.move_to(State::Idle)?;
             Ok(Vec::new())
         }
     }
@@ -884,6 +924,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             dkg_id: self.dkg_id,
             signer_id: self.signer_id,
         };
+        self.move_to(State::DkgPublicSharesDoneAck)?;
         Ok(vec![Message::DkgPublicSharesDoneAck(ack)])
     }
 
@@ -911,6 +952,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             dkg_id: self.dkg_id,
             signer_id: self.signer_id,
         };
+        self.move_to(State::DkgPrivateSharesDoneAck)?;
         Ok(vec![Message::DkgPrivateSharesDoneAck(ack)])
     }
 
@@ -1229,15 +1271,23 @@ impl<SignerType: SignerTrait> StateMachine<State, Error> for Signer<SignerType> 
         let prev_state = &self.state;
         let accepted = match state {
             State::Idle => true,
-            State::DkgPublicDistribute => {
-                prev_state == &State::Idle
-                    || prev_state == &State::DkgPublicGather
-                    || prev_state == &State::DkgPrivateDistribute
-            }
+            // DkgBegin can restart from any state
+            State::DkgPublicDistribute => matches!(
+                prev_state,
+                State::Idle
+                    | State::DkgPublicDistribute
+                    | State::DkgPublicGather
+                    | State::DkgPublicSharesDoneAck
+                    | State::DkgPrivateDistribute
+                    | State::DkgPrivateGather
+                    | State::DkgPrivateSharesDoneAck
+            ),
             State::DkgPublicGather => prev_state == &State::DkgPublicDistribute,
-            State::DkgPrivateDistribute => prev_state == &State::DkgPublicGather,
+            State::DkgPublicSharesDoneAck => prev_state == &State::DkgPublicGather,
+            State::DkgPrivateDistribute => prev_state == &State::DkgPublicSharesDoneAck,
             State::DkgPrivateGather => prev_state == &State::DkgPrivateDistribute,
-            State::SignGather => prev_state == &State::Idle,
+            State::DkgPrivateSharesDoneAck => prev_state == &State::DkgPrivateGather,
+            State::SignGather => prev_state == &State::Idle || prev_state == &State::SignGather,
         };
         if accepted {
             debug!("state change from {prev_state:?} to {state:?}");
@@ -1258,7 +1308,10 @@ pub mod test {
     use crate::{
         common::PolyCommitment,
         curve::{ecdsa, scalar::Scalar},
-        net::{DkgBegin, DkgEndBegin, DkgPrivateBegin, DkgPublicShares, DkgStatus, Message},
+        net::{
+            DkgBegin, DkgEndBegin, DkgPrivateBegin, DkgPrivateSharesDone, DkgPublicShares,
+            DkgPublicSharesDone, DkgStatus, Message,
+        },
         schnorr::ID,
         state_machine::{
             signer::{ConfigError, Error, Signer, State as SignerState},
@@ -1701,6 +1754,18 @@ pub mod test {
         let _ = signer
             .process(&dkg_public_shares_packet, &mut rng)
             .expect("failed to process DkgPublicShares");
+        // coordinator signals all public shares received; signer moves to DkgPublicSharesDoneAck
+        let dkg_public_shares_done = Message::DkgPublicSharesDone(DkgPublicSharesDone {
+            dkg_id: 1,
+            signer_ids: vec![0],
+        });
+        let dkg_public_shares_done_packet = Packet {
+            msg: dkg_public_shares_done,
+            sig: vec![],
+        };
+        let _ = signer
+            .process(&dkg_public_shares_done_packet, &mut rng)
+            .expect("failed to process DkgPublicSharesDone");
         let dkg_private_begin = Message::DkgPrivateBegin(DkgPrivateBegin {
             dkg_id: 1,
             signer_ids: vec![0],
@@ -1712,7 +1777,7 @@ pub mod test {
         };
         let dkg_private_shares = signer
             .process(&dkg_private_begin_packet, &mut rng)
-            .expect("failed to process DkgBegin");
+            .expect("failed to process DkgPrivateBegin");
         let dkg_private_shares_packet = Packet {
             msg: dkg_private_shares[0].clone(),
             sig: vec![],
@@ -1720,6 +1785,18 @@ pub mod test {
         let _ = signer
             .process(&dkg_private_shares_packet, &mut rng)
             .expect("failed to process DkgPrivateShares");
+        // coordinator signals all private shares received; signer moves to DkgPrivateSharesDoneAck
+        let dkg_private_shares_done = Message::DkgPrivateSharesDone(DkgPrivateSharesDone {
+            dkg_id: 1,
+            signer_ids: vec![0],
+        });
+        let dkg_private_shares_done_packet = Packet {
+            msg: dkg_private_shares_done,
+            sig: vec![],
+        };
+        let _ = signer
+            .process(&dkg_private_shares_done_packet, &mut rng)
+            .expect("failed to process DkgPrivateSharesDone");
         let dkg_end_begin = DkgEndBegin {
             dkg_id: 1,
             signer_ids: vec![0],

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -775,6 +775,15 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
         nonce_request: &NonceRequest,
         rng: &mut R,
     ) -> Result<Vec<Message>, Error> {
+        if nonce_request.dkg_id != self.dkg_id {
+            warn!(
+                signer_id = %self.signer_id,
+                got = %nonce_request.dkg_id,
+                expected = %self.dkg_id,
+                "NonceRequest dkg_id mismatch"
+            );
+            return Ok(vec![]);
+        }
         let mut msgs = vec![];
         let signer_id = self.signer_id;
         let key_ids = self.signer.get_key_ids();
@@ -810,6 +819,15 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
         sign_request: &SignatureShareRequest,
         rng: &mut R,
     ) -> Result<Vec<Message>, Error> {
+        if sign_request.dkg_id != self.dkg_id {
+            warn!(
+                signer_id = %self.signer_id,
+                got = %sign_request.dkg_id,
+                expected = %self.dkg_id,
+                "SignatureShareRequest dkg_id mismatch"
+            );
+            return Ok(vec![]);
+        }
         let signer_id_set = sign_request
             .nonce_responses
             .iter()

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -1040,6 +1040,15 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
         dkg_private_begin: &DkgPrivateBegin,
         rng: &mut R,
     ) -> Result<Vec<Message>, Error> {
+        if dkg_private_begin.dkg_id != self.dkg_id {
+            warn!(
+                signer_id = %self.signer_id,
+                got = %dkg_private_begin.dkg_id,
+                expected = %self.dkg_id,
+                "DkgPrivateBegin dkg_id mismatch"
+            );
+            return Ok(vec![]);
+        }
         let mut msgs = vec![];
         let mut private_shares = DkgPrivateShares {
             dkg_id: self.dkg_id,
@@ -1103,6 +1112,15 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
 
     /// handle incoming DkgEndBegin
     pub fn dkg_end_begin(&mut self, dkg_end_begin: &DkgEndBegin) -> Result<Vec<Message>, Error> {
+        if dkg_end_begin.dkg_id != self.dkg_id {
+            warn!(
+                signer_id = %self.signer_id,
+                got = %dkg_end_begin.dkg_id,
+                expected = %self.dkg_id,
+                "DkgEndBegin dkg_id mismatch"
+            );
+            return Ok(vec![]);
+        }
         let msgs = vec![];
 
         self.dkg_end_begin_msg = Some(dkg_end_begin.clone());
@@ -1121,6 +1139,15 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
         &mut self,
         dkg_public_shares: &DkgPublicShares,
     ) -> Result<Vec<Message>, Error> {
+        if dkg_public_shares.dkg_id != self.dkg_id {
+            warn!(
+                signer_id = %self.signer_id,
+                got = %dkg_public_shares.dkg_id,
+                expected = %self.dkg_id,
+                "DkgPublicShares dkg_id mismatch"
+            );
+            return Ok(vec![]);
+        }
         debug!(
             "received DkgPublicShares from signer {} {}/{}",
             dkg_public_shares.signer_id,
@@ -1207,6 +1234,15 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
         dkg_private_shares: &DkgPrivateShares,
         rng: &mut R,
     ) -> Result<Vec<Message>, Error> {
+        if dkg_private_shares.dkg_id != self.dkg_id {
+            warn!(
+                signer_id = %self.signer_id,
+                got = %dkg_private_shares.dkg_id,
+                expected = %self.dkg_id,
+                "DkgPrivateShares dkg_id mismatch"
+            );
+            return Ok(vec![]);
+        }
         // go ahead and decrypt here, since we know the signer_id and hence the pubkey of the sender
         let src_signer_id = dkg_private_shares.signer_id;
 

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -20,8 +20,9 @@ use crate::{
     errors::{DkgError, EncryptionError},
     net::{
         BadPrivateShare, DkgBegin, DkgEnd, DkgEndBegin, DkgFailure, DkgPrivateBegin,
-        DkgPrivateShares, DkgPublicShares, DkgStatus, Message, NonceRequest, NonceResponse, Packet,
-        SignatureShareRequest, SignatureShareResponse, SignatureType,
+        DkgPrivateShares, DkgPublicShares, DkgPublicSharesDone, DkgPublicSharesDoneAck, DkgStatus,
+        Message, NonceRequest, NonceResponse, Packet, SignatureShareRequest,
+        SignatureShareResponse, SignatureType,
     },
     state_machine::{PublicKeys, StateMachine},
     traits::{Signer as SignerTrait, SignerState as SignerSavedState},
@@ -479,6 +480,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             }
             Message::DkgEndBegin(dkg_end_begin) => self.dkg_end_begin(dkg_end_begin),
             Message::DkgPublicShares(dkg_public_shares) => self.dkg_public_share(dkg_public_shares),
+            Message::DkgPublicSharesDone(msg) => self.dkg_public_shares_done(msg),
             Message::DkgPrivateShares(dkg_private_shares) => {
                 self.dkg_private_shares(dkg_private_shares, rng)
             }
@@ -486,9 +488,10 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                 self.sign_share_request(sign_share_request, rng)
             }
             Message::NonceRequest(nonce_request) => self.nonce_request(nonce_request, rng),
-            Message::DkgEnd(_) | Message::NonceResponse(_) | Message::SignatureShareResponse(_) => {
-                Ok(vec![])
-            } // TODO
+            Message::DkgEnd(_)
+            | Message::DkgPublicSharesDoneAck(_)
+            | Message::NonceResponse(_)
+            | Message::SignatureShareResponse(_) => Ok(vec![]), // TODO
         };
 
         match out_msgs {
@@ -856,6 +859,30 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
         //let _party_state = self.signer.save();
 
         self.dkg_public_begin(rng)
+    }
+
+    fn dkg_public_shares_done(&mut self, msg: &DkgPublicSharesDone) -> Result<Vec<Message>, Error> {
+        if msg.dkg_id != self.dkg_id {
+            warn!(
+                signer_id = %self.signer_id,
+                got = %msg.dkg_id,
+                expected = %self.dkg_id,
+                "DkgPublicSharesDone dkg_id mismatch"
+            );
+            return Ok(vec![]);
+        }
+        if !msg.signer_ids.contains(&self.signer_id) {
+            warn!(
+                signer_id = %self.signer_id,
+                "signer_id not in DkgPublicSharesDone, coordinator did not receive our public shares"
+            );
+            return Ok(vec![]);
+        }
+        let ack = DkgPublicSharesDoneAck {
+            dkg_id: self.dkg_id,
+            signer_id: self.signer_id,
+        };
+        Ok(vec![Message::DkgPublicSharesDoneAck(ack)])
     }
 
     fn dkg_public_begin<R: RngCore + CryptoRng>(

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -175,6 +175,8 @@ pub struct SavedState {
     kex_private_key: Scalar,
     /// Ephemeral public keys for key exchange indexed by key_id
     kex_public_keys: HashMap<u32, Point>,
+    /// whether this signer successfully completed DKG for the current dkg_id
+    dkg_completed: bool,
 }
 
 impl fmt::Debug for SavedState {
@@ -262,6 +264,8 @@ pub struct Signer<SignerType: SignerTrait> {
     kex_private_key: Scalar,
     /// Ephemeral public keys for key exchange indexed by key_id
     kex_public_keys: HashMap<u32, Point>,
+    /// whether this signer successfully completed DKG for the current dkg_id
+    dkg_completed: bool,
 }
 
 impl<SignerType: SignerTrait> fmt::Debug for Signer<SignerType> {
@@ -367,6 +371,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             coordinator_public_key: None,
             kex_private_key: Scalar::random(rng),
             kex_public_keys: Default::default(),
+            dkg_completed: false,
         })
     }
 
@@ -400,6 +405,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             coordinator_public_key: state.coordinator_public_key,
             kex_private_key: state.kex_private_key,
             kex_public_keys: state.kex_public_keys.clone(),
+            dkg_completed: state.dkg_completed,
         }
     }
 
@@ -433,6 +439,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             coordinator_public_key: self.coordinator_public_key,
             kex_private_key: self.kex_private_key,
             kex_public_keys: self.kex_public_keys.clone(),
+            dkg_completed: self.dkg_completed,
         }
     }
 
@@ -453,6 +460,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
         self.pending_private_shares_done = None;
         self.kex_private_key = Scalar::random(rng);
         self.kex_public_keys.clear();
+        self.dkg_completed = false;
         self.state = State::Idle;
     }
 
@@ -709,6 +717,10 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             }
         };
 
+        if matches!(dkg_end.status, DkgStatus::Success) {
+            self.dkg_completed = true;
+        }
+
         info!(
             signer_id = %self.signer_id,
             dkg_id = %self.dkg_id,
@@ -784,6 +796,14 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             );
             return Ok(vec![]);
         }
+        if !self.dkg_completed {
+            warn!(
+                signer_id = %self.signer_id,
+                dkg_id = %self.dkg_id,
+                "NonceRequest rejected: DKG not completed"
+            );
+            return Ok(vec![]);
+        }
         let mut msgs = vec![];
         let signer_id = self.signer_id;
         let key_ids = self.signer.get_key_ids();
@@ -825,6 +845,14 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                 got = %sign_request.dkg_id,
                 expected = %self.dkg_id,
                 "SignatureShareRequest dkg_id mismatch"
+            );
+            return Ok(vec![]);
+        }
+        if !self.dkg_completed {
+            warn!(
+                signer_id = %self.signer_id,
+                dkg_id = %self.dkg_id,
+                "SignatureShareRequest rejected: DKG not completed"
             );
             return Ok(vec![]);
         }
@@ -955,6 +983,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                 signer_id = %self.signer_id,
                 "signer_id not in DkgPublicSharesDone, coordinator did not receive our public shares"
             );
+            self.move_to(State::Idle)?;
             return Ok(vec![]);
         }
         // Discard any shares already collected from signers not in the coordinator's accepted list
@@ -1015,6 +1044,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                 signer_id = %self.signer_id,
                 "signer_id not in DkgPrivateSharesDone, coordinator did not receive our private shares"
             );
+            self.move_to(State::Idle)?;
             return Ok(vec![]);
         }
         // Discard any shares already collected from signers not in the coordinator's accepted list

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -20,9 +20,9 @@ use crate::{
     errors::{DkgError, EncryptionError},
     net::{
         BadPrivateShare, DkgBegin, DkgEnd, DkgEndBegin, DkgFailure, DkgPrivateBegin,
-        DkgPrivateShares, DkgPublicShares, DkgPublicSharesDone, DkgPublicSharesDoneAck, DkgStatus,
-        Message, NonceRequest, NonceResponse, Packet, SignatureShareRequest,
-        SignatureShareResponse, SignatureType,
+        DkgPrivateShares, DkgPrivateSharesDone, DkgPrivateSharesDoneAck, DkgPublicShares,
+        DkgPublicSharesDone, DkgPublicSharesDoneAck, DkgStatus, Message, NonceRequest,
+        NonceResponse, Packet, SignatureShareRequest, SignatureShareResponse, SignatureType,
     },
     state_machine::{PublicKeys, StateMachine},
     traits::{Signer as SignerTrait, SignerState as SignerSavedState},
@@ -484,12 +484,14 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             Message::DkgPrivateShares(dkg_private_shares) => {
                 self.dkg_private_shares(dkg_private_shares, rng)
             }
+            Message::DkgPrivateSharesDone(msg) => self.dkg_private_shares_done(msg),
             Message::SignatureShareRequest(sign_share_request) => {
                 self.sign_share_request(sign_share_request, rng)
             }
             Message::NonceRequest(nonce_request) => self.nonce_request(nonce_request, rng),
             Message::DkgEnd(_)
             | Message::DkgPublicSharesDoneAck(_)
+            | Message::DkgPrivateSharesDoneAck(_)
             | Message::NonceResponse(_)
             | Message::SignatureShareResponse(_) => Ok(vec![]), // TODO
         };
@@ -883,6 +885,33 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             signer_id: self.signer_id,
         };
         Ok(vec![Message::DkgPublicSharesDoneAck(ack)])
+    }
+
+    fn dkg_private_shares_done(
+        &mut self,
+        msg: &DkgPrivateSharesDone,
+    ) -> Result<Vec<Message>, Error> {
+        if msg.dkg_id != self.dkg_id {
+            warn!(
+                signer_id = %self.signer_id,
+                got = %msg.dkg_id,
+                expected = %self.dkg_id,
+                "DkgPrivateSharesDone dkg_id mismatch"
+            );
+            return Ok(vec![]);
+        }
+        if !msg.signer_ids.contains(&self.signer_id) {
+            warn!(
+                signer_id = %self.signer_id,
+                "signer_id not in DkgPrivateSharesDone, coordinator did not receive our private shares"
+            );
+            return Ok(vec![]);
+        }
+        let ack = DkgPrivateSharesDoneAck {
+            dkg_id: self.dkg_id,
+            signer_id: self.signer_id,
+        };
+        Ok(vec![Message::DkgPrivateSharesDoneAck(ack)])
     }
 
     fn dkg_public_begin<R: RngCore + CryptoRng>(

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -917,6 +917,21 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             );
             return Ok(vec![]);
         }
+        // Reject any unknown signer IDs
+        let unknown_ids: Vec<u32> = msg
+            .signer_ids
+            .iter()
+            .filter(|id| !self.public_keys.signers.contains_key(*id))
+            .copied()
+            .collect();
+        if !unknown_ids.is_empty() {
+            warn!(
+                signer_id = %self.signer_id,
+                ?unknown_ids,
+                "DkgPublicSharesDone contains unknown signer_ids"
+            );
+            return Ok(vec![]);
+        }
         if !msg.signer_ids.contains(&self.signer_id) {
             warn!(
                 signer_id = %self.signer_id,
@@ -959,6 +974,21 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                 got = %msg.dkg_id,
                 expected = %self.dkg_id,
                 "DkgPrivateSharesDone dkg_id mismatch"
+            );
+            return Ok(vec![]);
+        }
+        // Reject any unknown signer IDs
+        let unknown_ids: Vec<u32> = msg
+            .signer_ids
+            .iter()
+            .filter(|id| !self.public_keys.signers.contains_key(*id))
+            .copied()
+            .collect();
+        if !unknown_ids.is_empty() {
+            warn!(
+                signer_id = %self.signer_id,
+                ?unknown_ids,
+                "DkgPrivateSharesDone contains unknown signer_ids"
             );
             return Ok(vec![]);
         }
@@ -1120,6 +1150,35 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                 "DkgEndBegin dkg_id mismatch"
             );
             return Ok(vec![]);
+        }
+        // Reject any unknown signer IDs
+        let unknown_ids: Vec<u32> = dkg_end_begin
+            .signer_ids
+            .iter()
+            .filter(|id| !self.public_keys.signers.contains_key(*id))
+            .copied()
+            .collect();
+        if !unknown_ids.is_empty() {
+            warn!(
+                signer_id = %self.signer_id,
+                ?unknown_ids,
+                "DkgEndBegin contains unknown signer_ids"
+            );
+            return Ok(vec![]);
+        }
+        let num_keys: u32 = dkg_end_begin
+            .signer_ids
+            .iter()
+            .filter_map(|id| self.public_keys.signer_key_ids.get(id))
+            .map(|key_ids| key_ids.len() as u32)
+            .sum();
+        if num_keys < self.dkg_threshold {
+            warn!(
+                signer_id = %self.signer_id,
+                num_keys,
+                dkg_threshold = self.dkg_threshold,
+                "DkgEndBegin below dkg_threshold"
+            );
         }
         let msgs = vec![];
 

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -163,6 +163,10 @@ pub struct SavedState {
     pub dkg_private_begin_msg: Option<DkgPrivateBegin>,
     /// the DKG end begin message received in this round
     pub dkg_end_begin_msg: Option<DkgEndBegin>,
+    /// pending DkgPublicSharesDone waiting for all public shares to arrive
+    pending_public_shares_done: Option<DkgPublicSharesDone>,
+    /// pending DkgPrivateSharesDone waiting for all private shares to arrive
+    pending_private_shares_done: Option<DkgPrivateSharesDone>,
     /// whether to verify the signature on Packets
     pub verify_packet_sigs: bool,
     /// coordinator public key
@@ -246,6 +250,10 @@ pub struct Signer<SignerType: SignerTrait> {
     pub dkg_private_begin_msg: Option<DkgPrivateBegin>,
     /// the DKG end begin message received in this round
     pub dkg_end_begin_msg: Option<DkgEndBegin>,
+    /// pending DkgPublicSharesDone waiting for all public shares to arrive
+    pending_public_shares_done: Option<DkgPublicSharesDone>,
+    /// pending DkgPrivateSharesDone waiting for all private shares to arrive
+    pending_private_shares_done: Option<DkgPrivateSharesDone>,
     /// whether to verify the signature on Packets
     pub verify_packet_sigs: bool,
     /// coordinator public key
@@ -353,6 +361,8 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             dkg_private_shares: Default::default(),
             dkg_private_begin_msg: Default::default(),
             dkg_end_begin_msg: Default::default(),
+            pending_public_shares_done: None,
+            pending_private_shares_done: None,
             verify_packet_sigs: true,
             coordinator_public_key: None,
             kex_private_key: Scalar::random(rng),
@@ -384,6 +394,8 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             dkg_private_shares: state.dkg_private_shares.clone(),
             dkg_private_begin_msg: state.dkg_private_begin_msg.clone(),
             dkg_end_begin_msg: state.dkg_end_begin_msg.clone(),
+            pending_public_shares_done: state.pending_public_shares_done.clone(),
+            pending_private_shares_done: state.pending_private_shares_done.clone(),
             verify_packet_sigs: state.verify_packet_sigs,
             coordinator_public_key: state.coordinator_public_key,
             kex_private_key: state.kex_private_key,
@@ -415,6 +427,8 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             dkg_private_shares: self.dkg_private_shares.clone(),
             dkg_private_begin_msg: self.dkg_private_begin_msg.clone(),
             dkg_end_begin_msg: self.dkg_end_begin_msg.clone(),
+            pending_public_shares_done: self.pending_public_shares_done.clone(),
+            pending_private_shares_done: self.pending_private_shares_done.clone(),
             verify_packet_sigs: self.verify_packet_sigs,
             coordinator_public_key: self.coordinator_public_key,
             kex_private_key: self.kex_private_key,
@@ -435,6 +449,8 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
         self.dkg_private_shares.clear();
         self.dkg_private_begin_msg = None;
         self.dkg_end_begin_msg = None;
+        self.pending_public_shares_done = None;
+        self.pending_private_shares_done = None;
         self.kex_private_key = Scalar::random(rng);
         self.kex_public_keys.clear();
         self.state = State::Idle;
@@ -482,10 +498,6 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             (_, Message::DkgBegin(msg)) => self.dkg_begin(msg, rng),
             // DKG public phase
             (State::DkgPublicGather, Message::DkgPublicShares(msg)) => self.dkg_public_share(msg),
-            // Late-arriving public shares are still stored even after we've acked done
-            (State::DkgPublicSharesDoneAck, Message::DkgPublicShares(msg)) => {
-                self.dkg_public_share(msg)
-            }
             (State::DkgPublicGather, Message::DkgPublicSharesDone(msg)) => {
                 self.dkg_public_shares_done(msg)
             }
@@ -496,15 +508,17 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             (State::DkgPrivateGather, Message::DkgPrivateShares(msg)) => {
                 self.dkg_private_shares(msg, rng)
             }
-            // Late-arriving private shares are still stored even after we've acked done
-            (State::DkgPrivateSharesDoneAck, Message::DkgPrivateShares(msg)) => {
-                self.dkg_private_shares(msg, rng)
-            }
             (State::DkgPrivateGather, Message::DkgPrivateSharesDone(msg)) => {
                 self.dkg_private_shares_done(msg)
             }
-            // DKG end phase
-            (State::DkgPrivateSharesDoneAck, Message::DkgEndBegin(msg)) => self.dkg_end_begin(msg),
+            // DKG end phase: by the time we reach DkgPrivateSharesDoneAck we have all
+            // public and private shares, so DkgEndBegin directly triggers dkg_ended
+            (State::DkgPrivateSharesDoneAck, Message::DkgEndBegin(msg)) => {
+                let mut out = self.dkg_end_begin(msg)?;
+                out.push(self.dkg_ended(rng)?);
+                self.move_to(State::Idle)?;
+                Ok(out)
+            }
             // Signing phase: NonceRequest accepted from Idle or SignGather (coordinator retry)
             (State::Idle | State::SignGather, Message::NonceRequest(msg)) => {
                 self.nonce_request(msg, rng)
@@ -533,17 +547,7 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             }
         };
 
-        match out_msgs {
-            Ok(mut out) => {
-                if self.can_dkg_end() {
-                    let dkg_end_msgs = self.dkg_ended(rng)?;
-                    out.push(dkg_end_msgs);
-                    self.move_to(State::Idle)?;
-                }
-                Ok(out)
-            }
-            Err(e) => Err(e),
-        }
+        out_msgs
     }
 
     /// DKG is done so compute secrets
@@ -920,12 +924,25 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             );
             return Ok(vec![]);
         }
-        let ack = DkgPublicSharesDoneAck {
-            dkg_id: self.dkg_id,
-            signer_id: self.signer_id,
-        };
-        self.move_to(State::DkgPublicSharesDoneAck)?;
-        Ok(vec![Message::DkgPublicSharesDoneAck(ack)])
+        let have_all = msg
+            .signer_ids
+            .iter()
+            .all(|id| self.dkg_public_shares.contains_key(id));
+        if have_all {
+            let ack = DkgPublicSharesDoneAck {
+                dkg_id: self.dkg_id,
+                signer_id: self.signer_id,
+            };
+            self.move_to(State::DkgPublicSharesDoneAck)?;
+            Ok(vec![Message::DkgPublicSharesDoneAck(ack)])
+        } else {
+            debug!(
+                signer_id = %self.signer_id,
+                "DkgPublicSharesDone received but missing some public shares, waiting"
+            );
+            self.pending_public_shares_done = Some(msg.clone());
+            Ok(vec![])
+        }
     }
 
     fn dkg_private_shares_done(
@@ -948,12 +965,25 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             );
             return Ok(vec![]);
         }
-        let ack = DkgPrivateSharesDoneAck {
-            dkg_id: self.dkg_id,
-            signer_id: self.signer_id,
-        };
-        self.move_to(State::DkgPrivateSharesDoneAck)?;
-        Ok(vec![Message::DkgPrivateSharesDoneAck(ack)])
+        let have_all = msg
+            .signer_ids
+            .iter()
+            .all(|id| self.dkg_private_shares.contains_key(id));
+        if have_all {
+            let ack = DkgPrivateSharesDoneAck {
+                dkg_id: self.dkg_id,
+                signer_id: self.signer_id,
+            };
+            self.move_to(State::DkgPrivateSharesDoneAck)?;
+            Ok(vec![Message::DkgPrivateSharesDoneAck(ack)])
+        } else {
+            debug!(
+                signer_id = %self.signer_id,
+                "DkgPrivateSharesDone received but missing some private shares, waiting"
+            );
+            self.pending_private_shares_done = Some(msg.clone());
+            Ok(vec![])
+        }
     }
 
     fn dkg_public_begin<R: RngCore + CryptoRng>(
@@ -1135,6 +1165,23 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
 
         self.dkg_public_shares
             .insert(dkg_public_shares.signer_id, dkg_public_shares.clone());
+
+        // If DkgPublicSharesDone arrived before this share, check if we now have everything
+        if let Some(pending) = self.pending_public_shares_done.take() {
+            if pending
+                .signer_ids
+                .iter()
+                .all(|id| self.dkg_public_shares.contains_key(id))
+            {
+                let ack = DkgPublicSharesDoneAck {
+                    dkg_id: self.dkg_id,
+                    signer_id: self.signer_id,
+                };
+                self.move_to(State::DkgPublicSharesDoneAck)?;
+                return Ok(vec![Message::DkgPublicSharesDoneAck(ack)]);
+            }
+            self.pending_public_shares_done = Some(pending);
+        }
         Ok(vec![])
     }
 
@@ -1219,6 +1266,23 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             self.decrypted_shares.len(),
             self.signer.get_num_parties(),
         );
+
+        // If DkgPrivateSharesDone arrived before this share, check if we now have everything
+        if let Some(pending) = self.pending_private_shares_done.take() {
+            if pending
+                .signer_ids
+                .iter()
+                .all(|id| self.dkg_private_shares.contains_key(id))
+            {
+                let ack = DkgPrivateSharesDoneAck {
+                    dkg_id: self.dkg_id,
+                    signer_id: self.signer_id,
+                };
+                self.move_to(State::DkgPrivateSharesDoneAck)?;
+                return Ok(vec![Message::DkgPrivateSharesDoneAck(ack)]);
+            }
+            self.pending_private_shares_done = Some(pending);
+        }
         Ok(vec![])
     }
 

--- a/src/state_machine/signer/mod.rs
+++ b/src/state_machine/signer/mod.rs
@@ -924,6 +924,10 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             );
             return Ok(vec![]);
         }
+        // Discard any shares already collected from signers not in the coordinator's accepted list
+        self.dkg_public_shares
+            .retain(|id, _| msg.signer_ids.contains(id));
+
         let have_all = msg
             .signer_ids
             .iter()
@@ -965,6 +969,10 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             );
             return Ok(vec![]);
         }
+        // Discard any shares already collected from signers not in the coordinator's accepted list
+        self.dkg_private_shares
+            .retain(|id, _| msg.signer_ids.contains(id));
+
         let have_all = msg
             .signer_ids
             .iter()
@@ -1139,6 +1147,14 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
             }
         }
 
+        // If we already know which signers the coordinator accepted, discard others
+        if let Some(pending) = &self.pending_public_shares_done {
+            if !pending.signer_ids.contains(&signer_id) {
+                debug!(%signer_id, "discarding DkgPublicShares from signer not in DkgPublicSharesDone");
+                return Ok(vec![]);
+            }
+        }
+
         let have_shares = self
             .dkg_public_shares
             .contains_key(&dkg_public_shares.signer_id);
@@ -1211,6 +1227,14 @@ impl<SignerType: SignerTrait> Signer<SignerType> {
                 &self.public_keys.signer_key_ids,
             ) {
                 warn!("Signer {src_signer_id} sent a polynomial commitment for party {party_id}");
+                return Ok(vec![]);
+            }
+        }
+
+        // If we already know which signers the coordinator accepted, discard others
+        if let Some(pending) = &self.pending_private_shares_done {
+            if !pending.signer_ids.contains(&src_signer_id) {
+                debug!(%src_signer_id, "discarding DkgPrivateShares from signer not in DkgPrivateSharesDone");
                 return Ok(vec![]);
             }
         }

--- a/src/taproot.rs
+++ b/src/taproot.rs
@@ -104,7 +104,7 @@ pub mod test_helpers {
         for signer in signers.iter_mut() {
             if let Err(signer_secret_errors) = signer.compute_secrets(&private_shares, &polys, &ctx)
             {
-                secret_errors.extend(signer_secret_errors.into_iter());
+                secret_errors.extend(signer_secret_errors);
             }
         }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -222,7 +222,7 @@ pub mod test_helpers {
             if let Err(signer_secret_errors) =
                 signer.compute_secrets(&private_shares, &public_shares, &ctx)
             {
-                secret_errors.extend(signer_secret_errors.into_iter());
+                secret_errors.extend(signer_secret_errors);
             }
         }
 
@@ -266,7 +266,7 @@ pub mod test_helpers {
         for signer in signers.iter_mut() {
             if let Err(signer_secret_errors) = signer.compute_secrets(&private_shares, &polys, &ctx)
             {
-                secret_errors.extend(signer_secret_errors.into_iter());
+                secret_errors.extend(signer_secret_errors);
             }
         }
 
@@ -396,7 +396,7 @@ pub mod test_helpers {
             if let Err(signer_secret_errors) =
                 signer.compute_secrets(&private_shares, &public_shares, &ctx)
             {
-                secret_errors.extend(signer_secret_errors.into_iter());
+                secret_errors.extend(signer_secret_errors);
             }
         }
 

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -813,7 +813,7 @@ pub mod test_helpers {
         for signer in signers.iter_mut() {
             if let Err(signer_secret_errors) = signer.compute_secrets(&private_shares, &comms, &ctx)
             {
-                secret_errors.extend(signer_secret_errors.into_iter());
+                secret_errors.extend(signer_secret_errors);
             }
         }
 


### PR DESCRIPTION
The state machine code in this repository is an artifact of the first attempt to implement `sBTC`, a wrapped `BTC` token on the `Stacks` blockchain, in a repository called `sbtc-alpha`.  

The signer state machine was missing many elements of a typical state machine, all of which were present in the coordinator state machines.   For example, it did not gate the handling of particular message types on certain states, nor did it effectively prevent improper state changes.  This allowed protocol attacks, such as attempts to reuse nonces during signing.

One reason why this was never fixed is because the protocol as originally envisioned did not deal well with out-of-order message delivery, which happens frequently in a p2p network.  So a coordinator might have received all DkgPublicShares from all signers, and thus signal that the signers should start sending DkgPrivateShares, triggering a state change on the signers.  But if one signer received this coordinator message before receiving DkgPublicShares from one of the signers, strictness in handling messages based on state would cause that signer to ignore the late DkgPublicShares message.

To fix this, we add Ack/Done states to the protocol.  This way state changes are gated on everyone having received all necessary information before progressing to the next state.

With this protocol change in place, we are now able to implement a proper state machine, and do so in this PR.